### PR TITLE
Update Kokkos to 3.1.1 and initialize and use only the backend(s) given at the command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ $(CUPLA_BASE)/lib: $(CUPLA_BASE) $(ALPAKA_DEPS) $(BOOST_DEPS) $(TBB_DEPS) $(CUDA
 external_kokkos: $(KOKKOS_LIB)
 
 $(KOKKOS_SRC):
-	git clone --branch 3.0.00 https://github.com/kokkos/kokkos.git $@
+	git clone --branch 3.1.01 https://github.com/kokkos/kokkos.git $@
 	cd $(KOKKOS_SRC) && patch -p1 < ../../../nvcc_wrapper.patch
 
 $(KOKKOS_BUILD):

--- a/src/kokkos/KokkosCore/kokkosConfigCommon.h
+++ b/src/kokkos/KokkosCore/kokkosConfigCommon.h
@@ -1,6 +1,7 @@
 #ifndef KokkosCore_kokkosConfigCommon_h
 #define KokkosCore_kokkosConfigCommon_h
 
+#include <vector>
 #include <memory>
 
 // This header needs to be #included in a file that may not be
@@ -8,7 +9,9 @@
 namespace kokkos_common {
   class InitializeScopeGuard {
   public:
-    InitializeScopeGuard();
+    enum class Backend { SERIAL, CUDA };
+
+    InitializeScopeGuard(std::vector<Backend> const& backends);
     ~InitializeScopeGuard();
 
   private:

--- a/src/kokkos/KokkosCore/kokkoshost/kokkosConfigCommon.cc
+++ b/src/kokkos/KokkosCore/kokkoshost/kokkosConfigCommon.cc
@@ -5,16 +5,25 @@
 namespace kokkos_common {
   class InitializeScopeGuard::Impl {
   public:
-    explicit Impl(const Kokkos::InitArguments& args) : guard(args) {}
+    explicit Impl(std::vector<Backend> const& backends, Kokkos::InitArguments const& args) {
+      Kokkos::Impl::pre_initialize(args);
+      if (std::find(backends.begin(), backends.end(), Backend::SERIAL) != backends.end()) {
+        Kokkos::Serial::impl_initialize();
+      }
+      if (std::find(backends.begin(), backends.end(), Backend::CUDA) != backends.end()) {
+        std::cout << "Initializing CUDA backend" << std::endl;
+        Kokkos::Cuda::impl_initialize();
+      }
+      Kokkos::Impl::post_initialize(args);
+    }
 
-  private:
-    Kokkos::ScopeGuard guard;
+    ~Impl() { Kokkos::finalize(); }
   };
 
-  InitializeScopeGuard::InitializeScopeGuard() {
+  InitializeScopeGuard::InitializeScopeGuard(std::vector<Backend> const& backends) {
     // for now pass in the default arguments
     Kokkos::InitArguments arguments;
-    pimpl_ = std::make_unique<Impl>(arguments);
+    pimpl_ = std::make_unique<Impl>(backends, arguments);
   }
 
   InitializeScopeGuard::~InitializeScopeGuard() = default;

--- a/src/kokkos/KokkosDataFormats/SiPixelDigiErrorsKokkos.h
+++ b/src/kokkos/KokkosDataFormats/SiPixelDigiErrorsKokkos.h
@@ -10,12 +10,13 @@ template <typename MemorySpace>
 class SiPixelDigiErrorsKokkos {
 public:
   SiPixelDigiErrorsKokkos() = default;
-  explicit SiPixelDigiErrorsKokkos(size_t maxFedWords, PixelFormatterErrors errors)
+  template <typename ExecSpace>
+  explicit SiPixelDigiErrorsKokkos(size_t maxFedWords, PixelFormatterErrors errors, ExecSpace const& execSpace)
       : data_d{"data_d", maxFedWords}, error_d{"error_d"}, error_h{"error_h"}, formatterErrors_h{std::move(errors)} {
     error_h.data()->construct(maxFedWords, data_d.data());
     assert(error_h.data()->empty());
     assert(error_h.data()->capacity() == static_cast<int>(maxFedWords));
-    Kokkos::deep_copy(error_d, error_h);
+    Kokkos::deep_copy(execSpace, error_d, error_h);
   }
   ~SiPixelDigiErrorsKokkos() = default;
 

--- a/src/kokkos/bin/main.cc
+++ b/src/kokkos/bin/main.cc
@@ -30,13 +30,12 @@ namespace {
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
         << std::endl;
   }
-
-  enum class Backend { SERIAL, CUDA };
 }  // namespace
 
 int main(int argc, char** argv) {
   // Parse command line arguments
   std::vector<std::string> args(argv, argv + argc);
+  using Backend = kokkos_common::InitializeScopeGuard::Backend;
   std::vector<Backend> backends;
   int numberOfThreads = 1;
   int numberOfStreams = 0;
@@ -87,7 +86,7 @@ int main(int argc, char** argv) {
   }
 
   // Initialize Kokkos
-  kokkos_common::InitializeScopeGuard kokkosGuard;
+  kokkos_common::InitializeScopeGuard kokkosGuard(backends);
 
   // Initialize EventProcessor
   std::vector<std::string> edmodules;

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelFedCablingMapESProducer.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelFedCablingMapESProducer.cc
@@ -32,15 +32,14 @@ namespace KOKKOS_NAMESPACE {
     Kokkos::View<SiPixelFedCablingMapGPU, KokkosExecSpace> cablingMap_d("cablingMap_d");
     auto cablingMap_h = Kokkos::create_mirror_view(cablingMap_d);
     (*cablingMap_h.data()) = obj;
-    Kokkos::deep_copy(cablingMap_d, cablingMap_h);
+    Kokkos::deep_copy(KokkosExecSpace(), cablingMap_d, cablingMap_h);
     eventSetup.put(std::make_unique<SiPixelFedCablingMapGPUWrapper<KokkosExecSpace>>(std::move(cablingMap_d), true));
 
     Kokkos::View<unsigned char*, KokkosExecSpace> modToUnp_d("modToUnp_d", modToUnpDefSize);
     auto modToUnp_h = Kokkos::create_mirror_view(modToUnp_d);
     std::copy(modToUnpDefault.begin(), modToUnpDefault.end(), modToUnp_h.data());
-    Kokkos::deep_copy(modToUnp_d, modToUnp_h);
+    Kokkos::deep_copy(KokkosExecSpace(), modToUnp_d, modToUnp_h);
     eventSetup.put(std::make_unique<Kokkos::View<const unsigned char*, KokkosExecSpace>>(std::move(modToUnp_d)));
-    Kokkos::fence();
   }
 }  // namespace KOKKOS_NAMESPACE
 

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelGainCalibrationForHLTESProducer.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelGainCalibrationForHLTESProducer.cc
@@ -51,7 +51,7 @@ namespace KOKKOS_NAMESPACE {
         "ped_d", gainData.size() / sizeof(SiPixelGainForHLTonGPU_DecodingStructure));
     auto ped_h = Kokkos::create_mirror_view(ped_d);
     memcpy(ped_h.data(), gainData.data(), gainData.size());
-    Kokkos::deep_copy(ped_d, ped_h);
+    Kokkos::deep_copy(KokkosExecSpace(), ped_d, ped_h);
 
     typename SiPixelGainForHLTonGPU<KokkosExecSpace>::RangeAndColsWritableView rangeAndCols_d("rangeAndCols_d");
     auto rangeAndCols_h = Kokkos::create_mirror_view(rangeAndCols_d);
@@ -60,7 +60,7 @@ namespace KOKKOS_NAMESPACE {
           Kokkos::make_pair(Kokkos::make_pair(gain.rangeAndCols[i].first.first, gain.rangeAndCols[i].first.second),
                             gain.rangeAndCols[i].second);
     }
-    Kokkos::deep_copy(rangeAndCols_d, rangeAndCols_h);
+    Kokkos::deep_copy(KokkosExecSpace(), rangeAndCols_d, rangeAndCols_h);
 
     typename SiPixelGainForHLTonGPU<KokkosExecSpace>::FieldsWritableView fields_d("fields_d");
     auto fields_h = Kokkos::create_mirror_view(fields_d);
@@ -76,11 +76,10 @@ namespace KOKKOS_NAMESPACE {
     COPY(deadFlag_);
     COPY(noisyFlag_);
 #undef COPY
-    Kokkos::deep_copy(fields_d, fields_h);
+    Kokkos::deep_copy(KokkosExecSpace(), fields_d, fields_h);
 
     eventSetup.put(std::make_unique<SiPixelGainForHLTonGPU<KokkosExecSpace>>(
         std::move(ped_d), std::move(rangeAndCols_d), std::move(fields_d)));
-    Kokkos::fence();
   }
 }  // namespace KOKKOS_NAMESPACE
 

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
@@ -535,7 +535,8 @@ namespace KOKKOS_NAMESPACE {
 
       digis_d = SiPixelDigisKokkos<KokkosExecSpace>(pixelgpudetails::MAX_FED_WORDS);
       if (includeErrors) {
-        digiErrors_d = SiPixelDigiErrorsKokkos<KokkosExecSpace>(pixelgpudetails::MAX_FED_WORDS, std::move(errors));
+        digiErrors_d = SiPixelDigiErrorsKokkos<KokkosExecSpace>(
+            pixelgpudetails::MAX_FED_WORDS, std::move(errors), KokkosExecSpace());
       }
       clusters_d = SiPixelClustersKokkos<KokkosExecSpace>(::gpuClustering::MaxNumModules);
 
@@ -558,8 +559,8 @@ namespace KOKKOS_NAMESPACE {
         //Kokkos::View<unsigned char *, KokkosExecSpace> fedId_d("fedId_d", wordCounter);
         Kokkos::View<unsigned int *, KokkosExecSpace> word_d("word_d", MAX_FED_WORDS);
         Kokkos::View<unsigned char *, KokkosExecSpace> fedId_d("fedId_d", MAX_FED_WORDS);
-        Kokkos::deep_copy(word_d, wordFed.word());
-        Kokkos::deep_copy(fedId_d, wordFed.fedId());
+        Kokkos::deep_copy(KokkosExecSpace(), word_d, wordFed.word());
+        Kokkos::deep_copy(KokkosExecSpace(), fedId_d, wordFed.fedId());
 
         {
           // need Kokkos::Views as local variables to pass to the lambda
@@ -626,10 +627,10 @@ namespace KOKKOS_NAMESPACE {
                                           i);
               });
         }
-        Kokkos::fence();
+        KokkosExecSpace().fence();
 
 #ifdef GPU_DEBUG
-        Kokkos::fence();
+        KokkosExecSpace().fence();
 #endif
 
 #ifdef GPU_DEBUG

--- a/src/kokkostest/KokkosCore/kokkosConfigCommon.h
+++ b/src/kokkostest/KokkosCore/kokkosConfigCommon.h
@@ -1,6 +1,7 @@
 #ifndef KokkosCore_kokkosConfigCommon_h
 #define KokkosCore_kokkosConfigCommon_h
 
+#include <vector>
 #include <memory>
 
 // This header needs to be #included in a file that may not be
@@ -8,7 +9,9 @@
 namespace kokkos_common {
   class InitializeScopeGuard {
   public:
-    InitializeScopeGuard();
+    enum class Backend { SERIAL, CUDA };
+
+    InitializeScopeGuard(std::vector<Backend> const& backends);
     ~InitializeScopeGuard();
 
   private:

--- a/src/kokkostest/KokkosCore/kokkoshost/kokkosConfigCommon.cc
+++ b/src/kokkostest/KokkosCore/kokkoshost/kokkosConfigCommon.cc
@@ -5,16 +5,25 @@
 namespace kokkos_common {
   class InitializeScopeGuard::Impl {
   public:
-    explicit Impl(const Kokkos::InitArguments& args) : guard(args) {}
+    explicit Impl(std::vector<Backend> const& backends, Kokkos::InitArguments const& args) {
+      Kokkos::Impl::pre_initialize(args);
+      if (std::find(backends.begin(), backends.end(), Backend::SERIAL) != backends.end()) {
+        Kokkos::Serial::impl_initialize();
+      }
+      if (std::find(backends.begin(), backends.end(), Backend::CUDA) != backends.end()) {
+        std::cout << "Initializing CUDA backend" << std::endl;
+        Kokkos::Cuda::impl_initialize();
+      }
+      Kokkos::Impl::post_initialize(args);
+    }
 
-  private:
-    Kokkos::ScopeGuard guard;
+    ~Impl() { Kokkos::finalize(); }
   };
 
-  InitializeScopeGuard::InitializeScopeGuard() {
+  InitializeScopeGuard::InitializeScopeGuard(std::vector<Backend> const& backends) {
     // for now pass in the default arguments
     Kokkos::InitArguments arguments;
-    pimpl_ = std::make_unique<Impl>(arguments);
+    pimpl_ = std::make_unique<Impl>(backends, arguments);
   }
 
   InitializeScopeGuard::~InitializeScopeGuard() = default;

--- a/src/kokkostest/bin/main.cc
+++ b/src/kokkostest/bin/main.cc
@@ -30,13 +30,12 @@ namespace {
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
         << std::endl;
   }
-
-  enum class Backend { SERIAL, CUDA };
 }  // namespace
 
 int main(int argc, char** argv) {
   // Parse command line arguments
   std::vector<std::string> args(argv, argv + argc);
+  using Backend = kokkos_common::InitializeScopeGuard::Backend;
   std::vector<Backend> backends;
   int numberOfThreads = 1;
   int numberOfStreams = 0;
@@ -87,7 +86,7 @@ int main(int argc, char** argv) {
   }
 
   // Initialize Kokkos
-  kokkos_common::InitializeScopeGuard kokkosGuard;
+  kokkos_common::InitializeScopeGuard kokkosGuard(backends);
 
   // Initialize EventProcessor
   std::vector<std::string> edmodules;

--- a/src/kokkostest/plugin-Test1/kokkos/kokkosAlgo1.cc
+++ b/src/kokkostest/plugin-Test1/kokkos/kokkosAlgo1.cc
@@ -25,8 +25,9 @@ namespace KOKKOS_NAMESPACE {
       h_b[i] = i * i;
     }
 
-    Kokkos::deep_copy(d_a, h_a);
-    Kokkos::deep_copy(d_b, h_b);
+    // TODO: take the execuction space object from the caller
+    Kokkos::deep_copy(KokkosExecSpace(), d_a, h_a);
+    Kokkos::deep_copy(KokkosExecSpace(), d_b, h_b);
 
     Kokkos::View<float*, KokkosExecSpace> d_c{"d_c", NUM_VALUES};
     Kokkos::parallel_for(

--- a/src/kokkostest/plugin-Test2/kokkos/kokkosAlgo2.cc
+++ b/src/kokkostest/plugin-Test2/kokkos/kokkosAlgo2.cc
@@ -25,8 +25,8 @@ namespace KOKKOS_NAMESPACE {
       h_b[i] = i * i;
     }
 
-    Kokkos::deep_copy(d_a, h_a);
-    Kokkos::deep_copy(d_b, h_b);
+    Kokkos::deep_copy(KokkosExecSpace(), d_a, h_a);
+    Kokkos::deep_copy(KokkosExecSpace(), d_b, h_b);
 
     Kokkos::View<float*, KokkosExecSpace> d_c{"d_c", NUM_VALUES};
     Kokkos::parallel_for(


### PR DESCRIPTION
The Kokkos update itself was seamless, and initializing only the selected backend(s) was straightforward. I also had to give the execution space object as a parameter to `Kokkos::deep_copy()` in order to have it call the `fence()` of the execution space instead of the global `Kokkos::fence()`.

Note that the update of Kokkos requires `make clean; rm -fR external/kokkos`.