### PR TITLE
Make module macros compatible with namespaces, and add test targets to Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,17 @@ Options
 
 ### Additional make targets
 
-| Target                  | Description                                     |
-|-------------------------|-------------------------------------------------|
-| `all` (default)         | Build all programs                              |
-| `format`                | Format the code with `clang-format`             |
-| `clean`                 | Remove all build artifacts                      |
-| `distclean`             | `clean` and remove all externals                |
-| `dataclean`             | Remove downloaded data files                    |
-| `external_kokkos_clean` | Remove Kokkos build and installation directory  |
+| Target                  | Description                                             |
+|-------------------------|---------------------------------------------------------|
+| `all` (default)         | Build all programs                                      |
+| `format`                | Format the code with `clang-format`                     |
+| `test`                  | Run all tests (each program with small number of events |
+| `test_cpu`              | Run tests for CPU test programs                         |
+| `test_cuda`             | Run tests for CUDA test programs                        |
+| `clean`                 | Remove all build artifacts                              |
+| `distclean`             | `clean` and remove all externals                        |
+| `dataclean`             | Remove downloaded data files                            |
+| `external_kokkos_clean` | Remove Kokkos build and installation directory          |
 
 ### Test program specific notes (if any)
 

--- a/src/cuda/Framework/ESPluginFactory.h
+++ b/src/cuda/Framework/ESPluginFactory.h
@@ -51,6 +51,9 @@ namespace edm {
   }  // namespace ESPluginFactory
 }  // namespace edm
 
-#define DEFINE_FWK_EVENTSETUP_MODULE(name) static edm::ESPluginFactory::impl::Registrar<name> reg_##name(#name);
+#define EDM_ES_PLUGIN_SYM(x, y) EDM_ES_PLUGIN_SYM2(x, y)
+#define EDM_ES_PLUGIN_SYM2(x, y) x##y
+
+#define DEFINE_FWK_EVENTSETUP_MODULE(type) static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif

--- a/src/cuda/Framework/PluginFactory.h
+++ b/src/cuda/Framework/PluginFactory.h
@@ -50,6 +50,9 @@ namespace edm {
   }  // namespace PluginFactory
 }  // namespace edm
 
-#define DEFINE_FWK_MODULE(name) static edm::PluginFactory::impl::Registrar<name> reg_##name(#name);
+#define EDM_PLUGIN_SYM(x, y) EDM_PLUGIN_SYM2(x, y)
+#define EDM_PLUGIN_SYM2(x, y) x##y
+
+#define DEFINE_FWK_MODULE(type) static edm::PluginFactory::impl::Registrar<type> EDM_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif

--- a/src/cuda/Makefile
+++ b/src/cuda/Makefile
@@ -5,6 +5,9 @@ include Makefile.deps
 EXTERNAL_DEPENDS := $(cuda_EXTERNAL_DEPENDS)
 
 $(TARGET):
+test_cpu:
+test_cuda: $(TARGET)
+	$(TARGET) --maxEvents 2
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))

--- a/src/cudatest/Framework/ESPluginFactory.h
+++ b/src/cudatest/Framework/ESPluginFactory.h
@@ -51,6 +51,9 @@ namespace edm {
   }  // namespace ESPluginFactory
 }  // namespace edm
 
-#define DEFINE_FWK_EVENTSETUP_MODULE(name) static edm::ESPluginFactory::impl::Registrar<name> reg_##name(#name);
+#define EDM_ES_PLUGIN_SYM(x, y) EDM_ES_PLUGIN_SYM2(x, y)
+#define EDM_ES_PLUGIN_SYM2(x, y) x##y
+
+#define DEFINE_FWK_EVENTSETUP_MODULE(type) static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif

--- a/src/cudatest/Framework/PluginFactory.h
+++ b/src/cudatest/Framework/PluginFactory.h
@@ -50,6 +50,9 @@ namespace edm {
   }  // namespace PluginFactory
 }  // namespace edm
 
