### PR TITLE
Improve check .cu file existence check in Makefiles

### DIFF
--- a/src/cuda/Makefile
+++ b/src/cuda/Makefile
@@ -41,7 +41,7 @@ $(1)_DEP := $$($(1)_OBJ:$.o=$.d)
 ALL_DEPENDS += $$($(1)_DEP)
 $(1)_LIB := $(LIB_DIR)/$(TARGET_NAME)/plugin$(1).so
 PLUGINS += $$($(1)_LIB)
-$(1)_CUDADLINK := $$(if $$($(1)_CUOBJ),$(OBJ_DIR)/$(TARGET_NAME)/plugin-$(1)/plugin$(1)_cudadlink.o,)
+$(1)_CUDADLINK := $$(if $$(strip $$($(1)_CUOBJ)),$(OBJ_DIR)/$(TARGET_NAME)/plugin-$(1)/plugin$(1)_cudadlink.o,)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 

--- a/src/cudatest/Makefile
+++ b/src/cudatest/Makefile
@@ -41,7 +41,7 @@ $(1)_DEP := $$($(1)_OBJ:$.o=$.d)
 ALL_DEPENDS += $$($(1)_DEP)
 $(1)_LIB := $(LIB_DIR)/$(TARGET_NAME)/plugin$(1).so
 PLUGINS += $$($(1)_LIB)
-$(1)_CUDADLINK := $$(if $$($(1)_CUOBJ),$(OBJ_DIR)/$(TARGET_NAME)/plugin-$(1)/plugin$(1)_cudadlink.o,)
+$(1)_CUDADLINK := $$(if $$(strip $$($(1)_CUOBJ)),$(OBJ_DIR)/$(TARGET_NAME)/plugin-$(1)/plugin$(1)_cudadlink.o,)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 


### PR DESCRIPTION
The `$(strip ..)` function strips all extra whitespace, and allows `$(1)_CUOBJ` to be assigned from multiple variables. Strictly speaking this change is not needed now for `cudatest` or `cuda` (but e.g. `kokkostest` will need it), but I think it is better have it in these as well because they will likely be used as a base Makefiles for subsequent programs.