### PR TITLE
Code format

### DIFF
--- a/src/alpaka/Framework/ESPluginFactory.h
+++ b/src/alpaka/Framework/ESPluginFactory.h
@@ -54,6 +54,7 @@ namespace edm {
 #define EDM_ES_PLUGIN_SYM(x, y) EDM_ES_PLUGIN_SYM2(x, y)
 #define EDM_ES_PLUGIN_SYM2(x, y) x##y
 
-#define DEFINE_FWK_EVENTSETUP_MODULE(type) static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
+#define DEFINE_FWK_EVENTSETUP_MODULE(type) \
+  static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif

--- a/src/cuda/Framework/ESPluginFactory.h
+++ b/src/cuda/Framework/ESPluginFactory.h
@@ -54,6 +54,7 @@ namespace edm {
 #define EDM_ES_PLUGIN_SYM(x, y) EDM_ES_PLUGIN_SYM2(x, y)
 #define EDM_ES_PLUGIN_SYM2(x, y) x##y
 
-#define DEFINE_FWK_EVENTSETUP_MODULE(type) static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
+#define DEFINE_FWK_EVENTSETUP_MODULE(type) \
+  static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif

--- a/src/cudatest/Framework/ESPluginFactory.h
+++ b/src/cudatest/Framework/ESPluginFactory.h
@@ -54,6 +54,7 @@ namespace edm {
 #define EDM_ES_PLUGIN_SYM(x, y) EDM_ES_PLUGIN_SYM2(x, y)
 #define EDM_ES_PLUGIN_SYM2(x, y) x##y
 
-#define DEFINE_FWK_EVENTSETUP_MODULE(type) static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
+#define DEFINE_FWK_EVENTSETUP_MODULE(type) \
+  static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif

--- a/src/fwtest/Framework/ESPluginFactory.h
+++ b/src/fwtest/Framework/ESPluginFactory.h
@@ -54,6 +54,7 @@ namespace edm {
 #define EDM_ES_PLUGIN_SYM(x, y) EDM_ES_PLUGIN_SYM2(x, y)
 #define EDM_ES_PLUGIN_SYM2(x, y) x##y
 
-#define DEFINE_FWK_EVENTSETUP_MODULE(type) static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
+#define DEFINE_FWK_EVENTSETUP_MODULE(type) \
+  static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif

--- a/src/kokkostest/Framework/ESPluginFactory.h
+++ b/src/kokkostest/Framework/ESPluginFactory.h
@@ -54,6 +54,7 @@ namespace edm {
 #define EDM_ES_PLUGIN_SYM(x, y) EDM_ES_PLUGIN_SYM2(x, y)
 #define EDM_ES_PLUGIN_SYM2(x, y) x##y
 
-#define DEFINE_FWK_EVENTSETUP_MODULE(type) static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
+#define DEFINE_FWK_EVENTSETUP_MODULE(type) \
+  static edm::ESPluginFactory::impl::Registrar<type> EDM_ES_PLUGIN_SYM(maker, __LINE__)(#type);
 
 #endif


### PR DESCRIPTION
I left `src/alpaka/plugin-SiPixelClusterizer/clustering_alpaka.cc` intentionally out to not cause conflicts with developments by @felicepantaleo and @waredjeb. Let's deal with the formatting when the `alpaka` code becomes more integrated.