### PR TITLE
Add support for EDProducer::endJob()

### DIFF
--- a/src/alpaka/Framework/EDProducer.h
+++ b/src/alpaka/Framework/EDProducer.h
@@ -20,6 +20,10 @@ namespace edm {
 
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
 
+    void doEndJob() { endJob(); }
+
+    virtual void endJob() {}
+
   private:
   };
 
@@ -38,6 +42,9 @@ namespace edm {
 
     virtual void acquire(Event const& event, EventSetup const& eventSetup, WaitingTaskWithArenaHolder holder) = 0;
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
+
+    void doEndJob() { endJob(); }
+    virtual void endJob() {}
 
   private:
   };

--- a/src/alpaka/Framework/Worker.h
+++ b/src/alpaka/Framework/Worker.h
@@ -30,6 +30,9 @@ namespace edm {
     virtual void doWorkAsync(Event& event, EventSetup const& eventSetup, WaitingTask* iTask) = 0;
 
     // not thread safe
+    virtual void doEndJob() = 0;
+
+    // not thread safe
     void reset() {
       prefetchRequested_ = false;
       doReset();
@@ -93,6 +96,8 @@ namespace edm {
         prefetchAsync(event, eventSetup, moduleTask);
       }
     }
+
+    void doEndJob() override { producer_.doEndJob(); }
 
   private:
     void doReset() override {

--- a/src/alpaka/bin/EventProcessor.cc
+++ b/src/alpaka/bin/EventProcessor.cc
@@ -37,4 +37,9 @@ namespace edm {
       std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
     }
   }
+
+  void EventProcessor::endJob() {
+    // Only on the first stream...
+    schedules_[0].endJob();
+  }
 }  // namespace edm

--- a/src/alpaka/bin/EventProcessor.h
+++ b/src/alpaka/bin/EventProcessor.h
@@ -25,6 +25,8 @@ namespace edm {
 
     void runToCompletion();
 
+    void endJob();
+
   private:
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;

--- a/src/alpaka/bin/StreamSchedule.cc
+++ b/src/alpaka/bin/StreamSchedule.cc
@@ -85,4 +85,10 @@ namespace edm {
       h.doneWaiting(std::exception_ptr{});
     }
   }
+
+  void StreamSchedule::endJob() {
+    for (auto& w : path_) {
+      w->doEndJob();
+    }
+  }
 }  // namespace edm

