### PR TITLE
Add support for unit tests, include several for CUDA program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 external
 obj
 lib
+./test
 .original_env
 env.sh
 data/*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ export OBJ_DIR := $(BASE_DIR)/obj
 # Directory where to put libraries
 export LIB_DIR := $(BASE_DIR)/lib
 
+# Directory where to put unit test executables
+export TEST_DIR := $(BASE_DIR)/test
+
 # System external definitions
 CUDA_BASE := /usr/local/cuda
 CUDA_LIBDIR := $(CUDA_BASE)/lib64

--- a/src/alpakatest/Makefile
+++ b/src/alpakatest/Makefile
@@ -6,15 +6,22 @@ EXTERNAL_DEPENDS := $(alpakatest_EXTERNAL_DEPENDS)
 
 $(TARGET):
 test_cpu: $(TARGET)
+	@echo
+	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --serial --tbb
+	@echo "Succeeded"
 test_cuda: $(TARGET)
+	@echo
+	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --cuda
+	@echo "Succeeded"
+.PHONY: test_cpu test_cuda
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
 EXE_DEP := $(EXE_OBJ:$.o=$.d)
 
-LIBNAMES := $(filter-out plugin-% bin Makefile% plugins.txt%,$(wildcard *))
+LIBNAMES := $(filter-out plugin-% bin test Makefile% plugins.txt%,$(wildcard *))
 PLUGINNAMES := $(patsubst plugin-%,%,$(filter plugin-%,$(wildcard *)))
 MY_CXXFLAGS := -I$(TARGET_DIR) -DSRC_DIR=$(TARGET_DIR) -DLIB_DIR=$(LIB_DIR)/$(TARGET_NAME)
 MY_LDFLAGS := -ldl -Wl,-rpath,$(LIB_DIR)/$(TARGET_NAME)
@@ -76,13 +83,42 @@ PLUGINS += $$($(1)_LIB)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 
+# Files for unit tests
+TESTS_PORTABLE_SRC := $(wildcard $(TARGET_DIR)/test/alpaka/*.cc)
+# serial backend
+TESTS_SERIAL_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.serial.o))
+TESTS_SERIAL_DEP := $(TESTS_SERIAL_OBJ:$.o=$.d)
+TESTS_SERIAL_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.serial,$(TESTS_PORTABLE_SRC))
+# TBB backend
+TESTS_TBB_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=tbb.serial.o))
+TESTS_TBB_DEP := $(TESTS_SERIAL_OBJ:$.o=$.d)
+TESTS_TBB_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.tbb,$(TESTS_PORTABLE_SRC))
+# CUDA backend
+TESTS_CUDA_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.cuda.o))
+TESTS_CUDA_DEP := $(TESTS_CUDA_OBJ:$.o=$.d)
+TESTS_CUDA_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.cuda,$(TESTS_PORTABLE_SRC))
+#
+TESTS_EXE := $(TESTS_SERIAL_EXE) $(TESTS_TBB_EXE) $(TESTS_CUDA_EXE)
+TESTS_CUOBJ := $(TESTS_CUDA_OBJ)
+TESTS_CUDADLINK := $(TESTS_CUOBJ:$cu.o=$cudadlink.o)
+ALL_DEPENDS += $(TESTS_SERIAL_DEP) $(TESTS_TBB_DEP) $(TESTS_CUDA_DEP)
+
+define RUNTEST_template
+run_$(1): $(1)
+	@echo
+	@echo "Running test $(1)"
+	@$(1)
+	@echo "Succeeded"
+test_$(2): run_$(1)
+endef
+$(foreach test,$(TESTS_SERIAL_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
+$(foreach test,$(TESTS_TBB_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
+$(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),cuda)))
+
 -include $(ALL_DEPENDS)
 
-bar:
-	@echo $(Test1_CUDADLINK)
-
 # Build targets
-$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS)
+$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS) | $(TESTS_EXE)
 	$(CXX) $(EXE_OBJ) $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
 
 define BUILD_template
@@ -145,3 +181,44 @@ $(OBJ_DIR)/$(TARGET_NAME)/bin/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/bin/%.cc
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
 	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.d.tmp >> $(@D)/$*.cc.d; \
 	  rm $(@D)/$*.cc.d.tmp
+
+# Tests, assume all are portable
+# Serial backend
+$(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.serial.o: $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED $(CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+	@cp $(@D)/$*.cc.serial.d $(@D)/$*.cc.serial.d.tmp; \
+	  sed 's#\($(TARGET_NAME)/$*\)\.o[ :]*#\1.o \1.d : #g' < $(@D)/$*.cc.serial.d.tmp > $(@D)/$*.cc.serial.d; \
+	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.serial.d.tmp >> $(@D)/$*.cc.serial.d; \
+	  rm $(@D)/$*.cc.serial.d.tmp
+
+$(TEST_DIR)/$(TARGET_NAME)/%.serial: $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.serial.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
+
+# TBB backend
+$(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.tbb.o: $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED $(CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+	@cp $(@D)/$*.cc.tbb.d $(@D)/$*.cc.tbb.d.tmp; \
+	  sed 's#\($(TARGET_NAME)/$*\)\.o[ :]*#\1.o \1.d : #g' < $(@D)/$*.cc.tbb.d.tmp > $(@D)/$*.cc.tbb.d; \
+	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.tbb.d.tmp >> $(@D)/$*.cc.tbb.d; \
+	  rm $(@D)/$*.cc.tbb.d.tmp
+
+$(TEST_DIR)/$(TARGET_NAME)/%.tbb: $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.tbb.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
+
+# CUDA backend
+$(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.cuda.o: $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CUDA_NVCC) -x cu -DALPAKA_ACC_GPU_CUDA_ENABLED $(ALPAKA_CUFLAGS) $(CUDA_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+
+$(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cudadlink.o: $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.o
+	$(CUDA_NVCC) $(CUDA_DLINKFLAGS) $(CUDA_LDFLAGS) $< -o $@
+
+$(TEST_DIR)/$(TARGET_NAME)/%.cuda: $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.cuda.o $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.cuda.cudadlink.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))

--- a/src/alpakatest/test/alpaka/hello.cc
+++ b/src/alpakatest/test/alpaka/hello.cc
@@ -1,0 +1,16 @@
+#include <iostream>
+
+#include "AlpakaCore/alpakaConfig.h"
+
+int main() {
+  std::cout << "Hello from "
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_SYNC_BACKEND
+            << "CPU serial"
+#elif defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+            << "CPU TBB"
+#elif defined ALPAKA_ACC_GPU_CUDA_ENABLED
+            << "CUDA"
+#endif
+            << " backend" << std::endl;
+  return 0;
+}

--- a/src/alpakatest/test/alpaka/world.cc
+++ b/src/alpakatest/test/alpaka/world.cc
@@ -1,0 +1,37 @@
+#include <iostream>
+
+#include "AlpakaCore/alpakaConfig.h"
+
+namespace {
+  struct Print {
+    template <typename T_Acc>
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc) const {
+      uint32_t const blockThreadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+      uint32_t const elemDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+      printf("Alpaka kernel thread index %u, number of elements %u\n", blockThreadIdx, elemDimension);
+    }
+  };
+}  // namespace
+
+int main() {
+  std::cout << "World" << std::endl;
+
+  using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+  const DevAcc device(alpaka::pltf::getDevByIdx<PltfAcc>(0u));
+  Queue queue(device);
+
+  Vec elementsPerThread(Vec::all(1));
+  Vec threadsPerBlock(Vec::all(4));
+  Vec blocksPerGrid(Vec::all(1));
+#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || \
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+  // on the GPU, run with 32 threads in parallel per block, each looking at a single element
+  // on the CPU, run serially with a single thread per block, over 32 elements
+  std::swap(threadsPerBlock, elementsPerThread);
+#endif
+  const WorkDiv workDiv(blocksPerGrid, threadsPerBlock, elementsPerThread);
+
+  alpaka::queue::enqueue(queue, alpaka::kernel::createTaskKernel<Acc>(workDiv, Print()));
+  alpaka::wait::wait(queue);
+  return 0;
+}

--- a/src/cuda/CUDACore/launch.h
+++ b/src/cuda/CUDACore/launch.h
@@ -1,0 +1,147 @@
+#ifndef HeterogeneousCore_CUDAUtilities_launch_h
+#define HeterogeneousCore_CUDAUtilities_launch_h
+
+#include <tuple>
+
+#include <cuda_runtime.h>
+
+#include "CUDACore/cudaCheck.h"
+
+/*
+ * `cms::cuda::launch` and `cms::cuda::launch_cooperative` are wrappers around
+ * the CUDA Runtime API calls to setup and call a CUDA kernel from the host.
+ *
+ * `kernel` should be a pointer to a __global__ void(...) function.
+ * `config` describe the launch configuration: the grid size and block size, the
+ *          dynamic shared memory size (default to 0) and the CUDA stream to use
+ *          (default to 0, the default stream).
+ * `args` are the arguments passed (by value) to the kernel.
+ *
+ *  Currently this is requires an extra copy to perform the necessary implicit
+ *  conversions and ensure that the arguments match the kernel function signature;
+ *  the extra copy could eventually be avoided for arguments that are already of
+ *  the exact type.
+ *
+ *  Unlike the `kernel<<<...>>>(...)` syntax and the `cuda::launch(...)` 
+ *  implementation from the CUDA API Wrappers, `cms::cuda::launch(...)` and 
+ *  `cms::cuda::launch_cooperative` can be called from standard C++ host code.
+ *
+ *  Possible optimisations
+ *
+ *    - once C++17 is available in CUDA, replace the `pointer_setter` functor
+ *      with a simpler function using fold expressions:
+ *
+ *  template<int N, class Tuple, std::size_t... Is>
+ *  void pointer_setter(void* ptrs[N], Tuple const& t, std::index_sequence<Is...>)
+ *  {
+ *    ((ptrs[Is] = & std::get<Is>(t)), ...);
+ *  }
+ *
+ *    - add a template specialisation to `launch` and `launch_cooperative` to
+ *      avoid making a temporary copy of the parameters when they match the
+ *      kernel signature.
+ */
+
+namespace cms {
+  namespace cuda {
+
+    struct LaunchParameters {
+      dim3 gridDim;
+      dim3 blockDim;
+      size_t sharedMem;
+      cudaStream_t stream;
+
+      LaunchParameters(dim3 gridDim, dim3 blockDim, size_t sharedMem = 0, cudaStream_t stream = nullptr)
+          : gridDim(gridDim), blockDim(blockDim), sharedMem(sharedMem), stream(stream) {}
+
+      LaunchParameters(int gridDim, int blockDim, size_t sharedMem = 0, cudaStream_t stream = nullptr)
+          : gridDim(gridDim), blockDim(blockDim), sharedMem(sharedMem), stream(stream) {}
+    };
+
+    namespace detail {
+
+      template <typename T>
+      struct kernel_traits;
+
+      template <typename... Args>
+      struct kernel_traits<void(Args...)> {
+        static constexpr size_t arguments_size = sizeof...(Args);
+
+        using argument_type_tuple = std::tuple<Args...>;
+
+        template <size_t i>
+        using argument_type = typename std::tuple_element<i, argument_type_tuple>::type;
+      };
+
+      // fill an array with the pointers to the elements of a tuple
+      template <int I>
+      struct pointer_setter {
+        template <typename Tuple>
+        void operator()(void const* ptrs[], Tuple const& t) {
+          pointer_setter<I - 1>()(ptrs, t);
+          ptrs[I - 1] = &std::get<I - 1>(t);
+        }
+      };
+
+      template <>
+      struct pointer_setter<0> {
+        template <typename Tuple>
+        void operator()(void const* ptrs[], Tuple const& t) {}
+      };
+
+    }  // namespace detail
+
+    // wrappers for cudaLaunchKernel
+
+    inline void launch(void (*kernel)(), LaunchParameters config) {
+      cudaCheck(cudaLaunchKernel(
+          (const void*)kernel, config.gridDim, config.blockDim, nullptr, config.sharedMem, config.stream));
+    }
+
+    template <typename F, typename... Args>
+#if __cplusplus >= 201703L
+    std::enable_if_t<std::is_invocable_r<void, F, Args&&...>::value>
+#else
+    std::enable_if_t<std::is_void<std::result_of_t<F && (Args && ...)> >::value>
+#endif
+    launch(F* kernel, LaunchParameters config, Args&&... args) {
+      using function_type = detail::kernel_traits<F>;
+      typename function_type::argument_type_tuple args_copy(args...);
+
+      constexpr auto size = function_type::arguments_size;
+      void const* pointers[size];
+
+      detail::pointer_setter<size>()(pointers, args_copy);
+      cudaCheck(cudaLaunchKernel(
+          (const void*)kernel, config.gridDim, config.blockDim, (void**)pointers, config.sharedMem, config.stream));
+    }
+
+    // wrappers for cudaLaunchCooperativeKernel
+
+    inline void launch_cooperative(void (*kernel)(), LaunchParameters config) {
+      cudaCheck(cudaLaunchCooperativeKernel(
+          (const void*)kernel, config.gridDim, config.blockDim, nullptr, config.sharedMem, config.stream));
+    }
+
+    template <typename F, typename... Args>
+#if __cplusplus >= 201703L
+    std::enable_if_t<std::is_invocable_r<void, F, Args&&...>::value>
+#else
+    std::enable_if_t<std::is_void<std::result_of_t<F && (Args && ...)> >::value>
+#endif
+    launch_cooperative(F* kernel, LaunchParameters config, Args&&... args) {
+      using function_type = detail::kernel_traits<F>;
+      typename function_type::argument_type_tuple args_copy(args...);
+
+      constexpr auto size = function_type::arguments_size;
+      void const* pointers[size];
+
+      detail::pointer_setter<size>()(pointers, args_copy);
+      cudaCheck(cudaLaunchCooperativeKernel(
+          (const void*)kernel, config.gridDim, config.blockDim, (void**)pointers, config.sharedMem, config.stream));
+    }
+
+  }  // namespace cuda
+}  // namespace cms
+
+#endif  // HeterogeneousCore_CUDAUtilities_launch_h

--- a/src/cuda/Makefile
+++ b/src/cuda/Makefile
@@ -7,13 +7,17 @@ EXTERNAL_DEPENDS := $(cuda_EXTERNAL_DEPENDS)
 $(TARGET):
 test_cpu:
 test_cuda: $(TARGET)
+	@echo
+	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2
+	@echo "Succeeded"
+.PHONY: test_cpu test_cuda
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
 EXE_DEP := $(EXE_OBJ:$.o=$.d)
 
-LIBNAMES := $(filter-out plugin-% bin Makefile% plugins.txt%,$(wildcard *))
+LIBNAMES := $(filter-out plugin-% bin test Makefile% plugins.txt%,$(wildcard *))
 PLUGINNAMES := $(patsubst plugin-%,%,$(filter plugin-%,$(wildcard *)))
 MY_CXXFLAGS := -I$(TARGET_DIR) -DSRC_DIR=$(TARGET_DIR) -DLIB_DIR=$(LIB_DIR)/$(TARGET_NAME)
 MY_LDFLAGS := -ldl -Wl,-rpath,$(LIB_DIR)/$(TARGET_NAME)