-#define DEFINE_FWK_MODULE(name) static edm::PluginFactory::impl::Registrar<name> reg_##name(#name);
+#define EDM_PLUGIN_SYM(x, y) EDM_PLUGIN_SYM2(x, y)
+#define EDM_PLUGIN_SYM2(x, y) x##y
+
+#define DEFINE_FWK_MODULE(type) static edm::PluginFactory::impl::Registrar<type> EDM_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif

--- a/src/cudatest/Makefile
+++ b/src/cudatest/Makefile
@@ -5,6 +5,9 @@ include Makefile.deps
 EXTERNAL_DEPENDS := $(cudatest_EXTERNAL_DEPENDS)
 
 $(TARGET):
+test_cpu:
+test_cuda: $(TARGET)
+	$(TARGET) --maxEvents 2
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))

--- a/src/fwtest/Framework/ESPluginFactory.h
+++ b/src/fwtest/Framework/ESPluginFactory.h
@@ -51,6 +51,9 @@ namespace edm {
   }  // namespace ESPluginFactory
 }  // namespace edm
 
-#define DEFINE_FWK_EVENTSETUP_MODULE(name) static edm::ESPluginFactory::impl::Registrar<name> reg_##name(#name);
+#define EDM_ES_PLUGIN_SYM(x, y) EDM_ES_PLUGIN_SYM2(x, y)
+#define EDM_ES_PLUGIN_SYM2(x, y) x##y
+
+#define DEFINE_FWK_EVENTSETUP_MODULE(type) static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif

--- a/src/fwtest/Framework/PluginFactory.h
+++ b/src/fwtest/Framework/PluginFactory.h
@@ -50,6 +50,9 @@ namespace edm {
   }  // namespace PluginFactory
 }  // namespace edm
 
-#define DEFINE_FWK_MODULE(name) static edm::PluginFactory::impl::Registrar<name> reg_##name(#name);
+#define EDM_PLUGIN_SYM(x, y) EDM_PLUGIN_SYM2(x, y)
+#define EDM_PLUGIN_SYM2(x, y) x##y
+
+#define DEFINE_FWK_MODULE(type) static edm::PluginFactory::impl::Registrar<type> EDM_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif

--- a/src/fwtest/Makefile
+++ b/src/fwtest/Makefile
@@ -5,6 +5,9 @@ include Makefile.deps
 EXTERNAL_DEPENDS := $(fwtest_EXTERNAL_DEPENDS)
 
 $(TARGET):
+test_cpu: $(TARGET)
+	$(TARGET) --maxEvents 2
+test_cuda:
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))

--- a/src/kokkostest/Framework/ESPluginFactory.h
+++ b/src/kokkostest/Framework/ESPluginFactory.h
@@ -51,6 +51,9 @@ namespace edm {
   }  // namespace ESPluginFactory
 }  // namespace edm
 
-#define DEFINE_FWK_EVENTSETUP_MODULE(name) static edm::ESPluginFactory::impl::Registrar<name> reg_##name(#name);
+#define EDM_ES_PLUGIN_SYM(x, y) EDM_ES_PLUGIN_SYM2(x, y)
+#define EDM_ES_PLUGIN_SYM2(x, y) x##y
+
+#define DEFINE_FWK_EVENTSETUP_MODULE(type) static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif

--- a/src/kokkostest/Makefile
+++ b/src/kokkostest/Makefile
@@ -5,6 +5,10 @@ include Makefile.deps
 EXTERNAL_DEPENDS := $(kokkostest_EXTERNAL_DEPENDS)
 
 $(TARGET):
+test_cpu: $(TARGET)
+	$(TARGET) --maxEvents 1 --serial
+test_cuda: $(TARGET)
+	$(TARGET) --maxEvents 2 --cuda
 
 KOKKOS_CUFLAGS := $(CUDA_CUFLAGS) -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
 


### PR DESCRIPTION
If/when we use namespaces for different backends, the macros `DEFINE_FWK_MODULE` and `DEFINE_FWK_EVENTSETUP_MODULE` better work with namespaces (solution copied from CMSSW, original was not).

I also add test targets (`test` for all tests, `test_{cpu,cuda}` for the CPU and CUDA platforms, and `test_<program>_{cpu,cuda}` for the elements of the full program x platform matrix).