--- a/src/alpaka/bin/StreamSchedule.h
+++ b/src/alpaka/bin/StreamSchedule.h
@@ -35,6 +35,8 @@ namespace edm {
 
     void runToCompletionAsync(WaitingTaskHolder h);
 
+    void endJob();
+
   private:
     void processOneEventAsync(WaitingTaskHolder h);
 

--- a/src/alpaka/bin/main.cc
+++ b/src/alpaka/bin/main.cc
@@ -143,6 +143,22 @@ int main(int argc, char** argv) {
   }
   auto stop = std::chrono::high_resolution_clock::now();
 
+  // Run endJob
+  try {
+    processor.endJob();
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;

--- a/src/alpakatest/Framework/EDProducer.h
+++ b/src/alpakatest/Framework/EDProducer.h
@@ -20,6 +20,10 @@ namespace edm {
 
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
 
+    void doEndJob() { endJob(); }
+
+    virtual void endJob() {}
+
   private:
   };
 
@@ -38,6 +42,9 @@ namespace edm {
 
     virtual void acquire(Event const& event, EventSetup const& eventSetup, WaitingTaskWithArenaHolder holder) = 0;
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
+
+    void doEndJob() { endJob(); }
+    virtual void endJob() {}
 
   private:
   };

--- a/src/alpakatest/Framework/Worker.h
+++ b/src/alpakatest/Framework/Worker.h
@@ -30,6 +30,9 @@ namespace edm {
     virtual void doWorkAsync(Event& event, EventSetup const& eventSetup, WaitingTask* iTask) = 0;
 
     // not thread safe
+    virtual void doEndJob() = 0;
+
+    // not thread safe
     void reset() {
       prefetchRequested_ = false;
       doReset();
@@ -93,6 +96,8 @@ namespace edm {
         prefetchAsync(event, eventSetup, moduleTask);
       }
     }
+
+    void doEndJob() override { producer_.doEndJob(); }
 
   private:
     void doReset() override {

--- a/src/alpakatest/bin/EventProcessor.cc
+++ b/src/alpakatest/bin/EventProcessor.cc
@@ -37,4 +37,9 @@ namespace edm {
       std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
     }
   }
+
+  void EventProcessor::endJob() {
+    // Only on the first stream...
+    schedules_[0].endJob();
+  }
 }  // namespace edm

--- a/src/alpakatest/bin/EventProcessor.h
+++ b/src/alpakatest/bin/EventProcessor.h
@@ -25,6 +25,8 @@ namespace edm {
 
     void runToCompletion();
 
+    void endJob();
+
   private:
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;

--- a/src/alpakatest/bin/StreamSchedule.cc
+++ b/src/alpakatest/bin/StreamSchedule.cc
@@ -85,4 +85,10 @@ namespace edm {
       h.doneWaiting(std::exception_ptr{});
     }
   }
+
+  void StreamSchedule::endJob() {
+    for (auto& w : path_) {
+      w->doEndJob();
+    }
+  }
 }  // namespace edm

--- a/src/alpakatest/bin/StreamSchedule.h
+++ b/src/alpakatest/bin/StreamSchedule.h
@@ -35,6 +35,8 @@ namespace edm {
 
     void runToCompletionAsync(WaitingTaskHolder h);
 
+    void endJob();
+
   private:
     void processOneEventAsync(WaitingTaskHolder h);
 

--- a/src/alpakatest/bin/main.cc
+++ b/src/alpakatest/bin/main.cc
@@ -147,6 +147,22 @@ int main(int argc, char** argv) {
   }
   auto stop = std::chrono::high_resolution_clock::now();
 
+  // Run endJob
+  try {
+    processor.endJob();
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;

--- a/src/alpakatest/plugin-Test2/alpaka/TestProducer2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/TestProducer2.cc
@@ -10,6 +10,10 @@
 
 #include "alpakaAlgo2.h"
 
+namespace {
+  std::atomic<int> nevents;
+}
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestProducer2 : public edm::EDProducerExternalWork {
   public:
@@ -20,6 +24,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                  edm::EventSetup const& eventSetup,
                  edm::WaitingTaskWithArenaHolder holder) override;
     void produce(edm::Event& event, edm::EventSetup const& eventSetup) override;
+    void endJob() override;
 
 #ifdef TODO
     edm::EDGetTokenT<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>> getToken_;
@@ -31,6 +36,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       : getToken_(reg.consumes<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>>())
 #endif
   {
+    nevents = 0;
   }
 
   void TestProducer2::acquire(edm::Event const& event,
@@ -54,6 +60,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   void TestProducer2::produce(edm::Event& event, edm::EventSetup const& eventSetup) {
     std::cout << "TestProducer2::produce Event " << event.eventID() << " stream " << event.streamID() << std::endl;
+    ++nevents;
+  }
+
+  void TestProducer2::endJob() {
+    std::cout << "TestProducer2::endJob processed " << nevents.load() << " events" << std::endl;
   }
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 

--- a/src/cuda/Framework/EDProducer.h
+++ b/src/cuda/Framework/EDProducer.h
@@ -20,6 +20,10 @@ namespace edm {
 
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
 
+    void doEndJob() { endJob(); }
+
+    virtual void endJob() {}
+
   private:
   };
 
@@ -38,6 +42,9 @@ namespace edm {
 
     virtual void acquire(Event const& event, EventSetup const& eventSetup, WaitingTaskWithArenaHolder holder) = 0;
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
+
+    void doEndJob() { endJob(); }
+    virtual void endJob() {}
 
   private:
   };

--- a/src/cuda/Framework/Worker.h
+++ b/src/cuda/Framework/Worker.h
@@ -29,6 +29,9 @@ namespace edm {
     virtual void doWorkAsync(Event& event, EventSetup const& eventSetup, WaitingTask* iTask) = 0;
 
     // not thread safe
+    virtual void doEndJob() = 0;
+
+    // not thread safe
     void reset() {
       prefetchRequested_ = false;
       doReset();
@@ -92,6 +95,8 @@ namespace edm {
         prefetchAsync(event, eventSetup, moduleTask);
       }
     }
+
+    void doEndJob() override { producer_.doEndJob(); }
 
   private:
     void doReset() override {

--- a/src/cuda/bin/EventProcessor.cc
+++ b/src/cuda/bin/EventProcessor.cc
@@ -37,4 +37,9 @@ namespace edm {
       std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
     }
   }
+
+  void EventProcessor::endJob() {
+    // Only on the first stream...
+    schedules_[0].endJob();
+  }
 }  // namespace edm

--- a/src/cuda/bin/EventProcessor.h
+++ b/src/cuda/bin/EventProcessor.h
@@ -25,6 +25,8 @@ namespace edm {
 
     void runToCompletion();
 
+    void endJob();
+
   private:
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;

--- a/src/cuda/bin/StreamSchedule.cc
+++ b/src/cuda/bin/StreamSchedule.cc
@@ -85,4 +85,10 @@ namespace edm {
       h.doneWaiting(std::exception_ptr{});
     }
   }
+
+  void StreamSchedule::endJob() {
+    for (auto& w : path_) {
+      w->doEndJob();
+    }
+  }
 }  // namespace edm

--- a/src/cuda/bin/StreamSchedule.h
+++ b/src/cuda/bin/StreamSchedule.h
@@ -35,6 +35,8 @@ namespace edm {
 
     void runToCompletionAsync(WaitingTaskHolder h);
 
+    void endJob();
+
   private:
     void processOneEventAsync(WaitingTaskHolder h);
 

--- a/src/cuda/bin/main.cc
+++ b/src/cuda/bin/main.cc
@@ -138,6 +138,22 @@ int main(int argc, char** argv) {
   }
   auto stop = std::chrono::high_resolution_clock::now();
 
+  // Run endJob
+  try {
+    processor.endJob();
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;

--- a/src/cudadev/Framework/EDProducer.h
+++ b/src/cudadev/Framework/EDProducer.h
@@ -20,6 +20,10 @@ namespace edm {
 
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
 
+    void doEndJob() { endJob(); }
+
+    virtual void endJob() {}
+
   private:
   };
 
@@ -38,6 +42,9 @@ namespace edm {
 
     virtual void acquire(Event const& event, EventSetup const& eventSetup, WaitingTaskWithArenaHolder holder) = 0;
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
+
+    void doEndJob() { endJob(); }
+    virtual void endJob() {}
 
   private:
   };

--- a/src/cudadev/Framework/Worker.h
+++ b/src/cudadev/Framework/Worker.h
@@ -29,6 +29,9 @@ namespace edm {
     virtual void doWorkAsync(Event& event, EventSetup const& eventSetup, WaitingTask* iTask) = 0;
 
     // not thread safe
+    virtual void doEndJob() = 0;
+
+    // not thread safe
     void reset() {
       prefetchRequested_ = false;
       doReset();
@@ -92,6 +95,8 @@ namespace edm {
         prefetchAsync(event, eventSetup, moduleTask);
       }
     }
+
+    void doEndJob() override { producer_.doEndJob(); }
 
   private:
     void doReset() override {

--- a/src/cudadev/bin/EventProcessor.cc
+++ b/src/cudadev/bin/EventProcessor.cc
@@ -37,4 +37,9 @@ namespace edm {
       std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
     }
   }
+
+  void EventProcessor::endJob() {
+    // Only on the first stream...
+    schedules_[0].endJob();
+  }
 }  // namespace edm

--- a/src/cudadev/bin/EventProcessor.h
+++ b/src/cudadev/bin/EventProcessor.h
@@ -25,6 +25,8 @@ namespace edm {
 
     void runToCompletion();
 
+    void endJob();
+
   private:
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;

--- a/src/cudadev/bin/StreamSchedule.cc
+++ b/src/cudadev/bin/StreamSchedule.cc
@@ -85,4 +85,10 @@ namespace edm {
       h.doneWaiting(std::exception_ptr{});
     }
   }
+
+  void StreamSchedule::endJob() {
+    for (auto& w : path_) {
+      w->doEndJob();
+    }
+  }
 }  // namespace edm

--- a/src/cudadev/bin/StreamSchedule.h
+++ b/src/cudadev/bin/StreamSchedule.h
@@ -35,6 +35,8 @@ namespace edm {
 
     void runToCompletionAsync(WaitingTaskHolder h);
 
+    void endJob();
+
   private:
     void processOneEventAsync(WaitingTaskHolder h);
 

--- a/src/cudadev/bin/main.cc
+++ b/src/cudadev/bin/main.cc
@@ -138,6 +138,22 @@ int main(int argc, char** argv) {
   }
   auto stop = std::chrono::high_resolution_clock::now();
 
+  // Run endJob
+  try {
+    processor.endJob();
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;

--- a/src/cudatest/Framework/EDProducer.h
+++ b/src/cudatest/Framework/EDProducer.h
@@ -20,6 +20,10 @@ namespace edm {
 
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
 
+    void doEndJob() { endJob(); }
+
+    virtual void endJob() {}
+
   private:
   };
 
@@ -38,6 +42,9 @@ namespace edm {
 
     virtual void acquire(Event const& event, EventSetup const& eventSetup, WaitingTaskWithArenaHolder holder) = 0;
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
+
+    void doEndJob() { endJob(); }
+    virtual void endJob() {}
 
   private:
   };

--- a/src/cudatest/Framework/Worker.h
+++ b/src/cudatest/Framework/Worker.h
@@ -29,6 +29,9 @@ namespace edm {
     virtual void doWorkAsync(Event& event, EventSetup const& eventSetup, WaitingTask* iTask) = 0;
 
     // not thread safe
+    virtual void doEndJob() = 0;
+
+    // not thread safe
     void reset() {
       prefetchRequested_ = false;
       doReset();
@@ -92,6 +95,8 @@ namespace edm {
         prefetchAsync(event, eventSetup, moduleTask);
       }
     }
+
+    void doEndJob() override { producer_.doEndJob(); }
 
   private:
     void doReset() override {

--- a/src/cudatest/bin/EventProcessor.cc
+++ b/src/cudatest/bin/EventProcessor.cc
@@ -37,4 +37,9 @@ namespace edm {
       std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
     }
   }
+
+  void EventProcessor::endJob() {
+    // Only on the first stream...
+    schedules_[0].endJob();
+  }
 }  // namespace edm

--- a/src/cudatest/bin/EventProcessor.h
+++ b/src/cudatest/bin/EventProcessor.h
@@ -25,6 +25,8 @@ namespace edm {
 
     void runToCompletion();
 
+    void endJob();
+
   private:
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;

--- a/src/cudatest/bin/StreamSchedule.cc
+++ b/src/cudatest/bin/StreamSchedule.cc
@@ -85,4 +85,10 @@ namespace edm {
       h.doneWaiting(std::exception_ptr{});
     }
   }
+
+  void StreamSchedule::endJob() {
+    for (auto& w : path_) {
+      w->doEndJob();
+    }
+  }
 }  // namespace edm

--- a/src/cudatest/bin/StreamSchedule.h
+++ b/src/cudatest/bin/StreamSchedule.h
@@ -35,6 +35,8 @@ namespace edm {
 
     void runToCompletionAsync(WaitingTaskHolder h);
 
+    void endJob();
+
   private:
     void processOneEventAsync(WaitingTaskHolder h);
 

--- a/src/cudatest/bin/main.cc
+++ b/src/cudatest/bin/main.cc
@@ -125,6 +125,22 @@ int main(int argc, char** argv) {
   }
   auto stop = std::chrono::high_resolution_clock::now();
 
+  // Run endJob
+  try {
+    processor.endJob();
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;

--- a/src/cudatest/plugin-Test2/TestProducer2.cc
+++ b/src/cudatest/plugin-Test2/TestProducer2.cc
@@ -11,6 +11,10 @@
 
 #include "gpuAlgo2.h"
 
+namespace {
+  std::atomic<int> nevents = 0;
+}
+
 class TestProducer2 : public edm::EDProducerExternalWork {
 public:
   explicit TestProducer2(edm::ProductRegistry& reg);
@@ -20,6 +24,7 @@ private:
                edm::EventSetup const& eventSetup,
                edm::WaitingTaskWithArenaHolder holder) override;
   void produce(edm::Event& event, edm::EventSetup const& eventSetup) override;
+  void endJob() override;
 
   edm::EDGetTokenT<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>> getToken_;
 };
@@ -43,6 +48,11 @@ void TestProducer2::acquire(edm::Event const& event,
 
 void TestProducer2::produce(edm::Event& event, edm::EventSetup const& eventSetup) {
   std::cout << "TestProducer2::produce Event " << event.eventID() << " stream " << event.streamID() << std::endl;
+  ++nevents;
+}
+
+void TestProducer2::endJob() {
+  std::cout << "TestProducer2::endJob processed " << nevents.load() << " events" << std::endl;
 }
 
 DEFINE_FWK_MODULE(TestProducer2);

--- a/src/cudauvm/Framework/EDProducer.h
+++ b/src/cudauvm/Framework/EDProducer.h
@@ -20,6 +20,10 @@ namespace edm {
 
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
 
+    void doEndJob() { endJob(); }
+
+    virtual void endJob() {}
+
   private:
   };
 
@@ -38,6 +42,9 @@ namespace edm {
 
     virtual void acquire(Event const& event, EventSetup const& eventSetup, WaitingTaskWithArenaHolder holder) = 0;
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
+
+    void doEndJob() { endJob(); }
+    virtual void endJob() {}
 
   private:
   };

--- a/src/cudauvm/Framework/Worker.h
+++ b/src/cudauvm/Framework/Worker.h
@@ -29,6 +29,9 @@ namespace edm {
     virtual void doWorkAsync(Event& event, EventSetup const& eventSetup, WaitingTask* iTask) = 0;
 
     // not thread safe
+    virtual void doEndJob() = 0;
+
+    // not thread safe
     void reset() {
       prefetchRequested_ = false;
       doReset();
@@ -92,6 +95,8 @@ namespace edm {
         prefetchAsync(event, eventSetup, moduleTask);
       }
     }
+
+    void doEndJob() override { producer_.doEndJob(); }
 
   private:
     void doReset() override {

--- a/src/cudauvm/bin/EventProcessor.cc
+++ b/src/cudauvm/bin/EventProcessor.cc
@@ -37,4 +37,9 @@ namespace edm {
       std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
     }
   }
+
+  void EventProcessor::endJob() {
+    // Only on the first stream...
+    schedules_[0].endJob();
+  }
 }  // namespace edm

--- a/src/cudauvm/bin/EventProcessor.h
+++ b/src/cudauvm/bin/EventProcessor.h
@@ -25,6 +25,8 @@ namespace edm {
 
     void runToCompletion();
 
+    void endJob();
+
   private:
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;

--- a/src/cudauvm/bin/StreamSchedule.cc
+++ b/src/cudauvm/bin/StreamSchedule.cc
@@ -85,4 +85,10 @@ namespace edm {
       h.doneWaiting(std::exception_ptr{});
     }
   }
+
+  void StreamSchedule::endJob() {
+    for (auto& w : path_) {
+      w->doEndJob();
+    }
+  }
 }  // namespace edm

--- a/src/cudauvm/bin/StreamSchedule.h
+++ b/src/cudauvm/bin/StreamSchedule.h
@@ -35,6 +35,8 @@ namespace edm {
 
     void runToCompletionAsync(WaitingTaskHolder h);
 
+    void endJob();
+
   private:
     void processOneEventAsync(WaitingTaskHolder h);
 

--- a/src/cudauvm/bin/main.cc
+++ b/src/cudauvm/bin/main.cc
@@ -138,6 +138,22 @@ int main(int argc, char** argv) {
   }
   auto stop = std::chrono::high_resolution_clock::now();
 
+  // Run endJob
+  try {
+    processor.endJob();
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;

--- a/src/fwtest/Framework/EDProducer.h
+++ b/src/fwtest/Framework/EDProducer.h
@@ -20,6 +20,10 @@ namespace edm {
 
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
 
+    void doEndJob() { endJob(); }
+
+    virtual void endJob() {}
+
   private:
   };
 
@@ -38,6 +42,9 @@ namespace edm {
 
     virtual void acquire(Event const& event, EventSetup const& eventSetup, WaitingTaskWithArenaHolder holder) = 0;
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
+
+    void doEndJob() { endJob(); }
+    virtual void endJob() {}
 
   private:
   };

--- a/src/fwtest/Framework/Worker.h
+++ b/src/fwtest/Framework/Worker.h
@@ -29,6 +29,9 @@ namespace edm {
     virtual void doWorkAsync(Event& event, EventSetup const& eventSetup, WaitingTask* iTask) = 0;
 
     // not thread safe
+    virtual void doEndJob() = 0;
+
+    // not thread safe
     void reset() {
       prefetchRequested_ = false;
       doReset();
@@ -92,6 +95,8 @@ namespace edm {
         prefetchAsync(event, eventSetup, moduleTask);
       }
     }
+
+    void doEndJob() override { producer_.doEndJob(); }
 
   private:
     void doReset() override {

--- a/src/fwtest/bin/EventProcessor.cc
+++ b/src/fwtest/bin/EventProcessor.cc
@@ -37,4 +37,9 @@ namespace edm {
       std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
     }
   }
+
+  void EventProcessor::endJob() {
+    // Only on the first stream...
+    schedules_[0].endJob();
+  }
 }  // namespace edm

--- a/src/fwtest/bin/EventProcessor.h
+++ b/src/fwtest/bin/EventProcessor.h
@@ -25,6 +25,8 @@ namespace edm {
 
     void runToCompletion();
 
+    void endJob();
+
   private:
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;

--- a/src/fwtest/bin/StreamSchedule.cc
+++ b/src/fwtest/bin/StreamSchedule.cc
@@ -85,4 +85,10 @@ namespace edm {
       h.doneWaiting(std::exception_ptr{});
     }
   }
+
+  void StreamSchedule::endJob() {
+    for (auto& w : path_) {
+      w->doEndJob();
+    }
+  }
 }  // namespace edm

--- a/src/fwtest/bin/StreamSchedule.h
+++ b/src/fwtest/bin/StreamSchedule.h
@@ -35,6 +35,8 @@ namespace edm {
 
     void runToCompletionAsync(WaitingTaskHolder h);
 
+    void endJob();
+
   private:
     void processOneEventAsync(WaitingTaskHolder h);
 

--- a/src/fwtest/bin/main.cc
+++ b/src/fwtest/bin/main.cc
@@ -116,6 +116,22 @@ int main(int argc, char** argv) {
   }
   auto stop = std::chrono::high_resolution_clock::now();
 
+  // Run endJob
+  try {
+    processor.endJob();
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;

--- a/src/fwtest/plugin-Test2/TestProducer2.cc
+++ b/src/fwtest/plugin-Test2/TestProducer2.cc
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <cassert>
 #include <future>
 #include <iostream>
@@ -6,6 +7,10 @@
 #include "Framework/EDProducer.h"
 #include "Framework/Event.h"
 #include "Framework/PluginFactory.h"
+
+namespace {
+  std::atomic<int> nevents = 0;
+}
 
 class TestProducer2 : public edm::EDProducerExternalWork {
 public:
@@ -16,6 +21,8 @@ private:
                edm::EventSetup const& eventSetup,
                edm::WaitingTaskWithArenaHolder holder) override;
   void produce(edm::Event& event, edm::EventSetup const& eventSetup) override;
+
+  void endJob() override;
 
   edm::EDGetTokenT<unsigned int> getToken_;
   std::future<int> future_;
@@ -43,6 +50,11 @@ void TestProducer2::acquire(edm::Event const& event,
 void TestProducer2::produce(edm::Event& event, edm::EventSetup const& eventSetup) {
   std::cout << "TestProducer2::produce Event " << event.eventID() << " stream " << event.streamID() << " from future "
             << future_.get() << std::endl;
+  ++nevents;
+}
+
+void TestProducer2::endJob() {
+  std::cout << "TestProducer2::endJob processed " << nevents.load() << " events" << std::endl;
 }
 
 DEFINE_FWK_MODULE(TestProducer2);

--- a/src/kokkos/Framework/EDProducer.h
+++ b/src/kokkos/Framework/EDProducer.h
@@ -20,6 +20,10 @@ namespace edm {
 
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
 
+    void doEndJob() { endJob(); }
+
+    virtual void endJob() {}
+
   private:
   };
 
@@ -38,6 +42,9 @@ namespace edm {
 
     virtual void acquire(Event const& event, EventSetup const& eventSetup, WaitingTaskWithArenaHolder holder) = 0;
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
+
+    void doEndJob() { endJob(); }
+    virtual void endJob() {}
 
   private:
   };

--- a/src/kokkos/Framework/Worker.h
+++ b/src/kokkos/Framework/Worker.h
@@ -30,6 +30,9 @@ namespace edm {
     virtual void doWorkAsync(Event& event, EventSetup const& eventSetup, WaitingTask* iTask) = 0;
 
     // not thread safe
+    virtual void doEndJob() = 0;
+
+    // not thread safe
     void reset() {
       prefetchRequested_ = false;
       doReset();
@@ -93,6 +96,8 @@ namespace edm {
         prefetchAsync(event, eventSetup, moduleTask);
       }
     }
+
+    void doEndJob() override { producer_.doEndJob(); }
 
   private:
     void doReset() override {

--- a/src/kokkos/bin/EventProcessor.cc
+++ b/src/kokkos/bin/EventProcessor.cc
@@ -37,4 +37,9 @@ namespace edm {
       std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
     }
   }
+
+  void EventProcessor::endJob() {
+    // Only on the first stream...
+    schedules_[0].endJob();
+  }
 }  // namespace edm

--- a/src/kokkos/bin/EventProcessor.h
+++ b/src/kokkos/bin/EventProcessor.h
@@ -25,6 +25,8 @@ namespace edm {
 
     void runToCompletion();
 
+    void endJob();
+
   private:
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;

--- a/src/kokkos/bin/StreamSchedule.cc
+++ b/src/kokkos/bin/StreamSchedule.cc
@@ -85,4 +85,10 @@ namespace edm {
       h.doneWaiting(std::exception_ptr{});
     }
   }
+
+  void StreamSchedule::endJob() {
+    for (auto& w : path_) {
+      w->doEndJob();
+    }
+  }
 }  // namespace edm

--- a/src/kokkos/bin/StreamSchedule.h
+++ b/src/kokkos/bin/StreamSchedule.h
@@ -35,6 +35,8 @@ namespace edm {
 
     void runToCompletionAsync(WaitingTaskHolder h);
 
+    void endJob();
+
   private:
     void processOneEventAsync(WaitingTaskHolder h);
 

--- a/src/kokkos/bin/main.cc
+++ b/src/kokkos/bin/main.cc
@@ -135,6 +135,22 @@ int main(int argc, char** argv) {
   }
   auto stop = std::chrono::high_resolution_clock::now();
 
+  // Run endJob
+  try {
+    processor.endJob();
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;

--- a/src/kokkostest/Framework/EDProducer.h
+++ b/src/kokkostest/Framework/EDProducer.h
@@ -20,6 +20,10 @@ namespace edm {
 
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
 
+    void doEndJob() { endJob(); }
+
+    virtual void endJob() {}
+
   private:
   };
 
@@ -38,6 +42,9 @@ namespace edm {
 
     virtual void acquire(Event const& event, EventSetup const& eventSetup, WaitingTaskWithArenaHolder holder) = 0;
     virtual void produce(Event& event, EventSetup const& eventSetup) = 0;
+
+    void doEndJob() { endJob(); }
+    virtual void endJob() {}
 
   private:
   };

--- a/src/kokkostest/Framework/Worker.h
+++ b/src/kokkostest/Framework/Worker.h
@@ -30,6 +30,9 @@ namespace edm {
     virtual void doWorkAsync(Event& event, EventSetup const& eventSetup, WaitingTask* iTask) = 0;
 
     // not thread safe
+    virtual void doEndJob() = 0;
+
+    // not thread safe
     void reset() {
       prefetchRequested_ = false;
       doReset();
@@ -93,6 +96,8 @@ namespace edm {
         prefetchAsync(event, eventSetup, moduleTask);
       }
     }
+
+    void doEndJob() override { producer_.doEndJob(); }
 
   private:
     void doReset() override {

--- a/src/kokkostest/bin/EventProcessor.cc
+++ b/src/kokkostest/bin/EventProcessor.cc
@@ -37,4 +37,9 @@ namespace edm {
       std::rethrow_exception(*(globalWaitTask->exceptionPtr()));
     }
   }
+
+  void EventProcessor::endJob() {
+    // Only on the first stream...
+    schedules_[0].endJob();
+  }
 }  // namespace edm

--- a/src/kokkostest/bin/EventProcessor.h
+++ b/src/kokkostest/bin/EventProcessor.h
@@ -25,6 +25,8 @@ namespace edm {
 
     void runToCompletion();
 
+    void endJob();
+
   private:
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;

--- a/src/kokkostest/bin/StreamSchedule.cc
+++ b/src/kokkostest/bin/StreamSchedule.cc
@@ -85,4 +85,10 @@ namespace edm {
       h.doneWaiting(std::exception_ptr{});
     }
   }
+
+  void StreamSchedule::endJob() {
+    for (auto& w : path_) {
+      w->doEndJob();
+    }
+  }
 }  // namespace edm

--- a/src/kokkostest/bin/StreamSchedule.h
+++ b/src/kokkostest/bin/StreamSchedule.h
@@ -35,6 +35,8 @@ namespace edm {
 
     void runToCompletionAsync(WaitingTaskHolder h);
 
+    void endJob();
+
   private:
     void processOneEventAsync(WaitingTaskHolder h);
 

--- a/src/kokkostest/bin/main.cc
+++ b/src/kokkostest/bin/main.cc
@@ -136,6 +136,22 @@ int main(int argc, char** argv) {
   }
   auto stop = std::chrono::high_resolution_clock::now();
 
+  // Run endJob
+  try {
+    processor.endJob();
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
+
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;

--- a/src/kokkostest/plugin-Test2/kokkos/TestProducer2.cc
+++ b/src/kokkostest/plugin-Test2/kokkos/TestProducer2.cc
@@ -11,6 +11,10 @@
 
 #include "kokkosAlgo2.h"
 
+namespace {
+  std::atomic<int> nevents;
+}
+
 namespace KOKKOS_NAMESPACE {
   class TestProducer2 : public edm::EDProducer {
   public:
@@ -18,17 +22,25 @@ namespace KOKKOS_NAMESPACE {
 
   private:
     void produce(edm::Event& event, edm::EventSetup const& eventSetup) override;
+    void endJob() override;
 
     edm::EDGetTokenT<Kokkos::View<const float*, KokkosExecSpace>> getToken_;
   };
 
   TestProducer2::TestProducer2(edm::ProductRegistry& reg)
-      : getToken_(reg.consumes<Kokkos::View<const float*, KokkosExecSpace>>()) {}
+      : getToken_(reg.consumes<Kokkos::View<const float*, KokkosExecSpace>>()) {
+    nevents = 0;
+  }
 
   void TestProducer2::produce(edm::Event& event, edm::EventSetup const& eventSetup) {
     std::cout << "TestProducer2::produce Event " << event.eventID() << " stream " << event.streamID() << std::endl;
 
     kokkosAlgo2();
+    ++nevents;
+  }
+
+  void TestProducer2::endJob() {
+    std::cout << "TestProducer2::endJob processed " << nevents.load() << " events" << std::endl;
   }
 }  // namespace KOKKOS_NAMESPACE
 


### PR DESCRIPTION
Intermediate step to solve #42.

The `endJob()` is run serially after the event "loop" has completed, outside of the throughput measurement, and only for stream 0 (approximation of `globalEndJob()` of CMSSW stream modules).