@@ -48,10 +52,34 @@ $(1)_CUDADLINK := $$(if $$(strip $$($(1)_CUOBJ)),$(OBJ_DIR)/$(TARGET_NAME)/plugi
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 
+# Files for unit tests
+TESTS_SRC := $(wildcard $(TARGET_DIR)/test/*.cc)
+TESTS_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_SRC:%=%.o))
+TESTS_DEP := $(TESTS_OBJ:$.o=$.d)
+TESTS_CUSRC := $(wildcard $(TARGET_DIR)/test/*.cu)
+TESTS_CUOBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_CUSRC:%=%.o))
+TESTS_CUDADLINK := $(TESTS_CUOBJ:$cu.o=$cudadlink.o)
+TESTS_CUDEP := $(TESTS_CUOBJ:$.o=$.d)
+TESTS_EXE_CPU := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%,$(TESTS_SRC))
+TESTS_EXE_CUDA :=  $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/%.cu,$(TEST_DIR)/$(TARGET_NAME)/%,$(TESTS_CUSRC))
+TESTS_EXE := $(TESTS_EXE_CPU) $(TESTS_EXE_CUDA)
+ALL_DEPENDS += $(TESTS_DEP) $(TESTS_CUDEP)
+
+define RUNTEST_template
+run_$(1): $(1)
+	@echo
+	@echo "Running test $(1)"
+	@$(1)
+	@echo "Succeeded"
+test_$(2): run_$(1)
+endef
+$(foreach test,$(TESTS_EXE_CPU),$(eval $(call RUNTEST_template,$(test),cpu)))
+$(foreach test,$(TESTS_EXE_CUDA),$(eval $(call RUNTEST_template,$(test),cuda)))
+
 -include $(ALL_DEPENDS)
 
 # Build targets
-$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS)
+$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS) | $(TESTS_EXE)
 	$(CXX) $(EXE_OBJ) $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
 
 define BUILD_template
@@ -87,3 +115,28 @@ $(OBJ_DIR)/$(TARGET_NAME)/bin/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/bin/%.cc
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
 	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.d.tmp >> $(@D)/$*.cc.d; \
 	  rm $(@D)/$*.cc.d.tmp
+
+# Tests
+$(OBJ_DIR)/$(TARGET_NAME)/test/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/test/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+	@cp $(@D)/$*.cc.d $(@D)/$*.cc.d.tmp; \
+	  sed 's#\($(TARGET_NAME)/$*\)\.o[ :]*#\1.o \1.d : #g' < $(@D)/$*.cc.d.tmp > $(@D)/$*.cc.d; \
+	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.d.tmp >> $(@D)/$*.cc.d; \
+	  rm $(@D)/$*.cc.d.tmp
+
+$(TEST_DIR)/$(TARGET_NAME)/%: $(OBJ_DIR)/$(TARGET_NAME)/test/%.cc.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $< $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
+
+$(OBJ_DIR)/$(TARGET_NAME)/test/%.cu.o: $(SRC_DIR)/$(TARGET_NAME)/test/%.cu
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CUDA_NVCC) $(CUDA_CUFLAGS) $(CUDA_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+
+$(OBJ_DIR)/$(TARGET_NAME)/test/%.cudadlink.o: $(OBJ_DIR)/$(TARGET_NAME)/test/%.cu.o
+	$(CUDA_NVCC) $(CUDA_DLINKFLAGS) $(CUDA_LDFLAGS) $< -o $@
+
+$(TEST_DIR)/$(TARGET_NAME)/%: $(OBJ_DIR)/$(TARGET_NAME)/test/%.cu.o $(OBJ_DIR)/$(TARGET_NAME)/test/%.cudadlink.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))

--- a/src/cuda/test/AtomicPairCounter_t.cu
+++ b/src/cuda/test/AtomicPairCounter_t.cu
@@ -1,0 +1,65 @@
+#include "CUDACore/cudaCheck.h"
+#include "CUDACore/AtomicPairCounter.h"
+
+#include "CUDACore/cuda_assert.h"
+
+__global__ void update(AtomicPairCounter *dc, uint32_t *ind, uint32_t *cont, uint32_t n) {
+  auto i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= n)
+    return;
+
+  auto m = i % 11;
+  m = m % 6 + 1;  // max 6, no 0
+  auto c = dc->add(m);
+  assert(c.m < n);
+  ind[c.m] = c.n;
+  for (int j = c.n; j < c.n + m; ++j)
+    cont[j] = i;
+};
+
+__global__ void finalize(AtomicPairCounter const *dc, uint32_t *ind, uint32_t *cont, uint32_t n) {
+  assert(dc->get().m == n);
+  ind[n] = dc->get().n;
+}
+
+__global__ void verify(AtomicPairCounter const *dc, uint32_t const *ind, uint32_t const *cont, uint32_t n) {
+  auto i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= n)
+    return;
+  assert(0 == ind[0]);
+  assert(dc->get().m == n);
+  assert(ind[n] == dc->get().n);
+  auto ib = ind[i];
+  auto ie = ind[i + 1];
+  auto k = cont[ib++];
+  assert(k < n);
+  for (; ib < ie; ++ib)
+    assert(cont[ib] == k);
+}
+
+#include <iostream>
+int main() {
+  AtomicPairCounter *dc_d;
+  cudaCheck(cudaMalloc(&dc_d, sizeof(AtomicPairCounter)));
+  cudaCheck(cudaMemset(dc_d, 0, sizeof(AtomicPairCounter)));
+
+  std::cout << "size " << sizeof(AtomicPairCounter) << std::endl;
+
+  constexpr uint32_t N = 20000;
+  constexpr uint32_t M = N * 6;
+  uint32_t *n_d, *m_d;
+  cudaCheck(cudaMalloc(&n_d, N * sizeof(int)));
+  // cudaMemset(n_d, 0, N*sizeof(int));
+  cudaCheck(cudaMalloc(&m_d, M * sizeof(int)));
+
+  update<<<2000, 512>>>(dc_d, n_d, m_d, 10000);
+  finalize<<<1, 1>>>(dc_d, n_d, m_d, 10000);
+  verify<<<2000, 512>>>(dc_d, n_d, m_d, 10000);
+
+  AtomicPairCounter dc;
+  cudaCheck(cudaMemcpy(&dc, dc_d, sizeof(AtomicPairCounter), cudaMemcpyDeviceToHost));
+
+  std::cout << dc.get().n << ' ' << dc.get().m << std::endl;
+
+  return 0;
+}

--- a/src/cuda/test/HistoContainer_t.cu
+++ b/src/cuda/test/HistoContainer_t.cu
@@ -1,0 +1,151 @@
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <limits>
+#include <random>
+
+#include "CUDACore/device_unique_ptr.h"
+#include "CUDACore/cudaCheck.h"
+#include "CUDACore/HistoContainer.h"
+
+template <typename T>
+void go() {
+  std::mt19937 eng;
+  std::uniform_int_distribution<T> rgen(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
+
+  constexpr int N = 12000;
+  T v[N];
+  auto v_d = cms::cuda::make_device_unique<T[]>(N, nullptr);
+
+  cudaCheck(cudaMemcpy(v_d.get(), v, N * sizeof(T), cudaMemcpyHostToDevice));
+
+  constexpr uint32_t nParts = 10;
+  constexpr uint32_t partSize = N / nParts;
+  uint32_t offsets[nParts + 1];
+
+  using Hist = HistoContainer<T, 128, N, 8 * sizeof(T), uint32_t, nParts>;
+  std::cout << "HistoContainer " << (int)(offsetof(Hist, off)) << ' ' << Hist::nbins() << ' ' << Hist::totbins() << ' '
+            << Hist::capacity() << ' ' << Hist::wsSize() << ' '
+            << (std::numeric_limits<T>::max() - std::numeric_limits<T>::min()) / Hist::nbins() << std::endl;
+
+  Hist h;
+  auto h_d = cms::cuda::make_device_unique<Hist[]>(1, nullptr);
+  auto ws_d = cms::cuda::make_device_unique<uint8_t[]>(Hist::wsSize(), nullptr);
+
+  auto off_d = cms::cuda::make_device_unique<uint32_t[]>(nParts + 1, nullptr);
+
+  for (int it = 0; it < 5; ++it) {
+    offsets[0] = 0;
+    for (uint32_t j = 1; j < nParts + 1; ++j) {
+      offsets[j] = offsets[j - 1] + partSize - 3 * j;
+      assert(offsets[j] <= N);
+    }
+
+    if (it == 1) {  // special cases...
+      offsets[0] = 0;
+      offsets[1] = 0;
+      offsets[2] = 19;
+      offsets[3] = 32 + offsets[2];
+      offsets[4] = 123 + offsets[3];
+      offsets[5] = 256 + offsets[4];
+      offsets[6] = 311 + offsets[5];
+      offsets[7] = 2111 + offsets[6];
+      offsets[8] = 256 * 11 + offsets[7];
+      offsets[9] = 44 + offsets[8];
+      offsets[10] = 3297 + offsets[9];
+    }
+
+    cudaCheck(cudaMemcpy(off_d.get(), offsets, 4 * (nParts + 1), cudaMemcpyHostToDevice));
+
+    for (long long j = 0; j < N; j++)
+      v[j] = rgen(eng);
+
+    if (it == 2) {  // big bin
+      for (long long j = 1000; j < 2000; j++)
+        v[j] = sizeof(T) == 1 ? 22 : 3456;
+    }
+
+    cudaCheck(cudaMemcpy(v_d.get(), v, N * sizeof(T), cudaMemcpyHostToDevice));
+
+    cms::cuda::fillManyFromVector(h_d.get(), ws_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, 0);
+    cudaCheck(cudaMemcpy(&h, h_d.get(), sizeof(Hist), cudaMemcpyDeviceToHost));
+    assert(0 == h.off[0]);
+    assert(offsets[10] == h.size());
+
+    auto verify = [&](uint32_t i, uint32_t k, uint32_t t1, uint32_t t2) {
+      assert(t1 < N);
+      assert(t2 < N);
+      if (T(v[t1] - v[t2]) <= 0)
+        std::cout << "for " << i << ':' << v[k] << " failed " << v[t1] << ' ' << v[t2] << std::endl;
+    };
+
+    auto incr = [](auto& k) { return k = (k + 1) % Hist::nbins(); };
+
+    // make sure it spans 3 bins...
+    auto window = T(1300);
+
+    for (uint32_t j = 0; j < nParts; ++j) {
+      auto off = Hist::histOff(j);
+      for (uint32_t i = 0; i < Hist::nbins(); ++i) {
+        auto ii = i + off;
+        if (0 == h.size(ii))
+          continue;
+        auto k = *h.begin(ii);
+        if (j % 2)
+          k = *(h.begin(ii) + (h.end(ii) - h.begin(ii)) / 2);
+        auto bk = h.bin(v[k]);
+        assert(bk == i);
+        assert(k < offsets[j + 1]);
+        auto kl = h.bin(v[k] - window);
+        auto kh = h.bin(v[k] + window);
+        assert(kl != i);
+        assert(kh != i);
+        // std::cout << kl << ' ' << kh << std::endl;
+
+        auto me = v[k];
+        auto tot = 0;
+        auto nm = 0;
+        bool l = true;
+        auto khh = kh;
+        incr(khh);
+        for (auto kk = kl; kk != khh; incr(kk)) {
+          if (kk != kl && kk != kh)
+            nm += h.size(kk + off);
+          for (auto p = h.begin(kk + off); p < h.end(kk + off); ++p) {
+            if (std::min(std::abs(T(v[*p] - me)), std::abs(T(me - v[*p]))) > window) {
+            } else {
+              ++tot;
+            }
+          }
+          if (kk == i) {
+            l = false;
+            continue;
+          }
+          if (l)
+            for (auto p = h.begin(kk + off); p < h.end(kk + off); ++p)
+              verify(i, k, k, (*p));
+          else
+            for (auto p = h.begin(kk + off); p < h.end(kk + off); ++p)
+              verify(i, k, (*p), k);
+        }
+        if (!(tot >= nm)) {
+          std::cout << "too bad " << j << ' ' << i << ' ' << int(me) << '/' << (int)T(me - window) << '/'
+                    << (int)T(me + window) << ": " << kl << '/' << kh << ' ' << khh << ' ' << tot << '/' << nm
+                    << std::endl;
+        }
+        if (l)
+          std::cout << "what? " << j << ' ' << i << ' ' << int(me) << '/' << (int)T(me - window) << '/'
+                    << (int)T(me + window) << ": " << kl << '/' << kh << ' ' << khh << ' ' << tot << '/' << nm
+                    << std::endl;
+        assert(!l);
+      }
+    }
+  }
+}
+
+int main() {
+  go<int16_t>();
+  go<int8_t>();
+
+  return 0;
+}

--- a/src/cuda/test/HistoContainer_t_cpu.cc
+++ b/src/cuda/test/HistoContainer_t_cpu.cc
@@ -1,0 +1,143 @@
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <limits>
+#include <random>
+
+#include "CUDACore/HistoContainer.h"
+
+template <typename T, int NBINS = 128, int S = 8 * sizeof(T), int DELTA = 1000>
+void go() {
+  std::mt19937 eng;
+
+  int rmin = std::numeric_limits<T>::min();
+  int rmax = std::numeric_limits<T>::max();
+  if (NBINS != 128) {
+    rmin = 0;
+    rmax = NBINS * 2 - 1;
+  }
+
+  std::uniform_int_distribution<T> rgen(rmin, rmax);
+
+  constexpr int N = 12000;
+  T v[N];
+
+  using Hist = HistoContainer<T, NBINS, N, S>;
+  using Hist4 = HistoContainer<T, NBINS, N, S, uint16_t, 4>;
+  std::cout << "HistoContainer " << Hist::nbits() << ' ' << Hist::nbins() << ' ' << Hist::totbins() << ' '
+            << Hist::capacity() << ' ' << (rmax - rmin) / Hist::nbins() << std::endl;
+  std::cout << "bins " << int(Hist::bin(0)) << ' ' << int(Hist::bin(rmin)) << ' ' << int(Hist::bin(rmax)) << std::endl;
+  std::cout << "HistoContainer4 " << Hist4::nbits() << ' ' << Hist4::nbins() << ' ' << Hist4::totbins() << ' '
+            << Hist4::capacity() << ' ' << (rmax - rmin) / Hist::nbins() << std::endl;
+  for (auto nh = 0; nh < 4; ++nh)
+    std::cout << "bins " << int(Hist4::bin(0)) + Hist4::histOff(nh) << ' ' << int(Hist::bin(rmin)) + Hist4::histOff(nh)
+              << ' ' << int(Hist::bin(rmax)) + Hist4::histOff(nh) << std::endl;
+
+  Hist h;
+  Hist4 h4;
+  for (int it = 0; it < 5; ++it) {
+    for (long long j = 0; j < N; j++)
+      v[j] = rgen(eng);
+    if (it == 2)
+      for (long long j = N / 2; j < N / 2 + N / 4; j++)
+        v[j] = 4;
+    h.zero();
+    h4.zero();
+    assert(h.size() == 0);
+    assert(h4.size() == 0);
+    for (long long j = 0; j < N; j++) {
+      h.count(v[j]);
+      if (j < 2000)
+        h4.count(v[j], 2);
+      else
+        h4.count(v[j], j % 4);
+    }
+    assert(h.size() == 0);
+    assert(h4.size() == 0);
+    h.finalize();
+    h4.finalize();
+    assert(h.size() == N);
+    assert(h4.size() == N);
+    for (long long j = 0; j < N; j++) {
+      h.fill(v[j], j);
+      if (j < 2000)
+        h4.fill(v[j], j, 2);
+      else
+        h4.fill(v[j], j, j % 4);
+    }
+    assert(h.off[0] == 0);
+    assert(h4.off[0] == 0);
+    assert(h.size() == N);
+    assert(h4.size() == N);
+
+    auto verify = [&](uint32_t i, uint32_t j, uint32_t k, uint32_t t1, uint32_t t2) {
+      assert((int32_t)t1 < N);
+      assert((int32_t)t2 < N);
+      if (i != j && T(v[t1] - v[t2]) <= 0)
+        std::cout << "for " << i << ':' << v[k] << " failed " << v[t1] << ' ' << v[t2] << std::endl;
+    };
+
+    for (uint32_t i = 0; i < Hist::nbins(); ++i) {
+      if (0 == h.size(i))
+        continue;
+      auto k = *h.begin(i);
+      assert(k < N);
+      auto kl = NBINS != 128 ? h.bin(std::max(rmin, v[k] - DELTA)) : h.bin(v[k] - T(DELTA));
+      auto kh = NBINS != 128 ? h.bin(std::min(rmax, v[k] + DELTA)) : h.bin(v[k] + T(DELTA));
+      if (NBINS == 128) {
+        assert(kl != i);
+        assert(kh != i);
+      }
+      if (NBINS != 128) {
+        assert(kl <= i);
+        assert(kh >= i);
+      }
+      // std::cout << kl << ' ' << kh << std::endl;
+      for (auto j = h.begin(kl); j < h.end(kl); ++j)
+        verify(i, kl, k, k, (*j));
+      for (auto j = h.begin(kh); j < h.end(kh); ++j)
+        verify(i, kh, k, (*j), k);
+    }
+  }
+
+  for (long long j = 0; j < N; j++) {
+    auto b0 = h.bin(v[j]);
+    int w = 0;
+    int tot = 0;
+    auto ftest = [&](int k) {
+      assert(k >= 0 && k < N);
+      tot++;
+    };
+    forEachInBins(h, v[j], w, ftest);
+    int rtot = h.end(b0) - h.begin(b0);
+    assert(tot == rtot);
+    w = 1;
+    tot = 0;
+    forEachInBins(h, v[j], w, ftest);
+    int bp = b0 + 1;
+    int bm = b0 - 1;
+    if (bp < int(h.nbins()))
+      rtot += h.end(bp) - h.begin(bp);
+    if (bm >= 0)
+      rtot += h.end(bm) - h.begin(bm);
+    assert(tot == rtot);
+    w = 2;
+    tot = 0;
+    forEachInBins(h, v[j], w, ftest);
+    bp++;
+    bm--;
+    if (bp < int(h.nbins()))
+      rtot += h.end(bp) - h.begin(bp);
+    if (bm >= 0)
+      rtot += h.end(bm) - h.begin(bm);
+    assert(tot == rtot);
+  }
+}
+
+int main() {
+  go<int16_t>();
+  go<uint8_t, 128, 8, 4>();
+  go<uint16_t, 313 / 2, 9, 4>();
+
+  return 0;
+}

--- a/src/cuda/test/OneHistoContainer_t.cu
+++ b/src/cuda/test/OneHistoContainer_t.cu
@@ -1,0 +1,137 @@
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <random>
+#include <limits>
+
+#include "CUDACore/device_unique_ptr.h"
+#include "CUDACore/cudaCheck.h"
+#include "CUDACore/HistoContainer.h"
+#include "CUDACore/launch.h"
+
+template <typename T, int NBINS, int S, int DELTA>
+__global__ void mykernel(T const* __restrict__ v, uint32_t N) {
+  assert(v);
+  assert(N == 12000);
+
+  if (threadIdx.x == 0)
+    printf("start kernel for %d data\n", N);
+
+  using Hist = HistoContainer<T, NBINS, 12000, S, uint16_t>;
+
+  __shared__ Hist hist;
+  __shared__ typename Hist::Counter ws[32];
+
+  for (auto j = threadIdx.x; j < Hist::totbins(); j += blockDim.x) {
+    hist.off[j] = 0;
+  }
+  __syncthreads();
+
+  for (auto j = threadIdx.x; j < N; j += blockDim.x)
+    hist.count(v[j]);
+  __syncthreads();
+
+  assert(0 == hist.size());
+  __syncthreads();
+
+  hist.finalize(ws);
+  __syncthreads();
+
+  assert(N == hist.size());
+  for (auto j = threadIdx.x; j < Hist::nbins(); j += blockDim.x)
+    assert(hist.off[j] <= hist.off[j + 1]);
+  __syncthreads();
+
+  if (threadIdx.x < 32)
+    ws[threadIdx.x] = 0;  // used by prefix scan...
+  __syncthreads();
+
+  for (auto j = threadIdx.x; j < N; j += blockDim.x)
+    hist.fill(v[j], j);
+  __syncthreads();
+  assert(0 == hist.off[0]);
+  assert(N == hist.size());
+
+  for (auto j = threadIdx.x; j < hist.size() - 1; j += blockDim.x) {
+    auto p = hist.begin() + j;
+    assert((*p) < N);
+    auto k1 = Hist::bin(v[*p]);
+    auto k2 = Hist::bin(v[*(p + 1)]);
+    assert(k2 >= k1);
+  }
+
+  for (auto i = threadIdx.x; i < hist.size(); i += blockDim.x) {
+    auto p = hist.begin() + i;
+    auto j = *p;
+    auto b0 = Hist::bin(v[j]);
+    int tot = 0;
+    auto ftest = [&](int k) {
+      assert(k >= 0 && k < N);
+      ++tot;
+    };
+    forEachInWindow(hist, v[j], v[j], ftest);
+    int rtot = hist.size(b0);
+    assert(tot == rtot);
+    tot = 0;
+    auto vm = int(v[j]) - DELTA;
+    auto vp = int(v[j]) + DELTA;
+    constexpr int vmax = NBINS != 128 ? NBINS * 2 - 1 : std::numeric_limits<T>::max();
+    vm = std::max(vm, 0);
+    vm = std::min(vm, vmax);
+    vp = std::min(vp, vmax);
+    vp = std::max(vp, 0);
+    assert(vp >= vm);
+    forEachInWindow(hist, vm, vp, ftest);
+    int bp = Hist::bin(vp);
+    int bm = Hist::bin(vm);
+    rtot = hist.end(bp) - hist.begin(bm);
+    assert(tot == rtot);
+  }
+}
+
+template <typename T, int NBINS = 128, int S = 8 * sizeof(T), int DELTA = 1000>
+void go() {
+  std::mt19937 eng;
+
+  int rmin = std::numeric_limits<T>::min();
+  int rmax = std::numeric_limits<T>::max();
+  if (NBINS != 128) {
+    rmin = 0;
+    rmax = NBINS * 2 - 1;
+  }
+
+  std::uniform_int_distribution<T> rgen(rmin, rmax);
+
+  constexpr int N = 12000;
+  T v[N];
+
+  auto v_d = cms::cuda::make_device_unique<T[]>(N, nullptr);
+  assert(v_d.get());
+
+  using Hist = HistoContainer<T, NBINS, N, S>;
+  std::cout << "HistoContainer " << Hist::nbits() << ' ' << Hist::nbins() << ' ' << Hist::capacity() << ' '
+            << (rmax - rmin) / Hist::nbins() << std::endl;
+  std::cout << "bins " << int(Hist::bin(0)) << ' ' << int(Hist::bin(rmin)) << ' ' << int(Hist::bin(rmax)) << std::endl;
+
+  for (int it = 0; it < 5; ++it) {
+    for (long long j = 0; j < N; j++)
+      v[j] = rgen(eng);
+    if (it == 2)
+      for (long long j = N / 2; j < N / 2 + N / 4; j++)
+        v[j] = 4;
+
+    assert(v_d.get());
+    assert(v);
+    cudaCheck(cudaMemcpy(v_d.get(), v, N * sizeof(T), cudaMemcpyHostToDevice));
+    assert(v_d.get());
+    cms::cuda::launch(mykernel<T, NBINS, S, DELTA>, {1, 256}, v_d.get(), N);
+  }
+}
+
+int main() {
+  go<int16_t>();
+  go<uint8_t, 128, 8, 4>();
+  go<uint16_t, 313 / 2, 9, 4>();
+
+  return 0;
+}

--- a/src/cuda/test/OneToManyAssoc_cpu_t.cc
+++ b/src/cuda/test/OneToManyAssoc_cpu_t.cc
@@ -1,0 +1,1 @@
+#include "OneToManyAssoc_t.h"

--- a/src/cuda/test/OneToManyAssoc_t.cu
+++ b/src/cuda/test/OneToManyAssoc_t.cu
@@ -1,0 +1,1 @@
+#include "OneToManyAssoc_t.h"

--- a/src/cuda/test/OneToManyAssoc_t.h
+++ b/src/cuda/test/OneToManyAssoc_t.h
@@ -1,0 +1,305 @@
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <random>
+#include <limits>
+#include <array>
+#include <memory>
+
+#ifdef __CUDACC__
+#include "CUDACore/device_unique_ptr.h"
+#include "CUDACore/cudaCheck.h"
+#include "CUDACore/currentDevice.h"
+#endif
+
+#include "CUDACore/HistoContainer.h"
+
+constexpr uint32_t MaxElem = 64000;
+constexpr uint32_t MaxTk = 8000;
+constexpr uint32_t MaxAssocs = 4 * MaxTk;
+using Assoc = OneToManyAssoc<uint16_t, MaxElem, MaxAssocs>;
+
+using SmallAssoc = OneToManyAssoc<uint16_t, 128, MaxAssocs>;
+
+using Multiplicity = OneToManyAssoc<uint16_t, 8, MaxTk>;
+
+using TK = std::array<uint16_t, 4>;
+
+__global__ void countMultiLocal(TK const* __restrict__ tk, Multiplicity* __restrict__ assoc, int32_t n) {
+  int first = blockDim.x * blockIdx.x + threadIdx.x;
+  for (int i = first; i < n; i += gridDim.x * blockDim.x) {
+    __shared__ Multiplicity::CountersOnly local;
+    if (threadIdx.x == 0)
+      local.zero();
+    __syncthreads();
+    local.countDirect(2 + i % 4);
+    __syncthreads();
+    if (threadIdx.x == 0)
+      assoc->add(local);
+  }
+}
+
+__global__ void countMulti(TK const* __restrict__ tk, Multiplicity* __restrict__ assoc, int32_t n) {
+  int first = blockDim.x * blockIdx.x + threadIdx.x;
+  for (int i = first; i < n; i += gridDim.x * blockDim.x)
+    assoc->countDirect(2 + i % 4);
+}
+
+__global__ void verifyMulti(Multiplicity* __restrict__ m1, Multiplicity* __restrict__ m2) {
+  auto first = blockDim.x * blockIdx.x + threadIdx.x;
+  for (auto i = first; i < Multiplicity::totbins(); i += gridDim.x * blockDim.x)
+    assert(m1->off[i] == m2->off[i]);
+}
+
+__global__ void count(TK const* __restrict__ tk, Assoc* __restrict__ assoc, int32_t n) {
+  int first = blockDim.x * blockIdx.x + threadIdx.x;
+  for (int i = first; i < 4 * n; i += gridDim.x * blockDim.x) {
+    auto k = i / 4;
+    auto j = i - 4 * k;
+    assert(j < 4);
+    if (k >= n)
+      return;
+    if (tk[k][j] < MaxElem)
+      assoc->countDirect(tk[k][j]);
+  }
+}
+
+__global__ void fill(TK const* __restrict__ tk, Assoc* __restrict__ assoc, int32_t n) {
+  int first = blockDim.x * blockIdx.x + threadIdx.x;
+  for (int i = first; i < 4 * n; i += gridDim.x * blockDim.x) {
+    auto k = i / 4;
+    auto j = i - 4 * k;
+    assert(j < 4);
+    if (k >= n)
+      return;
+    if (tk[k][j] < MaxElem)
+      assoc->fillDirect(tk[k][j], k);
+  }
+}
+
+__global__ void verify(Assoc* __restrict__ assoc) { assert(assoc->size() < Assoc::capacity()); }
+
+template <typename Assoc>
+__global__ void fillBulk(AtomicPairCounter* apc, TK const* __restrict__ tk, Assoc* __restrict__ assoc, int32_t n) {
+  int first = blockDim.x * blockIdx.x + threadIdx.x;
+  for (int k = first; k < n; k += gridDim.x * blockDim.x) {
+    auto m = tk[k][3] < MaxElem ? 4 : 3;
+    assoc->bulkFill(*apc, &tk[k][0], m);
+  }
+}
+
+template <typename Assoc>
+__global__ void verifyBulk(Assoc const* __restrict__ assoc, AtomicPairCounter const* apc) {
+  if (apc->get().m >= Assoc::nbins())
+    printf("Overflow %d %d\n", apc->get().m, Assoc::nbins());
+  assert(assoc->size() < Assoc::capacity());
+}
+
+int main() {
+#ifdef __CUDACC__
+  auto current_device = cms::cuda::currentDevice();
+#else
+  // make sure cuda emulation is working
+  std::cout << "cuda x's " << threadIdx.x << ' ' << blockIdx.x << ' ' << blockDim.x << ' ' << gridDim.x << std::endl;
+  std::cout << "cuda y's " << threadIdx.y << ' ' << blockIdx.y << ' ' << blockDim.y << ' ' << gridDim.y << std::endl;
+  std::cout << "cuda z's " << threadIdx.z << ' ' << blockIdx.z << ' ' << blockDim.z << ' ' << gridDim.z << std::endl;
+  assert(threadIdx.x == 0);
+  assert(threadIdx.y == 0);
+  assert(threadIdx.z == 0);
+  assert(blockIdx.x == 0);
+  assert(blockIdx.y == 0);
+  assert(blockIdx.z == 0);
+  assert(blockDim.x == 1);
+  assert(blockDim.y == 1);
+  assert(blockDim.z == 1);
+  assert(gridDim.x == 1);
+  assert(gridDim.y == 1);
+  assert(gridDim.z == 1);
+#endif
+
+  std::cout << "OneToManyAssoc " << Assoc::nbins() << ' ' << Assoc::capacity() << ' ' << Assoc::wsSize() << std::endl;
+  std::cout << "OneToManyAssoc (small) " << SmallAssoc::nbins() << ' ' << SmallAssoc::capacity() << ' '
+            << SmallAssoc::wsSize() << std::endl;
+
+  std::mt19937 eng;
+
+  std::geometric_distribution<int> rdm(0.8);
+
+  constexpr uint32_t N = 4000;
+
+  std::vector<std::array<uint16_t, 4>> tr(N);
+
+  // fill with "index" to element
+  long long ave = 0;
+  int imax = 0;
+  auto n = 0U;
+  auto z = 0U;
+  auto nz = 0U;
+  for (auto i = 0U; i < 4U; ++i) {
+    auto j = 0U;
+    while (j < N && n < MaxElem) {
+      if (z == 11) {
+        ++n;
+        z = 0;
+        ++nz;
+        continue;
+      }  // a bit of not assoc
+      auto x = rdm(eng);
+      auto k = std::min(j + x + 1, N);
+      if (i == 3 && z == 3) {  // some triplets time to time
+        for (; j < k; ++j)
+          tr[j][i] = MaxElem + 1;
+      } else {
+        ave += x + 1;
+        imax = std::max(imax, x);
+        for (; j < k; ++j)
+          tr[j][i] = n;
+        ++n;
+      }
+      ++z;
+    }
+    assert(n <= MaxElem);
+    assert(j <= N);
+  }
+  std::cout << "filled with " << n << " elements " << double(ave) / n << ' ' << imax << ' ' << nz << std::endl;
+
+#ifdef __CUDACC__
+  auto v_d = cms::cuda::make_device_unique<std::array<uint16_t, 4>[]>(N, nullptr);
+  assert(v_d.get());
+  auto a_d = cms::cuda::make_device_unique<Assoc[]>(1, nullptr);
+  auto sa_d = cms::cuda::make_device_unique<SmallAssoc[]>(1, nullptr);
+  auto ws_d = cms::cuda::make_device_unique<uint8_t[]>(Assoc::wsSize(), nullptr);
+
+  cudaCheck(cudaMemcpy(v_d.get(), tr.data(), N * sizeof(std::array<uint16_t, 4>), cudaMemcpyHostToDevice));
+#else
+  auto a_d = std::make_unique<Assoc>();
+  auto sa_d = std::make_unique<SmallAssoc>();
+  auto v_d = tr.data();
+#endif
+
+  cms::cuda::launchZero(a_d.get(), 0);
+
+#ifdef __CUDACC__
+  auto nThreads = 256;
+  auto nBlocks = (4 * N + nThreads - 1) / nThreads;
+
+  count<<<nBlocks, nThreads>>>(v_d.get(), a_d.get(), N);
+
+  cms::cuda::launchFinalize(a_d.get(), ws_d.get(), 0);
+  verify<<<1, 1>>>(a_d.get());
+  fill<<<nBlocks, nThreads>>>(v_d.get(), a_d.get(), N);
+#else
+  count(v_d, a_d.get(), N);
+  cms::cuda::launchFinalize(a_d.get());
+  verify(a_d.get());
+  fill(v_d, a_d.get(), N);
+#endif
+
+  Assoc la;
+
+#ifdef __CUDACC__
+  cudaCheck(cudaMemcpy(&la, a_d.get(), sizeof(Assoc), cudaMemcpyDeviceToHost));
+#else
+  memcpy(&la, a_d.get(), sizeof(Assoc));  // not required, easier
+#endif
+
+  std::cout << la.size() << std::endl;
+  imax = 0;
+  ave = 0;
+  z = 0;
+  for (auto i = 0U; i < n; ++i) {
+    auto x = la.size(i);
+    if (x == 0) {
+      z++;
+      continue;
+    }
+    ave += x;
+    imax = std::max(imax, int(x));
+  }
+  assert(0 == la.size(n));
+  std::cout << "found with " << n << " elements " << double(ave) / n << ' ' << imax << ' ' << z << std::endl;
+
+  // now the inverse map (actually this is the direct....)
+  AtomicPairCounter* dc_d;
+  AtomicPairCounter dc(0);
+
+#ifdef __CUDACC__
+  cudaCheck(cudaMalloc(&dc_d, sizeof(AtomicPairCounter)));
+  cudaCheck(cudaMemset(dc_d, 0, sizeof(AtomicPairCounter)));
+  nBlocks = (N + nThreads - 1) / nThreads;
+  fillBulk<<<nBlocks, nThreads>>>(dc_d, v_d.get(), a_d.get(), N);
+  cms::cuda::finalizeBulk<<<nBlocks, nThreads>>>(dc_d, a_d.get());
+  verifyBulk<<<1, 1>>>(a_d.get(), dc_d);
+
+  cudaCheck(cudaMemcpy(&la, a_d.get(), sizeof(Assoc), cudaMemcpyDeviceToHost));
+  cudaCheck(cudaMemcpy(&dc, dc_d, sizeof(AtomicPairCounter), cudaMemcpyDeviceToHost));
+
+  cudaCheck(cudaMemset(dc_d, 0, sizeof(AtomicPairCounter)));
+  fillBulk<<<nBlocks, nThreads>>>(dc_d, v_d.get(), sa_d.get(), N);
+  cms::cuda::finalizeBulk<<<nBlocks, nThreads>>>(dc_d, sa_d.get());
+  verifyBulk<<<1, 1>>>(sa_d.get(), dc_d);
+
+#else
+  dc_d = &dc;
+  fillBulk(dc_d, v_d, a_d.get(), N);
+  cms::cuda::finalizeBulk(dc_d, a_d.get());
+  verifyBulk(a_d.get(), dc_d);
+  memcpy(&la, a_d.get(), sizeof(Assoc));
+
+  AtomicPairCounter sdc(0);
+  fillBulk(&sdc, v_d, sa_d.get(), N);
+  cms::cuda::finalizeBulk(&sdc, sa_d.get());
+  verifyBulk(sa_d.get(), &sdc);
+
+#endif
+
+  std::cout << "final counter value " << dc.get().n << ' ' << dc.get().m << std::endl;
+
+  std::cout << la.size() << std::endl;
+  imax = 0;
+  ave = 0;
+  for (auto i = 0U; i < N; ++i) {
+    auto x = la.size(i);
+    if (!(x == 4 || x == 3))
+      std::cout << i << ' ' << x << std::endl;
+    assert(x == 4 || x == 3);
+    ave += x;
+    imax = std::max(imax, int(x));
+  }
+  assert(0 == la.size(N));
+  std::cout << "found with ave occupancy " << double(ave) / N << ' ' << imax << std::endl;
+
+  // here verify use of block local counters
+#ifdef __CUDACC__
+  auto m1_d = cms::cuda::make_device_unique<Multiplicity[]>(1, nullptr);
+  auto m2_d = cms::cuda::make_device_unique<Multiplicity[]>(1, nullptr);
+#else
+  auto m1_d = std::make_unique<Multiplicity>();
+  auto m2_d = std::make_unique<Multiplicity>();
+#endif
+  cms::cuda::launchZero(m1_d.get(), 0);
+  cms::cuda::launchZero(m2_d.get(), 0);
+
+#ifdef __CUDACC__
+  nBlocks = (4 * N + nThreads - 1) / nThreads;
+  countMulti<<<nBlocks, nThreads>>>(v_d.get(), m1_d.get(), N);
+  countMultiLocal<<<nBlocks, nThreads>>>(v_d.get(), m2_d.get(), N);
+  verifyMulti<<<1, Multiplicity::totbins()>>>(m1_d.get(), m2_d.get());
+
+  cms::cuda::launchFinalize(m1_d.get(), ws_d.get(), 0);
+  cms::cuda::launchFinalize(m2_d.get(), ws_d.get(), 0);
+  verifyMulti<<<1, Multiplicity::totbins()>>>(m1_d.get(), m2_d.get());
+
+  cudaCheck(cudaGetLastError());
+  cudaCheck(cudaDeviceSynchronize());
+#else
+  countMulti(v_d, m1_d.get(), N);
+  countMultiLocal(v_d, m2_d.get(), N);
+  verifyMulti(m1_d.get(), m2_d.get());
+
+  cms::cuda::launchFinalize(m1_d.get());
+  cms::cuda::launchFinalize(m2_d.get());
+  verifyMulti(m1_d.get(), m2_d.get());
+#endif
+  return 0;
+}

--- a/src/cuda/test/cpuClustering_t.cc
+++ b/src/cuda/test/cpuClustering_t.cc
@@ -1,0 +1,1 @@
+#include "gpuClustering_t.h"

--- a/src/cuda/test/cudastdAlgorithm_t.cu
+++ b/src/cuda/test/cudastdAlgorithm_t.cu
@@ -1,0 +1,25 @@
+#include <cassert>
+#include <iostream>
+
+#include "CUDACore/cudastdAlgorithm.h"
+#include "CUDACore/launch.h"
+
+__global__ void testBinaryFind() {
+  int data[] = {1, 1, 2, 3, 3, 3, 3, 4, 4, 4, 5, 5, 6};
+
+  auto lower = cuda_std::lower_bound(data, data + 13, 4);
+  auto upper = cuda_std::upper_bound(data, data + 12, 4);
+
+  assert(3 == upper - lower);
+
+  // classic binary search, returning a value only if it is present
+
+  constexpr int data2[] = {1, 2, 4, 6, 9, 10};
+
+  assert(data2 + 2 == cuda_std::binary_find(data2, data2 + 6, 4));
+  assert(data2 + 6 == cuda_std::binary_find(data2, data2 + 6, 5));
+}
+
+void wrapper() { cms::cuda::launch(testBinaryFind, {32, 64}); }
+
+int main() { wrapper(); }

--- a/src/cuda/test/cudastdAlgorithm_t_cpu.cc
+++ b/src/cuda/test/cudastdAlgorithm_t_cpu.cc
@@ -1,0 +1,34 @@
+#include "CUDACore/cudastdAlgorithm.h"
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <vector>
+
+void testBinaryFind() {
+  std::vector<int> data = {1, 1, 2, 3, 3, 3, 3, 4, 4, 4, 5, 5, 6};
+
+  auto lower = cuda_std::lower_bound(data.begin(), data.end(), 4);
+  auto upper = cuda_std::upper_bound(data.begin(), data.end(), 4);
+
+  std::copy(lower, upper, std::ostream_iterator<int>(std::cout, " "));
+
+  std::cout << '\n';
+
+  // classic binary search, returning a value only if it is present
+
+  data = {1, 2, 4, 6, 9, 10};
+
+  auto test = [&](auto v) {
+    auto it = cuda_std::binary_find(data.cbegin(), data.cend(), v);
+
+    if (it != data.cend())
+      std::cout << *it << " found at index " << std::distance(data.cbegin(), it) << std::endl;
+    else
+      std::cout << v << " non found" << std::endl;
+  };
+
+  test(4);
+  test(5);
+}
+
+int main() { testBinaryFind(); }

--- a/src/cuda/test/eigenSoA_t.cu
+++ b/src/cuda/test/eigenSoA_t.cu
@@ -1,0 +1,1 @@
+#include "eigenSoA_t.h"

--- a/src/cuda/test/eigenSoA_t.h
+++ b/src/cuda/test/eigenSoA_t.h
@@ -1,0 +1,96 @@
+#include <Eigen/Dense>
+
+#include "CUDACore/eigenSoA.h"
+
+template <int32_t S>
+struct MySoA {
+  // we can find a way to avoid this copy/paste???
+  static constexpr int32_t stride() { return S; }
+
+  eigenSoA::ScalarSoA<float, S> a;
+  eigenSoA::ScalarSoA<float, S> b;
+};
+
+using V = MySoA<128>;
+
+__global__ void testBasicSoA(float* p) {
+  using namespace eigenSoA;
+
+  assert(!isPowerOf2(0));
+  assert(isPowerOf2(1));
+  assert(isPowerOf2(1024));
+  assert(!isPowerOf2(1026));
+
+  using M3 = Eigen::Matrix<float, 3, 3>;
+  ;
+  __shared__ eigenSoA::MatrixSoA<M3, 64> m;
+
+  int first = threadIdx.x + blockIdx.x * blockDim.x;
+  if (0 == first)
+    printf("before %f\n", p[0]);
+
+  // a silly game...
+  int n = 64;
+  for (int i = first; i < n; i += blockDim.x * gridDim.x) {
+    m[i].setZero();
+    m[i](0, 0) = p[i];
+    m[i](1, 1) = p[i + 64];
+    m[i](2, 2) = p[i + 64 * 2];
+  }
+  __syncthreads();  // not needed
+
+  for (int i = first; i < n; i += blockDim.x * gridDim.x)
+    m[i] = m[i].inverse().eval();
+  __syncthreads();
+
+  for (int i = first; i < n; i += blockDim.x * gridDim.x) {
+    p[i] = m[63 - i](0, 0);
+    p[i + 64] = m[63 - i](1, 1);
+    p[i + 64 * 2] = m[63 - i](2, 2);
+  }
+
+  if (0 == first)
+    printf("after %f\n", p[0]);
+}
+
+#include <cassert>
+#include <iostream>
+#include <memory>
+#include <random>
+
+#ifdef __CUDACC__
+#include "CUDACore/cudaCheck.h"
+#endif
+
+int main() {
+  float p[1024];
+
+  std::uniform_real_distribution<float> rgen(0.01, 0.99);
+  std::mt19937 eng;
+
+  for (auto& r : p)
+    r = rgen(eng);
+  for (int i = 0, n = 64 * 3; i < n; ++i)
+    assert(p[i] > 0 && p[i] < 1.);
+
+  std::cout << p[0] << std::endl;
+#ifdef __CUDACC__
+  float* p_d;
+  cudaCheck(cudaMalloc(&p_d, 1024 * 4));
+  cudaCheck(cudaMemcpy(p_d, p, 1024 * 4, cudaMemcpyDefault));
+  testBasicSoA<<<1, 1024>>>(p_d);
+  cudaCheck(cudaGetLastError());
+  cudaCheck(cudaMemcpy(p, p_d, 1024 * 4, cudaMemcpyDefault));
+  cudaCheck(cudaDeviceSynchronize());
+#else
+  testBasicSoA(p);
+#endif
+
+  std::cout << p[0] << std::endl;
+
+  for (int i = 0, n = 64 * 3; i < n; ++i)
+    assert(p[i] > 1.);
+
+  std::cout << "END" << std::endl;
+  return 0;
+}

--- a/src/cuda/test/eigenSoA_t_cpu.cc
+++ b/src/cuda/test/eigenSoA_t_cpu.cc
@@ -1,0 +1,1 @@
+#include "eigenSoA_t.h"

--- a/src/cuda/test/gpuClustering_t.cu
+++ b/src/cuda/test/gpuClustering_t.cu
@@ -1,0 +1,1 @@
+#include "gpuClustering_t.h"

--- a/src/cuda/test/gpuClustering_t.h
+++ b/src/cuda/test/gpuClustering_t.h
@@ -1,0 +1,396 @@
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <set>
+#include <vector>
+
+#ifdef __CUDACC__
+
+#include "CUDACore/device_unique_ptr.h"
+#include "CUDACore/cudaCheck.h"
+#include "CUDACore/launch.h"
+#endif
+
+// dirty, but works
+#include "plugin-SiPixelClusterizer/gpuClustering.h"
+#include "plugin-SiPixelClusterizer/gpuClusterChargeCut.h"
+
+int main(void) {
+  using namespace gpuClustering;
+
+  int numElements = 256 * 2000;
+  // these in reality are already on GPU
+  auto h_id = std::make_unique<uint16_t[]>(numElements);
+  auto h_x = std::make_unique<uint16_t[]>(numElements);
+  auto h_y = std::make_unique<uint16_t[]>(numElements);
+  auto h_adc = std::make_unique<uint16_t[]>(numElements);
+
+  auto h_clus = std::make_unique<int[]>(numElements);
+
+#ifdef __CUDACC__
+  auto d_id = cms::cuda::make_device_unique<uint16_t[]>(numElements, nullptr);
+  auto d_x = cms::cuda::make_device_unique<uint16_t[]>(numElements, nullptr);
+  auto d_y = cms::cuda::make_device_unique<uint16_t[]>(numElements, nullptr);
+  auto d_adc = cms::cuda::make_device_unique<uint16_t[]>(numElements, nullptr);
+  auto d_clus = cms::cuda::make_device_unique<int[]>(numElements, nullptr);
+  auto d_moduleStart = cms::cuda::make_device_unique<uint32_t[]>(MaxNumModules + 1, nullptr);
+  auto d_clusInModule = cms::cuda::make_device_unique<uint32_t[]>(MaxNumModules, nullptr);
+  auto d_moduleId = cms::cuda::make_device_unique<uint32_t[]>(MaxNumModules, nullptr);
+#else
+
+  auto h_moduleStart = std::make_unique<uint32_t[]>(MaxNumModules + 1);
+  auto h_clusInModule = std::make_unique<uint32_t[]>(MaxNumModules);
+  auto h_moduleId = std::make_unique<uint32_t[]>(MaxNumModules);
+
+#endif
+
+  // later random number
+  int n = 0;
+  int ncl = 0;
+  int y[10] = {5, 7, 9, 1, 3, 0, 4, 8, 2, 6};
+
+  auto generateClusters = [&](int kn) {
+    auto addBigNoise = 1 == kn % 2;
+    if (addBigNoise) {
+      constexpr int MaxPixels = 1000;
+      int id = 666;
+      for (int x = 0; x < 140; x += 3) {
+        for (int yy = 0; yy < 400; yy += 3) {
+          h_id[n] = id;
+          h_x[n] = x;
+          h_y[n] = yy;
+          h_adc[n] = 1000;
+          ++n;
+          ++ncl;
+          if (MaxPixels <= ncl)
+            break;
+        }
+        if (MaxPixels <= ncl)
+          break;
+      }
+    }
+
+    {
+      // isolated
+      int id = 42;
+      int x = 10;
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x;
+      h_y[n] = x;
+      h_adc[n] = kn == 0 ? 100 : 5000;
+      ++n;
+
+      // first column
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x;
+      h_y[n] = 0;
+      h_adc[n] = 5000;
+      ++n;
+      // first columns
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x + 80;
+      h_y[n] = 2;
+      h_adc[n] = 5000;
+      ++n;
+      h_id[n] = id;
+      h_x[n] = x + 80;
+      h_y[n] = 1;
+      h_adc[n] = 5000;
+      ++n;
+
+      // last column
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x;
+      h_y[n] = 415;
+      h_adc[n] = 5000;
+      ++n;
+      // last columns
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x + 80;
+      h_y[n] = 415;
+      h_adc[n] = 2500;
+      ++n;
+      h_id[n] = id;
+      h_x[n] = x + 80;
+      h_y[n] = 414;
+      h_adc[n] = 2500;
+      ++n;
+
+      // diagonal
+      ++ncl;
+      for (int x = 20; x < 25; ++x) {
+        h_id[n] = id;
+        h_x[n] = x;
+        h_y[n] = x;
+        h_adc[n] = 1000;
+        ++n;
+      }
+      ++ncl;
+      // reversed
+      for (int x = 45; x > 40; --x) {
+        h_id[n] = id;
+        h_x[n] = x;
+        h_y[n] = x;
+        h_adc[n] = 1000;
+        ++n;
+      }
+      ++ncl;
+      h_id[n++] = InvId;  // error
+      // messy
+      int xx[5] = {21, 25, 23, 24, 22};
+      for (int k = 0; k < 5; ++k) {
+        h_id[n] = id;
+        h_x[n] = xx[k];
+        h_y[n] = 20 + xx[k];
+        h_adc[n] = 1000;
+        ++n;
+      }
+      // holes
+      ++ncl;
+      for (int k = 0; k < 5; ++k) {
+        h_id[n] = id;
+        h_x[n] = xx[k];
+        h_y[n] = 100;
+        h_adc[n] = kn == 2 ? 100 : 1000;
+        ++n;
+        if (xx[k] % 2 == 0) {
+          h_id[n] = id;
+          h_x[n] = xx[k];
+          h_y[n] = 101;
+          h_adc[n] = 1000;
+          ++n;
+        }
+      }
+    }
+    {
+      // id == 0 (make sure it works!
+      int id = 0;
+      int x = 10;
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x;
+      h_y[n] = x;
+      h_adc[n] = 5000;
+      ++n;
+    }
+    // all odd id
+    for (int id = 11; id <= 1800; id += 2) {
+      if ((id / 20) % 2)
+        h_id[n++] = InvId;  // error
+      for (int x = 0; x < 40; x += 4) {
+        ++ncl;
+        if ((id / 10) % 2) {
+          for (int k = 0; k < 10; ++k) {
+            h_id[n] = id;
+            h_x[n] = x;
+            h_y[n] = x + y[k];
+            h_adc[n] = 100;
+            ++n;
+            h_id[n] = id;
+            h_x[n] = x + 1;
+            h_y[n] = x + y[k] + 2;
+            h_adc[n] = 1000;
+            ++n;
+          }
+        } else {
+          for (int k = 0; k < 10; ++k) {
+            h_id[n] = id;
+            h_x[n] = x;
+            h_y[n] = x + y[9 - k];
+            h_adc[n] = kn == 2 ? 10 : 1000;
+            ++n;
+            if (y[k] == 3)
+              continue;  // hole
+            if (id == 51) {
+              h_id[n++] = InvId;
+              h_id[n++] = InvId;
+            }  // error
+            h_id[n] = id;
+            h_x[n] = x + 1;
+            h_y[n] = x + y[k] + 2;
+            h_adc[n] = kn == 2 ? 10 : 1000;
+            ++n;
+          }
+        }
+      }
+    }
+  };  // end lambda
+  for (auto kkk = 0; kkk < 5; ++kkk) {
+    n = 0;
+    ncl = 0;
+    generateClusters(kkk);
+
+    std::cout << "created " << n << " digis in " << ncl << " clusters" << std::endl;
+    assert(n <= numElements);
+
+    uint32_t nModules = 0;
+#ifdef __CUDACC__
+    size_t size32 = n * sizeof(unsigned int);
+    size_t size16 = n * sizeof(unsigned short);
+    // size_t size8 = n * sizeof(uint8_t);
+
+    cudaCheck(cudaMemcpy(d_moduleStart.get(), &nModules, sizeof(uint32_t), cudaMemcpyHostToDevice));
+
+    cudaCheck(cudaMemcpy(d_id.get(), h_id.get(), size16, cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(d_x.get(), h_x.get(), size16, cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(d_y.get(), h_y.get(), size16, cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(d_adc.get(), h_adc.get(), size16, cudaMemcpyHostToDevice));
+    // Launch CUDA Kernels
+    int threadsPerBlock = (kkk == 5) ? 512 : ((kkk == 3) ? 128 : 256);
+    int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
+    std::cout << "CUDA countModules kernel launch with " << blocksPerGrid << " blocks of " << threadsPerBlock
+              << " threads\n";
+
+    cms::cuda::launch(countModules, {blocksPerGrid, threadsPerBlock}, d_id.get(), d_moduleStart.get(), d_clus.get(), n);
+
+    blocksPerGrid = MaxNumModules;  //nModules;
+
+    std::cout << "CUDA findModules kernel launch with " << blocksPerGrid << " blocks of " << threadsPerBlock
+              << " threads\n";
+    cudaCheck(cudaMemset(d_clusInModule.get(), 0, MaxNumModules * sizeof(uint32_t)));
+
+    cms::cuda::launch(findClus,
+                      {blocksPerGrid, threadsPerBlock},
+                      d_id.get(),
+                      d_x.get(),
+                      d_y.get(),
+                      d_moduleStart.get(),
+                      d_clusInModule.get(),
+                      d_moduleId.get(),
+                      d_clus.get(),
+                      n);
+    cudaDeviceSynchronize();
+    cudaCheck(cudaMemcpy(&nModules, d_moduleStart.get(), sizeof(uint32_t), cudaMemcpyDeviceToHost));
+
+    uint32_t nclus[MaxNumModules], moduleId[nModules];
+    cudaCheck(cudaMemcpy(&nclus, d_clusInModule.get(), MaxNumModules * sizeof(uint32_t), cudaMemcpyDeviceToHost));
+
+    std::cout << "before charge cut found " << std::accumulate(nclus, nclus + MaxNumModules, 0) << " clusters"
+              << std::endl;
+    for (auto i = MaxNumModules; i > 0; i--)
+      if (nclus[i - 1] > 0) {
+        std::cout << "last module is " << i - 1 << ' ' << nclus[i - 1] << std::endl;
+        break;
+      }
+    if (ncl != std::accumulate(nclus, nclus + MaxNumModules, 0))
+      std::cout << "ERROR!!!!! wrong number of cluster found" << std::endl;
+
+    cms::cuda::launch(clusterChargeCut,
+                      {blocksPerGrid, threadsPerBlock},
+                      d_id.get(),
+                      d_adc.get(),
+                      d_moduleStart.get(),
+                      d_clusInModule.get(),
+                      d_moduleId.get(),
+                      d_clus.get(),
+                      n);
+
+    cudaDeviceSynchronize();
+#else
+    h_moduleStart[0] = nModules;
+    countModules(h_id.get(), h_moduleStart.get(), h_clus.get(), n);
+    memset(h_clusInModule.get(), 0, MaxNumModules * sizeof(uint32_t));
+    gridDim.x = MaxNumModules;  //not needed in the kernel for this specific case;
+    assert(blockIdx.x == 0);
+    for (; blockIdx.x < gridDim.x; ++blockIdx.x)
+      findClus(h_id.get(),
+               h_x.get(),
+               h_y.get(),
+               h_moduleStart.get(),
+               h_clusInModule.get(),
+               h_moduleId.get(),
+               h_clus.get(),
+               n);
+    resetGrid();
+
+    nModules = h_moduleStart[0];
+    auto nclus = h_clusInModule.get();
+
+    std::cout << "before charge cut found " << std::accumulate(nclus, nclus + MaxNumModules, 0) << " clusters"
+              << std::endl;
+    for (auto i = MaxNumModules; i > 0; i--)
+      if (nclus[i - 1] > 0) {
+        std::cout << "last module is " << i - 1 << ' ' << nclus[i - 1] << std::endl;
+        break;
+      }
+    if (ncl != std::accumulate(nclus, nclus + MaxNumModules, 0))
+      std::cout << "ERROR!!!!! wrong number of cluster found" << std::endl;
+
+    gridDim.x = MaxNumModules;  // no needed in the kernel for in this specific case
+    assert(blockIdx.x == 0);
+    for (; blockIdx.x < gridDim.x; ++blockIdx.x)
+      clusterChargeCut(
+          h_id.get(), h_adc.get(), h_moduleStart.get(), h_clusInModule.get(), h_moduleId.get(), h_clus.get(), n);
+    resetGrid();
+
+#endif
+
+    std::cout << "found " << nModules << " Modules active" << std::endl;
+
+#ifdef __CUDACC__
+    cudaCheck(cudaMemcpy(h_id.get(), d_id.get(), size16, cudaMemcpyDeviceToHost));
+    cudaCheck(cudaMemcpy(h_clus.get(), d_clus.get(), size32, cudaMemcpyDeviceToHost));
+    cudaCheck(cudaMemcpy(&nclus, d_clusInModule.get(), MaxNumModules * sizeof(uint32_t), cudaMemcpyDeviceToHost));
+    cudaCheck(cudaMemcpy(&moduleId, d_moduleId.get(), nModules * sizeof(uint32_t), cudaMemcpyDeviceToHost));
+#endif
+
+    std::set<unsigned int> clids;
+    for (int i = 0; i < n; ++i) {
+      assert(h_id[i] != 666);  // only noise
+      if (h_id[i] == InvId)
+        continue;
+      assert(h_clus[i] >= 0);
+      assert(h_clus[i] < int(nclus[h_id[i]]));
+      clids.insert(h_id[i] * 1000 + h_clus[i]);
+      // clids.insert(h_clus[i]);
+    }
+
+    // verify no hole in numbering
+    auto p = clids.begin();
+    auto cmid = (*p) / 1000;
+    assert(0 == (*p) % 1000);
+    auto c = p;
+    ++c;
+    std::cout << "first clusters " << *p << ' ' << *c << ' ' << nclus[cmid] << ' ' << nclus[(*c) / 1000] << std::endl;
+    std::cout << "last cluster " << *clids.rbegin() << ' ' << nclus[(*clids.rbegin()) / 1000] << std::endl;
+    for (; c != clids.end(); ++c) {
+      auto cc = *c;
+      auto pp = *p;
+      auto mid = cc / 1000;
+      auto pnc = pp % 1000;
+      auto nc = cc % 1000;
+      if (mid != cmid) {
+        assert(0 == cc % 1000);
+        assert(nclus[cmid] - 1 == pp % 1000);
+        // if (nclus[cmid]-1 != pp%1000) std::cout << "error size " << mid << ": "  << nclus[mid] << ' ' << pp << std::endl;
+        cmid = mid;
+        p = c;
+        continue;
+      }
+      p = c;
+      // assert(nc==pnc+1);
+      if (nc != pnc + 1)
+        std::cout << "error " << mid << ": " << nc << ' ' << pnc << std::endl;
+    }
+
+    std::cout << "found " << std::accumulate(nclus, nclus + MaxNumModules, 0) << ' ' << clids.size() << " clusters"
+              << std::endl;
+    for (auto i = MaxNumModules; i > 0; i--)
+      if (nclus[i - 1] > 0) {
+        std::cout << "last module is " << i - 1 << ' ' << nclus[i - 1] << std::endl;
+        break;
+      }
+    // << " and " << seeds.size() << " seeds" << std::endl;
+  }  /// end loop kkk
+  return 0;
+}

--- a/src/cuda/test/prefixScan_t.cu
+++ b/src/cuda/test/prefixScan_t.cu
@@ -1,0 +1,150 @@
+#include <iostream>
+
+#include <cub/cub.cuh>
+
+#include "CUDACore/cudaCheck.h"
+#include "CUDACore/prefixScan.h"
+
+template <typename T>
+__global__ void testPrefixScan(uint32_t size) {
+  __shared__ T ws[32];
+  __shared__ T c[1024];
+  __shared__ T co[1024];
+
+  auto first = threadIdx.x;
+  for (auto i = first; i < size; i += blockDim.x)
+    c[i] = 1;
+  __syncthreads();
+
+  blockPrefixScan(c, co, size, ws);
+  blockPrefixScan(c, size, ws);
+
+  assert(1 == c[0]);
+  assert(1 == co[0]);
+  for (auto i = first + 1; i < size; i += blockDim.x) {
+    if (c[i] != c[i - 1] + 1)
+      printf("failed %d %d %d: %d %d\n", size, i, blockDim.x, c[i], c[i - 1]);
+    assert(c[i] == c[i - 1] + 1);
+    assert(c[i] == i + 1);
+    assert(c[i] = co[i]);
+  }
+}
+
+template <typename T>
+__global__ void testWarpPrefixScan(uint32_t size) {
+  assert(size <= 32);
+  __shared__ T c[1024];
+  __shared__ T co[1024];
+  auto i = threadIdx.x;
+  c[i] = 1;
+  __syncthreads();
+
+  warpPrefixScan(c, co, i, 0xffffffff);
+  warpPrefixScan(c, i, 0xffffffff);
+  __syncthreads();
+
+  assert(1 == c[0]);
+  assert(1 == co[0]);
+  if (i != 0) {
+    if (c[i] != c[i - 1] + 1)
+      printf("failed %d %d %d: %d %d\n", size, i, blockDim.x, c[i], c[i - 1]);
+    assert(c[i] == c[i - 1] + 1);
+    assert(c[i] == i + 1);
+    assert(c[i] = co[i]);
+  }
+}
+
+__global__ void init(uint32_t *v, uint32_t val, uint32_t n) {
+  auto i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n)
+    v[i] = val;
+  if (i == 0)
+    printf("init\n");
+}
+
+__global__ void verify(uint32_t const *v, uint32_t n) {
+  auto i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n)
+    assert(v[i] == i + 1);
+  if (i == 0)
+    printf("verify\n");
+}
+
+int main() {
+  std::cout << "warp level" << std::endl;
+  // std::cout << "warp 32" << std::endl;
+  testWarpPrefixScan<int><<<1, 32>>>(32);
+  cudaDeviceSynchronize();
+  // std::cout << "warp 16" << std::endl;
+  testWarpPrefixScan<int><<<1, 32>>>(16);
+  cudaDeviceSynchronize();
+  // std::cout << "warp 5" << std::endl;
+  testWarpPrefixScan<int><<<1, 32>>>(5);
+  cudaDeviceSynchronize();
+
+  std::cout << "block level" << std::endl;
+  for (int bs = 32; bs <= 1024; bs += 32) {
+    // std::cout << "bs " << bs << std::endl;
+    for (int j = 1; j <= 1024; ++j) {
+      // std::cout << j << std::endl;
+      testPrefixScan<uint16_t><<<1, bs>>>(j);
+      cudaDeviceSynchronize();
+      testPrefixScan<float><<<1, bs>>>(j);
+      cudaDeviceSynchronize();
+    }
+  }
+  cudaDeviceSynchronize();
+
+  int num_items = 200;
+  for (int ksize = 1; ksize < 4; ++ksize) {
+    // test multiblock
+    std::cout << "multiblok" << std::endl;
+    // Declare, allocate, and initialize device-accessible pointers for input and output
+    num_items *= 10;
+    uint32_t *d_in;
+    uint32_t *d_out1;
+    uint32_t *d_out2;
+
+    cudaCheck(cudaMalloc(&d_in, num_items * sizeof(uint32_t)));
+    cudaCheck(cudaMalloc(&d_out1, num_items * sizeof(uint32_t)));
+    cudaCheck(cudaMalloc(&d_out2, num_items * sizeof(uint32_t)));
+
+    auto nthreads = 256;
+    auto nblocks = (num_items + nthreads - 1) / nthreads;
+
+    init<<<nblocks, nthreads, 0>>>(d_in, 1, num_items);
+
+    // the block counter
+    int32_t *d_pc;
+    cudaCheck(cudaMalloc(&d_pc, sizeof(int32_t)));
+    cudaCheck(cudaMemset(d_pc, 0, 4));
+
+    nthreads = 1024;
+    nblocks = (num_items + nthreads - 1) / nthreads;
+    multiBlockPrefixScan<<<nblocks, nthreads, 0>>>(d_in, d_out1, num_items, d_pc);
+    verify<<<nblocks, nthreads, 0>>>(d_out1, num_items);
+    cudaDeviceSynchronize();
+
+    // test cub
+    std::cout << "cub" << std::endl;
+    // Determine temporary device storage requirements for inclusive prefix sum
+    void *d_temp_storage = nullptr;
+    size_t temp_storage_bytes = 0;
+    cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out2, num_items);
+
+    std::cout << "temp storage " << temp_storage_bytes << std::endl;
+
+    // Allocate temporary storage for inclusive prefix sum
+    // fake larger ws already available
+    temp_storage_bytes *= 8;
+    cudaCheck(cudaMalloc(&d_temp_storage, temp_storage_bytes));
+    std::cout << "temp storage " << temp_storage_bytes << std::endl;
+    // Run inclusive prefix sum
+    CubDebugExit(cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out2, num_items));
+    std::cout << "temp storage " << temp_storage_bytes << std::endl;
+
+    verify<<<nblocks, nthreads, 0>>>(d_out2, num_items);
+    cudaDeviceSynchronize();
+  }  // ksize
+  return 0;
+}

--- a/src/cuda/test/radixSort_t.cu
+++ b/src/cuda/test/radixSort_t.cu
@@ -1,0 +1,199 @@
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <random>
+#include <set>
+
+#include "CUDACore/device_unique_ptr.h"
+#include "CUDACore/cudaCheck.h"
+#include "CUDACore/launch.h"
+#include "CUDACore/radixSort.h"
+
+template <typename T>
+struct RS {
+  using type = std::uniform_int_distribution<T>;
+  static auto ud() { return type(std::numeric_limits<T>::min(), std::numeric_limits<T>::max()); }
+  static constexpr T imax = std::numeric_limits<T>::max();
+};
+
+template <>
+struct RS<float> {
+  using T = float;
+  using type = std::uniform_real_distribution<float>;
+  static auto ud() { return type(-std::numeric_limits<T>::max() / 2, std::numeric_limits<T>::max() / 2); }
+  //  static auto ud() { return type(0,std::numeric_limits<T>::max()/2);}
+  static constexpr int imax = std::numeric_limits<int>::max();
+};
+
+template <typename T, int NS = sizeof(T), typename U = T, typename LL = long long>
+void go(bool useShared) {
+  std::mt19937 eng;
+  //std::mt19937 eng2;
+  auto rgen = RS<T>::ud();
+
+  auto start = std::chrono::high_resolution_clock::now();
+  auto delta = start - start;
+
+  constexpr int blocks = 10;
+  constexpr int blockSize = 256 * 32;
+  constexpr int N = blockSize * blocks;
+  T v[N];
+  uint16_t ind[N];
+
+  constexpr bool sgn = T(-1) < T(0);
+  std::cout << "Will sort " << N << (sgn ? " signed" : " unsigned")
+            << (std::numeric_limits<T>::is_integer ? " 'ints'" : " 'float'") << " of size " << sizeof(T) << " using "
+            << NS << " significant bytes" << std::endl;
+
+  for (int i = 0; i < 50; ++i) {
+    if (i == 49) {
+      for (long long j = 0; j < N; j++)
+        v[j] = 0;
+    } else if (i > 30) {
+      for (long long j = 0; j < N; j++)
+        v[j] = rgen(eng);
+    } else {
+      uint64_t imax = (i < 15) ? uint64_t(RS<T>::imax) + 1LL : 255;
+      for (uint64_t j = 0; j < N; j++) {
+        v[j] = (j % imax);
+        if (j % 2 && i % 2)
+          v[j] = -v[j];
+      }
+    }
+
+    uint32_t offsets[blocks + 1];
+    offsets[0] = 0;
+    for (int j = 1; j < blocks + 1; ++j) {
+      offsets[j] = offsets[j - 1] + blockSize - 3 * j;
+      assert(offsets[j] <= N);
+    }
+
+    if (i == 1) {  // special cases...
+      offsets[0] = 0;
+      offsets[1] = 0;
+      offsets[2] = 19;
+      offsets[3] = 32 + offsets[2];
+      offsets[4] = 123 + offsets[3];
+      offsets[5] = 256 + offsets[4];
+      offsets[6] = 311 + offsets[5];
+      offsets[7] = 2111 + offsets[6];
+      offsets[8] = 256 * 11 + offsets[7];
+      offsets[9] = 44 + offsets[8];
+      offsets[10] = 3297 + offsets[9];
+    }
+
+    std::random_shuffle(v, v + N);
+
+    auto v_d = cms::cuda::make_device_unique<U[]>(N, nullptr);
+    auto ind_d = cms::cuda::make_device_unique<uint16_t[]>(N, nullptr);
+    auto ws_d = cms::cuda::make_device_unique<uint16_t[]>(N, nullptr);
+    auto off_d = cms::cuda::make_device_unique<uint32_t[]>(blocks + 1, nullptr);
+
+    cudaCheck(cudaMemcpy(v_d.get(), v, N * sizeof(T), cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(off_d.get(), offsets, 4 * (blocks + 1), cudaMemcpyHostToDevice));
+
+    if (i < 2)
+      std::cout << "lauch for " << offsets[blocks] << std::endl;
+
+    auto ntXBl __attribute__((unused)) = 1 == i % 4 ? 256 : 256;
+
+    delta -= (std::chrono::high_resolution_clock::now() - start);
+    constexpr int MaxSize = 256 * 32;
+    if (useShared)
+      cms::cuda::launch(
+          radixSortMultiWrapper<U, NS>, {blocks, ntXBl, MaxSize * 2}, v_d.get(), ind_d.get(), off_d.get(), nullptr);
+    else
+      cms::cuda::launch(
+          radixSortMultiWrapper2<U, NS>, {blocks, ntXBl}, v_d.get(), ind_d.get(), off_d.get(), ws_d.get());
+
+    if (i == 0)
+      std::cout << "done for " << offsets[blocks] << std::endl;
+
+    cudaCheck(cudaMemcpy(ind, ind_d.get(), 2 * N, cudaMemcpyDeviceToHost));
+
+    delta += (std::chrono::high_resolution_clock::now() - start);
+
+    if (i == 0)
+      std::cout << "done for " << offsets[blocks] << std::endl;
+
+    if (32 == i) {
+      std::cout << LL(v[ind[0]]) << ' ' << LL(v[ind[1]]) << ' ' << LL(v[ind[2]]) << std::endl;
+      std::cout << LL(v[ind[3]]) << ' ' << LL(v[ind[10]]) << ' ' << LL(v[ind[blockSize - 1000]]) << std::endl;
+      std::cout << LL(v[ind[blockSize / 2 - 1]]) << ' ' << LL(v[ind[blockSize / 2]]) << ' '
+                << LL(v[ind[blockSize / 2 + 1]]) << std::endl;
+    }
+    for (int ib = 0; ib < blocks; ++ib) {
+      std::set<uint16_t> inds;
+      if (offsets[ib + 1] > offsets[ib])
+        inds.insert(ind[offsets[ib]]);
+      for (auto j = offsets[ib] + 1; j < offsets[ib + 1]; j++) {
+        inds.insert(ind[j]);
+        auto a = v + offsets[ib];
+        auto k1 = a[ind[j]];
+        auto k2 = a[ind[j - 1]];
+        auto sh = sizeof(uint64_t) - NS;
+        sh *= 8;
+        auto shorten = [sh](T& t) {
+          auto k = (uint64_t*)(&t);
+          *k = (*k >> sh) << sh;
+        };
+        shorten(k1);
+        shorten(k2);
+        if (k1 < k2)
+          std::cout << ib << " not ordered at " << ind[j] << " : " << a[ind[j]] << ' ' << a[ind[j - 1]] << std::endl;
+      }
+      if (!inds.empty()) {
+        assert(0 == *inds.begin());
+        assert(inds.size() - 1 == *inds.rbegin());
+      }
+      if (inds.size() != (offsets[ib + 1] - offsets[ib]))
+        std::cout << "error " << i << ' ' << ib << ' ' << inds.size() << "!=" << (offsets[ib + 1] - offsets[ib])
+                  << std::endl;
+      assert(inds.size() == (offsets[ib + 1] - offsets[ib]));
+    }
+  }  // 50 times
+  std::cout << "cuda computation took " << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count() / 50.
+            << " ms" << std::endl;
+}
+
+int main() {
+  bool useShared = false;
+
+  std::cout << "using Global memory" << std::endl;
+
+  go<int8_t>(useShared);
+  go<int16_t>(useShared);
+  go<int32_t>(useShared);
+  go<int32_t, 3>(useShared);
+  go<int64_t>(useShared);
+  go<float, 4, float, double>(useShared);
+  go<float, 2, float, double>(useShared);
+
+  go<uint8_t>(useShared);
+  go<uint16_t>(useShared);
+  go<uint32_t>(useShared);
+  // go<uint64_t>(v);
+
+  useShared = true;
+
+  std::cout << "using Shared memory" << std::endl;
+
+  go<int8_t>(useShared);
+  go<int16_t>(useShared);
+  go<int32_t>(useShared);
+  go<int32_t, 3>(useShared);
+  go<int64_t>(useShared);
+  go<float, 4, float, double>(useShared);
+  go<float, 2, float, double>(useShared);
+
+  go<uint8_t>(useShared);
+  go<uint16_t>(useShared);
+  go<uint32_t>(useShared);
+  // go<uint64_t>(v);
+
+  return 0;
+}

--- a/src/cuda/test/test_GPUSimpleVector.cu
+++ b/src/cuda/test/test_GPUSimpleVector.cu
@@ -1,0 +1,80 @@
+//  author: Felice Pantaleo, CERN, 2018
+#include <cassert>
+#include <iostream>
+#include <new>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include "CUDACore/GPUSimpleVector.h"
+#include "CUDACore/cudaCheck.h"
+
+__global__ void vector_pushback(GPU::SimpleVector<int> *foo) {
+  auto index = threadIdx.x + blockIdx.x * blockDim.x;
+  foo->push_back(index);
+}
+
+__global__ void vector_reset(GPU::SimpleVector<int> *foo) { foo->reset(); }
+
+__global__ void vector_emplace_back(GPU::SimpleVector<int> *foo) {
+  auto index = threadIdx.x + blockIdx.x * blockDim.x;
+  foo->emplace_back(index);
+}
+
+int main() {
+  auto maxN = 10000;
+  GPU::SimpleVector<int> *obj_ptr = nullptr;
+  GPU::SimpleVector<int> *d_obj_ptr = nullptr;
+  GPU::SimpleVector<int> *tmp_obj_ptr = nullptr;
+  int *data_ptr = nullptr;
+  int *d_data_ptr = nullptr;
+
+  cudaCheck(cudaMallocHost(&obj_ptr, sizeof(GPU::SimpleVector<int>)));
+  cudaCheck(cudaMallocHost(&data_ptr, maxN * sizeof(int)));
+  cudaCheck(cudaMalloc(&d_data_ptr, maxN * sizeof(int)));
+
+  auto v = GPU::make_SimpleVector(obj_ptr, maxN, data_ptr);
+
+  cudaCheck(cudaMallocHost(&tmp_obj_ptr, sizeof(GPU::SimpleVector<int>)));
+  GPU::make_SimpleVector(tmp_obj_ptr, maxN, d_data_ptr);
+  assert(tmp_obj_ptr->size() == 0);
+  assert(tmp_obj_ptr->capacity() == static_cast<int>(maxN));
+
+  cudaCheck(cudaMalloc(&d_obj_ptr, sizeof(GPU::SimpleVector<int>)));
+  // ... and copy the object to the device.
+  cudaCheck(cudaMemcpy(d_obj_ptr, tmp_obj_ptr, sizeof(GPU::SimpleVector<int>), cudaMemcpyDefault));
+
+  int numBlocks = 5;
+  int numThreadsPerBlock = 256;
+  vector_pushback<<<numBlocks, numThreadsPerBlock>>>(d_obj_ptr);
+  cudaCheck(cudaGetLastError());
+  cudaCheck(cudaDeviceSynchronize());
+
+  cudaCheck(cudaMemcpy(obj_ptr, d_obj_ptr, sizeof(GPU::SimpleVector<int>), cudaMemcpyDefault));
+
+  assert(obj_ptr->size() == (numBlocks * numThreadsPerBlock < maxN ? numBlocks * numThreadsPerBlock : maxN));
+  vector_reset<<<numBlocks, numThreadsPerBlock>>>(d_obj_ptr);
+  cudaCheck(cudaGetLastError());
+  cudaCheck(cudaDeviceSynchronize());
+
+  cudaCheck(cudaMemcpy(obj_ptr, d_obj_ptr, sizeof(GPU::SimpleVector<int>), cudaMemcpyDefault));
+
+  assert(obj_ptr->size() == 0);
+
+  vector_emplace_back<<<numBlocks, numThreadsPerBlock>>>(d_obj_ptr);
+  cudaCheck(cudaGetLastError());
+  cudaCheck(cudaDeviceSynchronize());
+
+  cudaCheck(cudaMemcpy(obj_ptr, d_obj_ptr, sizeof(GPU::SimpleVector<int>), cudaMemcpyDefault));
+
+  assert(obj_ptr->size() == (numBlocks * numThreadsPerBlock < maxN ? numBlocks * numThreadsPerBlock : maxN));
+
+  cudaCheck(cudaMemcpy(data_ptr, d_data_ptr, obj_ptr->size() * sizeof(int), cudaMemcpyDefault));
+  cudaCheck(cudaFreeHost(obj_ptr));
+  cudaCheck(cudaFreeHost(data_ptr));
+  cudaCheck(cudaFreeHost(tmp_obj_ptr));
+  cudaCheck(cudaFree(d_data_ptr));
+  cudaCheck(cudaFree(d_obj_ptr));
+  std::cout << "TEST PASSED" << std::endl;
+  return 0;
+}

--- a/src/cudatest/Makefile
+++ b/src/cudatest/Makefile
@@ -7,13 +7,17 @@ EXTERNAL_DEPENDS := $(cudatest_EXTERNAL_DEPENDS)
 $(TARGET):
 test_cpu:
 test_cuda: $(TARGET)
+	@echo
+	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2
+	@echo "Succeeded"
+.PHONY: test_cpu test_cuda
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
 EXE_DEP := $(EXE_OBJ:$.o=$.d)
 
-LIBNAMES := $(filter-out plugin-% bin Makefile% plugins.txt%,$(wildcard *))
+LIBNAMES := $(filter-out plugin-% bin test Makefile% plugins.txt%,$(wildcard *))
 PLUGINNAMES := $(patsubst plugin-%,%,$(filter plugin-%,$(wildcard *)))
 MY_CXXFLAGS := -I$(TARGET_DIR) -DSRC_DIR=$(TARGET_DIR) -DLIB_DIR=$(LIB_DIR)/$(TARGET_NAME)
 MY_LDFLAGS := -ldl -Wl,-rpath,$(LIB_DIR)/$(TARGET_NAME)
@@ -48,10 +52,34 @@ $(1)_CUDADLINK := $$(if $$(strip $$($(1)_CUOBJ)),$(OBJ_DIR)/$(TARGET_NAME)/plugi
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 
+# Files for unit tests
+TESTS_SRC := $(wildcard $(TARGET_DIR)/test/*.cc)
+TESTS_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_SRC:%=%.o))
+TESTS_DEP := $(TESTS_OBJ:$.o=$.d)
+TESTS_CUSRC := $(wildcard $(TARGET_DIR)/test/*.cu)
+TESTS_CUOBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_CUSRC:%=%.o))
+TESTS_CUDADLINK := $(TESTS_CUOBJ:$cu.o=$cudadlink.o)
+TESTS_CUDEP := $(TESTS_CUOBJ:$.o=$.d)
+TESTS_EXE_CPU := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%,$(TESTS_SRC))
+TESTS_EXE_CUDA :=  $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/%.cu,$(TEST_DIR)/$(TARGET_NAME)/%,$(TESTS_CUSRC))
+TESTS_EXE := $(TESTS_EXE_CPU) $(TESTS_EXE_CUDA)
+ALL_DEPENDS += $(TESTS_DEP) $(TESTS_CUDEP)
+
+define RUNTEST_template
+run_$(1): $(1)
+	@echo
+	@echo "Running test $(1)"
+	@$(1)
+	@echo "Succeeded"
+test_$(2): run_$(1)
+endef
+$(foreach test,$(TESTS_EXE_CPU),$(eval $(call RUNTEST_template,$(test),cpu)))
+$(foreach test,$(TESTS_EXE_CUDA),$(eval $(call RUNTEST_template,$(test),cuda)))
+
 -include $(ALL_DEPENDS)
 
 # Build targets
-$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS)
+$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS) | $(TESTS_EXE)
 	$(CXX) $(EXE_OBJ) $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
 
 define BUILD_template
@@ -87,3 +115,28 @@ $(OBJ_DIR)/$(TARGET_NAME)/bin/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/bin/%.cc
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
 	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.d.tmp >> $(@D)/$*.cc.d; \
 	  rm $(@D)/$*.cc.d.tmp
+
+# Tests
+$(OBJ_DIR)/$(TARGET_NAME)/test/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/test/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+	@cp $(@D)/$*.cc.d $(@D)/$*.cc.d.tmp; \
+	  sed 's#\($(TARGET_NAME)/$*\)\.o[ :]*#\1.o \1.d : #g' < $(@D)/$*.cc.d.tmp > $(@D)/$*.cc.d; \
+	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.d.tmp >> $(@D)/$*.cc.d; \
+	  rm $(@D)/$*.cc.d.tmp
+
+$(TEST_DIR)/$(TARGET_NAME)/%: $(OBJ_DIR)/$(TARGET_NAME)/test/%.cc.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $< $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
+
+$(OBJ_DIR)/$(TARGET_NAME)/test/%.cu.o: $(SRC_DIR)/$(TARGET_NAME)/test/%.cu
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CUDA_NVCC) $(CUDA_CUFLAGS) $(CUDA_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+
+$(OBJ_DIR)/$(TARGET_NAME)/test/%.cudadlink.o: $(OBJ_DIR)/$(TARGET_NAME)/test/%.cu.o
+	$(CUDA_NVCC) $(CUDA_DLINKFLAGS) $(CUDA_LDFLAGS) $< -o $@
+
+$(TEST_DIR)/$(TARGET_NAME)/%: $(OBJ_DIR)/$(TARGET_NAME)/test/%.cu.o $(OBJ_DIR)/$(TARGET_NAME)/test/%.cudadlink.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))

--- a/src/cudatest/test/hello.cc
+++ b/src/cudatest/test/hello.cc
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+  std::cout << "Hello" << std::endl;
+  return 0;
+}

--- a/src/cudatest/test/world.cu
+++ b/src/cudatest/test/world.cu
@@ -1,0 +1,14 @@
+#include <iostream>
+
+#include <cuda_runtime.h>
+
+#include "CUDACore/cudaCheck.h"
+
+__global__ void print() { printf("GPU thread %d\n", threadIdx.x); }
+
+int main() {
+  std::cout << "World from" << std::endl;
+  print<<<1, 4>>>();
+  cudaCheck(cudaDeviceSynchronize());
+  return 0;
+}

--- a/src/fwtest/Makefile
+++ b/src/fwtest/Makefile
@@ -6,14 +6,18 @@ EXTERNAL_DEPENDS := $(fwtest_EXTERNAL_DEPENDS)
 
 $(TARGET):
 test_cpu: $(TARGET)
+	@echo
+	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2
+	@echo "Succeeded"
 test_cuda:
+.PHONY: test_cpu test_cuda
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
 EXE_DEP := $(EXE_OBJ:$.o=$.d)
 
-LIBNAMES := $(filter-out plugin-% bin Makefile% plugins.txt%,$(wildcard *))
+LIBNAMES := $(filter-out plugin-% bin test Makefile% plugins.txt%,$(wildcard *))
 PLUGINNAMES := $(patsubst plugin-%,%,$(filter plugin-%,$(wildcard *)))
 MY_CXXFLAGS := -I$(TARGET_DIR) -DSRC_DIR=$(TARGET_DIR) -DLIB_DIR=$(LIB_DIR)/$(TARGET_NAME)
 MY_LDFLAGS := -ldl -Wl,-rpath,$(LIB_DIR)/$(TARGET_NAME)
@@ -45,10 +49,27 @@ PLUGINS += $$($(1)_LIB)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 
+# Files for unit tests
+TESTS_SRC := $(wildcard $(TARGET_DIR)/test/*.cc)
+TESTS_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_SRC:%=%.o))
+TESTS_DEP := $(TESTS_OBJ:$.o=$.d)
+TESTS_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%,$(TESTS_SRC))
+ALL_DEPENDS += $(TESTS_DEP)
+
+define RUNTEST_template
+run_$(1): $(1)
+	@echo
+	@echo "Running test $(1)"
+	@$(1)
+	@echo "Succeeded"
+test_cpu: run_$(1)
+endef
+$(foreach test,$(TESTS_EXE),$(eval $(call RUNTEST_template,$(test))))
+
 -include $(ALL_DEPENDS)
 
 # Build targets
-$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS)
+$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS) | $(TESTS_EXE)
 	$(CXX) $(EXE_OBJ) $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
 
 define BUILD_template
@@ -77,3 +98,17 @@ $(OBJ_DIR)/$(TARGET_NAME)/bin/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/bin/%.cc
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
 	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.d.tmp >> $(@D)/$*.cc.d; \
 	  rm $(@D)/$*.cc.d.tmp
+
+# Tests
+$(OBJ_DIR)/$(TARGET_NAME)/test/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/test/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+	@cp $(@D)/$*.cc.d $(@D)/$*.cc.d.tmp; \
+	  sed 's#\($(TARGET_NAME)/$*\)\.o[ :]*#\1.o \1.d : #g' < $(@D)/$*.cc.d.tmp > $(@D)/$*.cc.d; \
+	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.d.tmp >> $(@D)/$*.cc.d; \
+	  rm $(@D)/$*.cc.d.tmp
+
+$(TEST_DIR)/$(TARGET_NAME)/%: $(OBJ_DIR)/$(TARGET_NAME)/test/%.cc.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $< $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))

--- a/src/fwtest/test/hello.cc
+++ b/src/fwtest/test/hello.cc
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+  std::cout << "Hello" << std::endl;
+  return 0;
+}

--- a/src/fwtest/test/world.cc
+++ b/src/fwtest/test/world.cc
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+  std::cout << "World" << std::endl;
+  return 0;
+}

--- a/src/kokkos/Makefile
+++ b/src/kokkos/Makefile
@@ -117,7 +117,6 @@ $(OBJ_DIR)/$(2)/kokkos/%.cc.cuda.o: $(SRC_DIR)/$(2)/kokkos/%.cc
 	$(CUDA_NVCC) -x cu -DKOKKOS_BACKEND_CUDA $(KOKKOS_CUFLAGS) $(CUDA_CXXFLAGS) $(MY_CXXFLAGS) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_CXXFLAGS)) -c $$< -o $$@ -MMD
 
 $$($(1)_CUDADLINK): $$($(1)_CUOBJ)
-	@echo $$($(1)_CUOBJ)
 	$(CUDA_NVCC) $(CUDA_DLINKFLAGS) $(CUDA_LDFLAGS) $$($(1)_CUOBJ) -o $$@
 endef
 

--- a/src/kokkos/Makefile
+++ b/src/kokkos/Makefile
@@ -6,15 +6,22 @@ EXTERNAL_DEPENDS := $(kokkos_EXTERNAL_DEPENDS)
 
 $(TARGET):
 test_cpu: $(TARGET)
+	@echo
+	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --serial
+	@echo "Succeeded"
 test_cuda: $(TARGET)
+	@echo
+	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --cuda
+	@echo "Succeeded"
+.PHONY: test_cpu test_cuda
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
 EXE_DEP := $(EXE_OBJ:$.o=$.d)
 
-LIBNAMES := $(filter-out plugin-% bin Makefile% plugins.txt%,$(wildcard *))
+LIBNAMES := $(filter-out plugin-% bin test Makefile% plugins.txt%,$(wildcard *))
 PLUGINNAMES := $(patsubst plugin-%,%,$(filter plugin-%,$(wildcard *)))
 MY_CXXFLAGS := -I$(TARGET_DIR) -DSRC_DIR=$(TARGET_DIR) -DLIB_DIR=$(LIB_DIR)/$(TARGET_NAME)
 MY_LDFLAGS := -ldl -Wl,-rpath,$(LIB_DIR)/$(TARGET_NAME)
@@ -80,10 +87,37 @@ PLUGINS += $$($(1)_LIB)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 
+# Files for unit tests
+TESTS_PORTABLE_SRC := $(wildcard $(TARGET_DIR)/test/kokkos/*.cc)
+# serial backend
+TESTS_SERIAL_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.serial.o))
+TESTS_SERIAL_DEP := $(TESTS_SERIAL_OBJ:$.o=$.d)
+TESTS_SERIAL_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/kokkos/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.serial,$(TESTS_PORTABLE_SRC))
+# CUDA backend
+TESTS_CUDA_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.cuda.o))
+TESTS_CUDA_DEP := $(TESTS_CUDA_OBJ:$.o=$.d)
+TESTS_CUDA_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/kokkos/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.cuda,$(TESTS_PORTABLE_SRC))
+#
+TESTS_EXE := $(TESTS_SERIAL_EXE) $(TESTS_CUDA_EXE)
+TESTS_CUOBJ := $(TESTS_SERIAL_OBJ) $(TESTS_CUDA_OBJ)
+TESTS_CUDADLINK := $(TESTS_CUOBJ:$cu.o=$cudadlink.o)
+ALL_DEPENDS += $(TESTS_SERIAL_DEP) $(TESTS_CUDA_DEP)
+
+define RUNTEST_template
+run_$(1): $(1)
+	@echo
+	@echo "Running test $(1)"
+	@$(1)
+	@echo "Succeeded"
+test_$(2): run_$(1)
+endef
+$(foreach test,$(TESTS_SERIAL_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
+$(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),cuda)))
+
 -include $(ALL_DEPENDS)
 
 # Build targets
-$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS)
+$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS) | $(TESTS_EXE)
 	$(CXX) $(EXE_OBJ) $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
 
 define BUILD_template
@@ -131,3 +165,26 @@ $(OBJ_DIR)/$(TARGET_NAME)/bin/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/bin/%.cc
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
 	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.d.tmp >> $(@D)/$*.cc.d; \
 	  rm $(@D)/$*.cc.d.tmp
+
+# Tests, assume all are portable
+# device link rule can be shared
+$(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cudadlink.o: $(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.o
+	$(CUDA_NVCC) $(CUDA_DLINKFLAGS) $(CUDA_LDFLAGS) $< -o $@
+
+# Serial backend
+$(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.serial.o: $(SRC_DIR)/$(TARGET_NAME)/test/kokkos/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CUDA_NVCC) -x cu -DKOKKOS_BACKEND_SERIAL $(KOKKOS_CUFLAGS) $(CUDA_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+
+$(TEST_DIR)/$(TARGET_NAME)/%.serial: $(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.serial.o $(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.serial.cudadlink.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
+
+# CUDA backend
+$(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.cuda.o: $(SRC_DIR)/$(TARGET_NAME)/test/kokkos/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CUDA_NVCC) -x cu -DKOKKOS_BACKEND_CUDA $(KOKKOS_CUFLAGS) $(CUDA_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+
+$(TEST_DIR)/$(TARGET_NAME)/%.cuda: $(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.cuda.o $(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.cuda.cudadlink.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))

--- a/src/kokkos/test/kokkos/clustering.cc
+++ b/src/kokkos/test/kokkos/clustering.cc
@@ -1,0 +1,397 @@
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <set>
+#include <vector>
+
+#include "KokkosCore/kokkosConfigCommon.h"
+#include "KokkosCore/kokkosConfig.h"
+
+// dirty, but works
+#include "plugin-SiPixelClusterizer/kokkos/gpuClustering.h"
+#include "plugin-SiPixelClusterizer/kokkos/gpuClusterChargeCut.h"
+
+void test() {
+  using namespace gpuClustering;
+
+  int numElements = 256 * 2000;
+  // these in reality are already on GPU
+  Kokkos::View<uint16_t*, KokkosExecSpace>::HostMirror h_id("h_id", numElements);
+  Kokkos::View<uint16_t*, KokkosExecSpace>::HostMirror h_x("h_x", numElements);
+  Kokkos::View<uint16_t*, KokkosExecSpace>::HostMirror h_y("h_y", numElements);
+  Kokkos::View<uint16_t*, KokkosExecSpace>::HostMirror h_adc("h_adc", numElements);
+
+  Kokkos::View<int*, KokkosExecSpace>::HostMirror h_clus("h_clus", numElements);
+
+  Kokkos::View<uint16_t*, KokkosExecSpace> d_id("d_id", numElements);
+  Kokkos::View<uint16_t*, KokkosExecSpace> d_x("d_x", numElements);
+  Kokkos::View<uint16_t*, KokkosExecSpace> d_y("d_y", numElements);
+  Kokkos::View<uint16_t*, KokkosExecSpace> d_adc("d_adc", numElements);
+  Kokkos::View<int*, KokkosExecSpace> d_clus("d_clus", numElements);
+  Kokkos::View<uint32_t*, KokkosExecSpace> d_moduleStart("d_moduleStart", MaxNumModules + 1);
+  Kokkos::View<uint32_t*, KokkosExecSpace> d_clusInModule("d_clusInModule", MaxNumModules);
+  Kokkos::View<uint32_t*, KokkosExecSpace> d_moduleId("d_moduleId", MaxNumModules);
+
+  Kokkos::View<uint32_t*, KokkosExecSpace>::HostMirror h_moduleStart("h_moduleStart", MaxNumModules + 1);
+  Kokkos::View<uint32_t*, KokkosExecSpace>::HostMirror h_clusInModule("h_clusInModule", MaxNumModules);
+  Kokkos::View<uint32_t*, KokkosExecSpace>::HostMirror h_moduleId("h_moduleId", MaxNumModules);
+
+  // later random number
+  int n = 0;
+  int ncl = 0;
+  int y[10] = {5, 7, 9, 1, 3, 0, 4, 8, 2, 6};
+
+  auto generateClusters = [&](int kn) {
+    auto addBigNoise = 1 == kn % 2;
+    if (addBigNoise) {
+      constexpr int MaxPixels = 1000;
+      int id = 666;
+      for (int x = 0; x < 140; x += 3) {
+        for (int yy = 0; yy < 400; yy += 3) {
+          h_id[n] = id;
+          h_x[n] = x;
+          h_y[n] = yy;
+          h_adc[n] = 1000;
+          ++n;
+          ++ncl;
+          if (MaxPixels <= ncl)
+            break;
+        }
+        if (MaxPixels <= ncl)
+          break;
+      }
+    }
+
+    {
+      // isolated
+      int id = 42;
+      int x = 10;
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x;
+      h_y[n] = x;
+      h_adc[n] = kn == 0 ? 100 : 5000;
+      ++n;
+
+      // first column
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x;
+      h_y[n] = 0;
+      h_adc[n] = 5000;
+      ++n;
+      // first columns
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x + 80;
+      h_y[n] = 2;
+      h_adc[n] = 5000;
+      ++n;
+      h_id[n] = id;
+      h_x[n] = x + 80;
+      h_y[n] = 1;
+      h_adc[n] = 5000;
+      ++n;
+
+      // last column
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x;
+      h_y[n] = 415;
+      h_adc[n] = 5000;
+      ++n;
+      // last columns
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x + 80;
+      h_y[n] = 415;
+      h_adc[n] = 2500;
+      ++n;
+      h_id[n] = id;
+      h_x[n] = x + 80;
+      h_y[n] = 414;
+      h_adc[n] = 2500;
+      ++n;
+
+      // diagonal
+      ++ncl;
+      for (int x = 20; x < 25; ++x) {
+        h_id[n] = id;
+        h_x[n] = x;
+        h_y[n] = x;
+        h_adc[n] = 1000;
+        ++n;
+      }
+      ++ncl;
+      // reversed
+      for (int x = 45; x > 40; --x) {
+        h_id[n] = id;
+        h_x[n] = x;
+        h_y[n] = x;
+        h_adc[n] = 1000;
+        ++n;
+      }
+      ++ncl;
+      h_id[n++] = InvId;  // error
+      // messy
+      int xx[5] = {21, 25, 23, 24, 22};
+      for (int k = 0; k < 5; ++k) {
+        h_id[n] = id;
+        h_x[n] = xx[k];
+        h_y[n] = 20 + xx[k];
+        h_adc[n] = 1000;
+        ++n;
+      }
+      // holes
+      ++ncl;
+      for (int k = 0; k < 5; ++k) {
+        h_id[n] = id;
+        h_x[n] = xx[k];
+        h_y[n] = 100;
+        h_adc[n] = kn == 2 ? 100 : 1000;
+        ++n;
+        if (xx[k] % 2 == 0) {
+          h_id[n] = id;
+          h_x[n] = xx[k];
+          h_y[n] = 101;
+          h_adc[n] = 1000;
+          ++n;
+        }
+      }
+    }
+    {
+      // id == 0 (make sure it works!
+      int id = 0;
+      int x = 10;
+      ++ncl;
+      h_id[n] = id;
+      h_x[n] = x;
+      h_y[n] = x;
+      h_adc[n] = 5000;
+      ++n;
+    }
+    // all odd id
+    for (int id = 11; id <= 1800; id += 2) {
+      if ((id / 20) % 2)
+        h_id[n++] = InvId;  // error
+      for (int x = 0; x < 40; x += 4) {
+        ++ncl;
+        if ((id / 10) % 2) {
+          for (int k = 0; k < 10; ++k) {
+            h_id[n] = id;
+            h_x[n] = x;
+            h_y[n] = x + y[k];
+            h_adc[n] = 100;
+            ++n;
+            h_id[n] = id;
+            h_x[n] = x + 1;
+            h_y[n] = x + y[k] + 2;
+            h_adc[n] = 1000;
+            ++n;
+          }
+        } else {
+          for (int k = 0; k < 10; ++k) {
+            h_id[n] = id;
+            h_x[n] = x;
+            h_y[n] = x + y[9 - k];
+            h_adc[n] = kn == 2 ? 10 : 1000;
+            ++n;
+            if (y[k] == 3)
+              continue;  // hole
+            if (id == 51) {
+              h_id[n++] = InvId;
+              h_id[n++] = InvId;
+            }  // error
+            h_id[n] = id;
+            h_x[n] = x + 1;
+            h_y[n] = x + y[k] + 2;
+            h_adc[n] = kn == 2 ? 10 : 1000;
+            ++n;
+          }
+        }
+      }
+    }
+  };  // end lambda
+  for (auto kkk = 0; kkk < 5; ++kkk) {
+    n = 0;
+    ncl = 0;
+    generateClusters(kkk);
+
+    std::cout << "created " << n << " digis in " << ncl << " clusters" << std::endl;
+    assert(n <= numElements);
+
+    uint32_t nModules = 0;
+    size_t size32 = n * sizeof(unsigned int);
+    size_t size16 = n * sizeof(unsigned short);
+    // size_t size8 = n * sizeof(uint8_t);
+
+    Kokkos::deep_copy(d_moduleStart, 0);
+    Kokkos::deep_copy(d_id, h_id);
+    Kokkos::deep_copy(d_x, h_x);
+    Kokkos::deep_copy(d_y, h_y);
+    Kokkos::deep_copy(d_adc, h_adc);
+
+    // Launch Kokkos Kernels
+    std::cout << "Kokkos countModules kernel launch\n";
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<KokkosExecSpace>(0, n), KOKKOS_LAMBDA(const size_t i) {
+          KOKKOS_NAMESPACE::gpuClustering::countModules(d_id, d_moduleStart, d_clus, n, i);
+        });
+    KokkosExecSpace().fence();
+#ifdef TODO
+#ifdef __CUDACC__
+    int threadsPerBlock = (kkk == 5) ? 512 : ((kkk == 3) ? 128 : 256);
+    int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
+
+    blocksPerGrid = MaxNumModules;  //nModules;
+
+    std::cout << "CUDA findModules kernel launch with " << blocksPerGrid << " blocks of " << threadsPerBlock
+              << " threads\n";
+    cudaCheck(cudaMemset(d_clusInModule.get(), 0, MaxNumModules * sizeof(uint32_t)));
+
+    cms::cuda::launch(findClus,
+                      {blocksPerGrid, threadsPerBlock},
+                      d_id.get(),
+                      d_x.get(),
+                      d_y.get(),
+                      d_moduleStart.get(),
+                      d_clusInModule.get(),
+                      d_moduleId.get(),
+                      d_clus.get(),
+                      n);
+    cudaDeviceSynchronize();
+    cudaCheck(cudaMemcpy(&nModules, d_moduleStart.get(), sizeof(uint32_t), cudaMemcpyDeviceToHost));
+
+    uint32_t nclus[MaxNumModules], moduleId[nModules];
+    cudaCheck(cudaMemcpy(&nclus, d_clusInModule.get(), MaxNumModules * sizeof(uint32_t), cudaMemcpyDeviceToHost));
+
+    std::cout << "before charge cut found " << std::accumulate(nclus, nclus + MaxNumModules, 0) << " clusters"
+              << std::endl;
+    for (auto i = MaxNumModules; i > 0; i--)
+      if (nclus[i - 1] > 0) {
+        std::cout << "last module is " << i - 1 << ' ' << nclus[i - 1] << std::endl;
+        break;
+      }
+    if (ncl != std::accumulate(nclus, nclus + MaxNumModules, 0))
+      std::cout << "ERROR!!!!! wrong number of cluster found" << std::endl;
+
+    cms::cuda::launch(clusterChargeCut,
+                      {blocksPerGrid, threadsPerBlock},
+                      d_id.get(),
+                      d_adc.get(),
+                      d_moduleStart.get(),
+                      d_clusInModule.get(),
+                      d_moduleId.get(),
+                      d_clus.get(),
+                      n);
+
+    cudaDeviceSynchronize();
+#else
+    h_moduleStart[0] = nModules;
+    countModules(h_id.get(), h_moduleStart.get(), h_clus.get(), n);
+    memset(h_clusInModule.get(), 0, MaxNumModules * sizeof(uint32_t));
+    gridDim.x = MaxNumModules;  //not needed in the kernel for this specific case;
+    assert(blockIdx.x == 0);
+    for (; blockIdx.x < gridDim.x; ++blockIdx.x)
+      findClus(h_id.get(),
+               h_x.get(),
+               h_y.get(),
+               h_moduleStart.get(),
+               h_clusInModule.get(),
+               h_moduleId.get(),
+               h_clus.get(),
+               n);
+    resetGrid();
+
+    nModules = h_moduleStart[0];
+    auto nclus = h_clusInModule.get();
+
+    std::cout << "before charge cut found " << std::accumulate(nclus, nclus + MaxNumModules, 0) << " clusters"
+              << std::endl;
+    for (auto i = MaxNumModules; i > 0; i--)
+      if (nclus[i - 1] > 0) {
+        std::cout << "last module is " << i - 1 << ' ' << nclus[i - 1] << std::endl;
+        break;
+      }
+    if (ncl != std::accumulate(nclus, nclus + MaxNumModules, 0))
+      std::cout << "ERROR!!!!! wrong number of cluster found" << std::endl;
+
+    gridDim.x = MaxNumModules;  // no needed in the kernel for in this specific case
+    assert(blockIdx.x == 0);
+    for (; blockIdx.x < gridDim.x; ++blockIdx.x)
+      clusterChargeCut(
+          h_id.get(), h_adc.get(), h_moduleStart.get(), h_clusInModule.get(), h_moduleId.get(), h_clus.get(), n);
+    resetGrid();
+
+#endif
+
+    std::cout << "found " << nModules << " Modules active" << std::endl;
+
+#ifdef __CUDACC__
+    cudaCheck(cudaMemcpy(h_id.get(), d_id.get(), size16, cudaMemcpyDeviceToHost));
+    cudaCheck(cudaMemcpy(h_clus.get(), d_clus.get(), size32, cudaMemcpyDeviceToHost));
+    cudaCheck(cudaMemcpy(&nclus, d_clusInModule.get(), MaxNumModules * sizeof(uint32_t), cudaMemcpyDeviceToHost));
+    cudaCheck(cudaMemcpy(&moduleId, d_moduleId.get(), nModules * sizeof(uint32_t), cudaMemcpyDeviceToHost));
+#endif
+
+    std::set<unsigned int> clids;
+    for (int i = 0; i < n; ++i) {
+      assert(h_id[i] != 666);  // only noise
+      if (h_id[i] == InvId)
+        continue;
+      assert(h_clus[i] >= 0);
+      assert(h_clus[i] < int(nclus[h_id[i]]));
+      clids.insert(h_id[i] * 1000 + h_clus[i]);
+      // clids.insert(h_clus[i]);
+    }
+
+    // verify no hole in numbering
+    auto p = clids.begin();
+    auto cmid = (*p) / 1000;
+    assert(0 == (*p) % 1000);
+    auto c = p;
+    ++c;
+    std::cout << "first clusters " << *p << ' ' << *c << ' ' << nclus[cmid] << ' ' << nclus[(*c) / 1000] << std::endl;
+    std::cout << "last cluster " << *clids.rbegin() << ' ' << nclus[(*clids.rbegin()) / 1000] << std::endl;
+    for (; c != clids.end(); ++c) {
+      auto cc = *c;
+      auto pp = *p;
+      auto mid = cc / 1000;
+      auto pnc = pp % 1000;
+      auto nc = cc % 1000;
+      if (mid != cmid) {
+        assert(0 == cc % 1000);
+        assert(nclus[cmid] - 1 == pp % 1000);
+        // if (nclus[cmid]-1 != pp%1000) std::cout << "error size " << mid << ": "  << nclus[mid] << ' ' << pp << std::endl;
+        cmid = mid;
+        p = c;
+        continue;
+      }
+      p = c;
+      // assert(nc==pnc+1);
+      if (nc != pnc + 1)
+        std::cout << "error " << mid << ": " << nc << ' ' << pnc << std::endl;
+    }
+
+    std::cout << "found " << std::accumulate(nclus, nclus + MaxNumModules, 0) << ' ' << clids.size() << " clusters"
+              << std::endl;
+    for (auto i = MaxNumModules; i > 0; i--)
+      if (nclus[i - 1] > 0) {
+        std::cout << "last module is " << i - 1 << ' ' << nclus[i - 1] << std::endl;
+        break;
+      }
+      // << " and " << seeds.size() << " seeds" << std::endl;
+#endif  // TODO
+  }     /// end loop kkk
+}
+
+int main(void) {
+  kokkos_common::InitializeScopeGuard kokkosGuard;
+  test();
+  return 0;
+}

--- a/src/kokkostest/Makefile
+++ b/src/kokkostest/Makefile
@@ -6,15 +6,22 @@ EXTERNAL_DEPENDS := $(kokkostest_EXTERNAL_DEPENDS)
 
 $(TARGET):
 test_cpu: $(TARGET)
-	$(TARGET) --maxEvents 1 --serial
+	@echo
+	@echo "Testing $(TARGET)"
+	$(TARGET) --maxEvents 2 --serial
+	@echo "Succeeded"
 test_cuda: $(TARGET)
+	@echo
+	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --cuda
+	@echo "Succeeded"
+.PHONY: test_cpu test_cuda
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
 EXE_DEP := $(EXE_OBJ:$.o=$.d)
 
-LIBNAMES := $(filter-out plugin-% bin Makefile% plugins.txt%,$(wildcard *))
+LIBNAMES := $(filter-out plugin-% bin test Makefile% plugins.txt%,$(wildcard *))
 PLUGINNAMES := $(patsubst plugin-%,%,$(filter plugin-%,$(wildcard *)))
 MY_CXXFLAGS := -I$(TARGET_DIR) -DSRC_DIR=$(TARGET_DIR) -DLIB_DIR=$(LIB_DIR)/$(TARGET_NAME)
 MY_LDFLAGS := -ldl -Wl,-rpath,$(LIB_DIR)/$(TARGET_NAME)
@@ -80,10 +87,37 @@ PLUGINS += $$($(1)_LIB)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 
+# Files for unit tests
+TESTS_PORTABLE_SRC := $(wildcard $(TARGET_DIR)/test/kokkos/*.cc)
+# serial backend
+TESTS_SERIAL_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.serial.o))
+TESTS_SERIAL_DEP := $(TESTS_SERIAL_OBJ:$.o=$.d)
+TESTS_SERIAL_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/kokkos/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.serial,$(TESTS_PORTABLE_SRC))
+# CUDA backend
+TESTS_CUDA_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.cuda.o))
+TESTS_CUDA_DEP := $(TESTS_CUDA_OBJ:$.o=$.d)
+TESTS_CUDA_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/kokkos/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.cuda,$(TESTS_PORTABLE_SRC))
+#
+TESTS_EXE := $(TESTS_SERIAL_EXE) $(TESTS_CUDA_EXE)
+TESTS_CUOBJ := $(TESTS_SERIAL_OBJ) $(TESTS_CUDA_OBJ)
+TESTS_CUDADLINK := $(TESTS_CUOBJ:$cu.o=$cudadlink.o)
+ALL_DEPENDS += $(TESTS_SERIAL_DEP) $(TESTS_CUDA_DEP)
+
+define RUNTEST_template
+run_$(1): $(1)
+	@echo
+	@echo "Running test $(1)"
+	@$(1)
+	@echo "Succeeded"
+test_$(2): run_$(1)
+endef
+$(foreach test,$(TESTS_SERIAL_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
+$(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),cuda)))
+
 -include $(ALL_DEPENDS)
 
 # Build targets
-$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS)
+$(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS) | $(TESTS_EXE)
 	$(CXX) $(EXE_OBJ) $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
 
 define BUILD_template
@@ -132,3 +166,26 @@ $(OBJ_DIR)/$(TARGET_NAME)/bin/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/bin/%.cc
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
 	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.d.tmp >> $(@D)/$*.cc.d; \
 	  rm $(@D)/$*.cc.d.tmp
+
+# Tests, assume all are portable
+# device link rule can be shared
+$(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cudadlink.o: $(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.o
+	$(CUDA_NVCC) $(CUDA_DLINKFLAGS) $(CUDA_LDFLAGS) $< -o $@
+
+# Serial backend
+$(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.serial.o: $(SRC_DIR)/$(TARGET_NAME)/test/kokkos/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CUDA_NVCC) -x cu -DKOKKOS_BACKEND_SERIAL $(KOKKOS_CUFLAGS) $(CUDA_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+
+$(TEST_DIR)/$(TARGET_NAME)/%.serial: $(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.serial.o $(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.serial.cudadlink.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
+
+# CUDA backend
+$(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.cuda.o: $(SRC_DIR)/$(TARGET_NAME)/test/kokkos/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CUDA_NVCC) -x cu -DKOKKOS_BACKEND_CUDA $(KOKKOS_CUFLAGS) $(CUDA_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+
+$(TEST_DIR)/$(TARGET_NAME)/%.cuda: $(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.cuda.o $(OBJ_DIR)/$(TARGET_NAME)/test/kokkos/%.cc.cuda.cudadlink.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(patsubst %,-l%,$(LIBNAMES)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))

--- a/src/kokkostest/Makefile
+++ b/src/kokkostest/Makefile
@@ -46,7 +46,7 @@ $(1)_SERIAL_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.
 $(1)_SERIAL_DEP := $$($(1)_SERIAL_OBJ:$.o=$.d)
 # CUDA backend
 $(1)_CUDA_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.cuda.o))
-$(1)_CUDA_DEP := $$($(1)_CUD_AOBJ:$.o=$.d)
+$(1)_CUDA_DEP := $$($(1)_CUDA_OBJ:$.o=$.d)
 # this means all built kokkos objects...
 $(1)_CUOBJ := $$($(1)_HOST_OBJ) $$($(1)_SERIAL_OBJ) $$($(1)_CUDA_OBJ)
 $(1)_CUDADLINK := $$(if $$(strip $$($(1)_CUOBJ)),$(OBJ_DIR)/$(TARGET_NAME)/$(1)/lib$(1)_cudalink.o)
@@ -151,7 +151,6 @@ $(OBJ_DIR)/$(2)/kokkos/%.cc.cuda.o: $(SRC_DIR)/$(2)/kokkos/%.cc
 	$(CUDA_NVCC) -x cu -DKOKKOS_BACKEND_CUDA $(KOKKOS_CUFLAGS) $(CUDA_CXXFLAGS) $(MY_CXXFLAGS) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_CXXFLAGS)) -c $$< -o $$@ -MMD
 
 $$($(1)_CUDADLINK): $$($(1)_CUOBJ)
-	@echo $$($(1)_CUOBJ)
 	$(CUDA_NVCC) $(CUDA_DLINKFLAGS) $(CUDA_LDFLAGS) $$($(1)_CUOBJ) -o $$@
 endef
 

--- a/src/kokkostest/test/kokkos/hello.cc
+++ b/src/kokkostest/test/kokkos/hello.cc
@@ -1,0 +1,14 @@
+#include <iostream>
+
+#include "KokkosCore/kokkosConfig.h"
+
+int main() {
+  std::cout << "Hello from "
+#ifdef KOKKOS_BACKEND_SERIAL
+            << "CPU serial"
+#elif defined KOKKOS_BACKEND_CUDA
+            << "CUDA"
+#endif
+            << " backend" << std::endl;
+  return 0;
+}

--- a/src/kokkostest/test/kokkos/world.cc
+++ b/src/kokkostest/test/kokkos/world.cc
@@ -1,0 +1,14 @@
+#include <iostream>
+
+#include "KokkosCore/kokkosConfigCommon.h"
+#include "KokkosCore/kokkosConfig.h"
+
+int main() {
+  kokkos_common::InitializeScopeGuard kokkosGuard;
+  std::cout << "World" << std::endl;
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<KokkosExecSpace>(0, 4),
+      KOKKOS_LAMBDA(const size_t i) { printf("Kokkos::parallel_for loop element %lu\n", i); });
+  return 0;
+}


### PR DESCRIPTION
This PR adds support for unit tests for all programs (except `alpaka`, which is not yet integrated in the common build system), and some unit tests (dummy for all `*test` programs to exercise the build rules, some real ones for `cuda` and `kokkos`).

The unit tests are built while building the corresponding program (technically each program executable is set to depend on the unit test executables). Running these unit test programs is included in the `make test` target, and also properly in the `test_cpu` and `test_cuda` targets.

Resolves #35.