### PR TITLE
porting countModules to Kokkos

### DIFF
--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClustering.h
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClustering.h
@@ -32,8 +32,8 @@ namespace KOKKOS_NAMESPACE {
         --j;
       if (j < 0 or id[j] != id[index]) {
         // boundary... replacing atomicInc with explicit logic
-        auto loc = Kokkos::atomic_compare_exchange(moduleStart,::gpuClustering::MaxNumModules,0);
-        Kokkos::atomic_increment(moduleStart);
+        auto loc = Kokkos::atomic_fetch_add(&moduleStart[0],1);
+        assert(moduleStart[0] < ::gpuClustering::MaxNumModules);
         moduleStart[loc + 1] = index;
       }
     }

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClustering.h
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClustering.h
@@ -15,31 +15,34 @@
 namespace KOKKOS_NAMESPACE {
   namespace gpuClustering {
 
-#ifdef TODO
+
 #ifdef GPU_DEBUG
     __device__ uint32_t gMaxHit = 0;
 #endif
 
-    KOKKOS_INLINE_FUNCTION void countModules(uint16_t const* __restrict__ id,
-                                             uint32_t* __restrict__ moduleStart,
-                                             int32_t* __restrict__ clusterId,
-                                             int numElements) {
-      int first = blockDim.x * blockIdx.x + threadIdx.x;
-      for (int i = first; i < numElements; i += gridDim.x * blockDim.x) {
-        clusterId[i] = i;
-        if (InvId == id[i])
-          continue;
-        auto j = i - 1;
-        while (j >= 0 and id[j] == InvId)
+    KOKKOS_INLINE_FUNCTION void countModules(
+            Kokkos::View<uint16_t const*,KokkosExecSpace> id,
+            Kokkos::View<uint32_t*,KokkosExecSpace> moduleStart,
+            Kokkos::View<int32_t*,KokkosExecSpace> clusterId,
+            int numElements,
+            const size_t index) {
+        clusterId[index] = index;
+        if (::gpuClustering::InvId == id[index])
+          return;
+        int j = index - 1;
+        while (j >= 0 and id[j] == ::gpuClustering::InvId)
           --j;
-        if (j < 0 or id[j] != id[i]) {
-          // boundary...
-          auto loc = atomicInc(moduleStart, MaxNumModules);
-          moduleStart[loc + 1] = i;
+        if (j < 0 or id[j] != id[index]) {
+          // boundary... replacing atomicInc with explicit logic
+          auto loc = moduleStart[0];
+          if( moduleStart[0] >= ::gpuClustering::MaxNumModules)
+            moduleStart[0] = 0;
+          else
+            moduleStart[0] = moduleStart[0] + 1;
+          moduleStart[loc + 1] = index;
         }
-      }
     }
-
+#ifdef TODO
     __global__
         //  __launch_bounds__(256,4)
         void

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClustering.h
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClustering.h
@@ -34,11 +34,8 @@ namespace KOKKOS_NAMESPACE {
           --j;
         if (j < 0 or id[j] != id[index]) {
           // boundary... replacing atomicInc with explicit logic
-          auto loc = moduleStart[0];
-          if( moduleStart[0] >= ::gpuClustering::MaxNumModules)
-            moduleStart[0] = 0;
-          else
-            moduleStart[0] = moduleStart[0] + 1;
+          auto loc = Kokkos::atomic_compare_exchange(moduleStart,::gpuClustering::MaxNumModules,0);
+          Kokkos::atomic_increment(moduleStart);
           moduleStart[loc + 1] = index;
         }
     }

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClustering.h
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClustering.h
@@ -32,7 +32,7 @@ namespace KOKKOS_NAMESPACE {
         --j;
       if (j < 0 or id[j] != id[index]) {
         // boundary... replacing atomicInc with explicit logic
-        auto loc = Kokkos::atomic_fetch_add(&moduleStart[0],1);
+        auto loc = Kokkos::atomic_fetch_add(&moduleStart[0], 1);
         assert(moduleStart[0] < ::gpuClustering::MaxNumModules);
         moduleStart[loc + 1] = index;
       }


### PR DESCRIPTION
I updated the `gpuClustering::countModules()` function from cuda to kokkos as a first test for me.