### PR TITLE
Various small changes to build rules and runtime environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 external
 obj
 lib
+.original_env
 env.sh
 data/*.tar.gz
 data/*.bin

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ All other external dependencies (listed below) are downloaded and built automati
 * [CUB](https://nvlabs.github.io/cub/) (`cudatest` and `cuda` programs)
 * [Eigen](http://eigen.tuxfamily.org/) (`cuda` program)
 * [Kokkos](https://github.com/kokkos/kokkos) (`kokkostest` program)
-* [Boost](https://www.boost.org/) (`alpakatest` and `alpakatest` programs)
-  * Boost libraries from the system can also be used, but they need to be newer than 1.63.0
-* [Alpaka](https://github.com/alpaka-group/alpaka) (`alpakatest` and `alpakatest` programs)
+* [Boost](https://www.boost.org/) (`alpakatest` and `alpaka` programs)
+  * Boost libraries from the system can also be used, but they need to be newer than 1.65.1
+* [Alpaka](https://github.com/alpaka-group/alpaka) (`alpakatest` and `alpaka` programs)
 
 The input data set consists of a minimal binary dump of 1000 events of
 ttbar+PU events from of


### PR DESCRIPTION
Updates to the build rules:
  - fix Boost detection on Debian/Ubuntu systems (from #22)
  - make the minimum required version of Boost more explicit
  - update external version of Boost to 1.73.0

Updates to the runtime environment:
  - add CUPLA_LIBDIR to the environment
  - save and reuse the original PATH and LD_LIBRARY_PATH variables