### PR TITLE
Makefile fixes and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ KOKKOS_CMAKEFLAGS := -DCMAKE_INSTALL_PREFIX=$(KOKKOS_INSTALL) \
 export KOKKOS_DEPS := $(KOKKOS_LIB)
 export KOKKOS_CXXFLAGS := -I$(KOKKOS_INSTALL)/include
 export KOKKOS_LDFLAGS := -L$(KOKKOS_INSTALL)/lib
+export NVCC_WRAPPER_DEFAULT_COMPILER := $(CXX)
 
 # force the recreation of the environment file any time the Makefile is updated, before building any other target
 -include environment
@@ -151,7 +152,7 @@ $(EIGEN_BASE):
 	cd $@ && git checkout -b cms_branch d812f411c3f9
 
 # Kokkos
-external_kokkos: $(KOKKOS_INSTALL)
+external_kokkos: $(KOKKOS_LIB)
 
 $(KOKKOS_SRC):
 	git clone --branch 3.0.00 https://github.com/kokkos/kokkos.git $@
@@ -159,7 +160,7 @@ $(KOKKOS_SRC):
 $(KOKKOS_BUILD):
 	mkdir -p $@
 
-$(KOKKOS_MAKEFILE): $(KOKKOS_BUILD) $(KOKKOS_SRC)
+$(KOKKOS_MAKEFILE): $(KOKKOS_SRC) | $(KOKKOS_BUILD)
 	cd $(KOKKOS_BUILD) && $(CMAKE) $(KOKKOS_SRC) $(KOKKOS_CMAKEFLAGS)
 
 $(KOKKOS_LIB): $(KOKKOS_MAKEFILE)

--- a/src/cuda/Makefile
+++ b/src/cuda/Makefile
@@ -27,8 +27,6 @@ ALL_DEPENDS += $$($(1)_DEP)
 $(1)_LIB := $(LIB_DIR)/$(TARGET_NAME)/lib$(1).so
 LIBS += $$($(1)_LIB)
 $(1)_LDFLAGS := -l$(1)
-
-$(1)_LIB: $$($(1)_SRC)
 endef
 $(foreach lib,$(LIBNAMES),$(eval $(call LIB_template,$(lib))))
 
@@ -44,8 +42,6 @@ ALL_DEPENDS += $$($(1)_DEP)
 $(1)_LIB := $(LIB_DIR)/$(TARGET_NAME)/plugin$(1).so
 PLUGINS += $$($(1)_LIB)
 $(1)_CUDADLINK := $$(if $$($(1)_CUOBJ),$(OBJ_DIR)/$(TARGET_NAME)/plugin-$(1)/plugin$(1)_cudadlink.o,)
-
-$(1)_LIB: $$($(1)_SRC)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 

--- a/src/cudatest/Makefile
+++ b/src/cudatest/Makefile
@@ -27,8 +27,6 @@ ALL_DEPENDS += $$($(1)_DEP)
 $(1)_LIB := $(LIB_DIR)/$(TARGET_NAME)/lib$(1).so
 LIBS += $$($(1)_LIB)
 $(1)_LDFLAGS := -l$(1)
-
-$(1)_LIB: $$($(1)_SRC)
 endef
 $(foreach lib,$(LIBNAMES),$(eval $(call LIB_template,$(lib))))
 
@@ -44,8 +42,6 @@ ALL_DEPENDS += $$($(1)_DEP)
 $(1)_LIB := $(LIB_DIR)/$(TARGET_NAME)/plugin$(1).so
 PLUGINS += $$($(1)_LIB)
 $(1)_CUDADLINK := $$(if $$($(1)_CUOBJ),$(OBJ_DIR)/$(TARGET_NAME)/plugin-$(1)/plugin$(1)_cudadlink.o,)
-
-$(1)_LIB: $$($(1)_SRC)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 

--- a/src/fwtest/Makefile
+++ b/src/fwtest/Makefile
@@ -27,8 +27,6 @@ ALL_DEPENDS += $$($(1)_DEP)
 $(1)_LIB := $(LIB_DIR)/$(TARGET_NAME)/lib$(1).so
 LIBS += $$($(1)_LIB)
 $(1)_LDFLAGS := -l$(1)
-
-$(1)_LIB: $$($(1)_SRC)
 endef
 $(foreach lib,$(LIBNAMES),$(eval $(call LIB_template,$(lib))))
 
@@ -41,8 +39,6 @@ $(1)_DEP := $$($(1)_OBJ:$.o=$.d)
 ALL_DEPENDS += $$($(1)_DEP)
 $(1)_LIB := $(LIB_DIR)/$(TARGET_NAME)/plugin$(1).so
 PLUGINS += $$($(1)_LIB)
-
-$(1)_LIB: $$($(1)_SRC)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 

--- a/src/kokkostest/Makefile
+++ b/src/kokkostest/Makefile
@@ -27,8 +27,6 @@ ALL_DEPENDS += $$($(1)_DEP)
 $(1)_LIB := $(LIB_DIR)/$(TARGET_NAME)/lib$(1).so
 LIBS += $$($(1)_LIB)
 $(1)_LDFLAGS := -l$(1)
-
-$(1)_LIB: $$($(1)_SRC)
 endef
 $(foreach lib,$(LIBNAMES),$(eval $(call LIB_template,$(lib))))
 
@@ -41,8 +39,6 @@ $(1)_DEP := $$($(1)_OBJ:$.o=$.d)
 ALL_DEPENDS += $$($(1)_DEP)
 $(1)_LIB := $(LIB_DIR)/$(TARGET_NAME)/plugin$(1).so
 PLUGINS += $$($(1)_LIB)
-
-$(1)_LIB: $$($(1)_SRC)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 


### PR DESCRIPTION
Fix Kokkos building recipe with
- `external_kokkos` to point to the right dependence
- avoid running CMake configure every time
- pass `$(CXX)` to `nvcc_wrapper`

Also clean up direct dependence from the .so files to source files, there is already dependence via the object files (which is more correct anyway).