### PR TITLE
[cudauvm] Move conditions to use managed memory

### DIFF
--- a/run-scan.py
+++ b/run-scan.py
@@ -12,7 +12,8 @@ import multiprocessing
 n_events_unit = 1000
 n_blocks_per_stream = {
     "fwtest": 1,
-    "cuda": {"": 400, "transfer": 350}
+    "cuda": {"": 400, "transfer": 350},
+    "cudauvm": {"": 400, "transfer": 350},
 }
 
 result_re = re.compile("Processed (?P<events>\d+) events in (?P<time>\S+) seconds, throughput (?P<throughput>\S+) events/s")

--- a/src/cudauvm/CondFormats/PixelCPEFast.h
+++ b/src/cudauvm/CondFormats/PixelCPEFast.h
@@ -9,35 +9,18 @@
 
 class PixelCPEFast {
 public:
-  PixelCPEFast(std::string const &path);
+  PixelCPEFast(std::string const& path);
 
-  ~PixelCPEFast() = default;
+  ~PixelCPEFast();
 
-  // The return value can only be used safely in kernels launched on
-  // the same cudaStream, or after cudaStreamSynchronize.
-  const pixelCPEforGPU::ParamsOnGPU *getGPUProductAsync(cudaStream_t cudaStream) const;
-
-  pixelCPEforGPU::ParamsOnGPU const &getCPUProduct() const { return cpuData_; }
+  pixelCPEforGPU::ParamsOnGPU const* get() const { return m_params; }
 
 private:
-  // allocate it with posix malloc to be ocmpatible with cpu wf
-  std::vector<pixelCPEforGPU::DetParams> m_detParamsGPU;
-  // std::vector<pixelCPEforGPU::DetParams, CUDAHostAllocator<pixelCPEforGPU::DetParams>> m_detParamsGPU;
-  pixelCPEforGPU::CommonParams m_commonParamsGPU;
-  pixelCPEforGPU::LayerGeometry m_layerGeometry;
-  pixelCPEforGPU::AverageGeometry m_averageGeometry;
-
-  pixelCPEforGPU::ParamsOnGPU cpuData_;
-
-  struct GPUData {
-    ~GPUData();
-    // not needed if not used on CPU...
-    pixelCPEforGPU::ParamsOnGPU h_paramsOnGPU;
-    pixelCPEforGPU::ParamsOnGPU *d_paramsOnGPU = nullptr;  // copy of the above on the Device
-  };
-  cms::cuda::ESProduct<GPUData> gpuData_;
-
-  void fillParamsForGpu();
+  pixelCPEforGPU::ParamsOnGPU* m_params = nullptr;
+  pixelCPEforGPU::CommonParams* m_commonParams = nullptr;
+  pixelCPEforGPU::DetParams* m_detParams = nullptr;
+  pixelCPEforGPU::LayerGeometry* m_layerGeometry = nullptr;
+  pixelCPEforGPU::AverageGeometry* m_averageGeometry = nullptr;
 };
 
 #endif  // RecoLocalTracker_SiPixelRecHits_PixelCPEFast_h

--- a/src/cudauvm/CondFormats/SiPixelFedCablingMapGPUWrapper.cc
+++ b/src/cudauvm/CondFormats/SiPixelFedCablingMapGPUWrapper.cc
@@ -9,46 +9,33 @@
 
 // CMSSW includes
 #include "CUDACore/cudaCheck.h"
-#include "CUDACore/device_unique_ptr.h"
-#include "CUDACore/host_unique_ptr.h"
+#include "CUDACore/deviceCount.h"
+#include "CUDACore/ScopedSetDevice.h"
+#include "CUDACore/StreamCache.h"
 #include "CondFormats/SiPixelFedCablingMapGPUWrapper.h"
 
 SiPixelFedCablingMapGPUWrapper::SiPixelFedCablingMapGPUWrapper(SiPixelFedCablingMapGPU const& cablingMap,
-                                                               std::vector<unsigned char> modToUnp)
-    : modToUnpDefault(modToUnp.size()), hasQuality_(true) {
-  cudaCheck(cudaMallocHost(&cablingMapHost, sizeof(SiPixelFedCablingMapGPU)));
-  std::memcpy(cablingMapHost, &cablingMap, sizeof(SiPixelFedCablingMapGPU));
-
-  std::copy(modToUnp.begin(), modToUnp.end(), modToUnpDefault.begin());
+                                                               std::vector<unsigned char> const& modToUnp)
+    : hasQuality_(true) {
+  cudaCheck(cudaMallocManaged(&cablingMap_, sizeof(SiPixelFedCablingMapGPU)));
+  *cablingMap_ = cablingMap;
+  cudaCheck(cudaMallocManaged(&modToUnpDefault_, modToUnp.size()));
+  std::copy(modToUnp.begin(), modToUnp.end(), modToUnpDefault_);
+  for (int device = 0, ndev = cms::cuda::deviceCount(); device < ndev; ++device) {
+#ifndef CUDAUVM_DISABLE_ADVICE
+    cudaCheck(cudaMemAdvise(cablingMap_, sizeof(SiPixelFedCablingMapGPU), cudaMemAdviseSetReadMostly, device));
+    cudaCheck(cudaMemAdvise(modToUnpDefault_, sizeof(modToUnp.size()), cudaMemAdviseSetReadMostly, device));
+#endif
+#ifndef CUDAUVM_DISABLE_PREFETCH
+    cms::cuda::ScopedSetDevice guard{device};
+    auto stream = cms::cuda::getStreamCache().get();
+    cudaCheck(cudaMemPrefetchAsync(cablingMap_, sizeof(SiPixelFedCablingMapGPU), device, stream.get()));
+    cudaCheck(cudaMemPrefetchAsync(modToUnpDefault_, modToUnp.size(), device, stream.get()));
+#endif
+  }
 }
 
-SiPixelFedCablingMapGPUWrapper::~SiPixelFedCablingMapGPUWrapper() { cudaCheck(cudaFreeHost(cablingMapHost)); }
-
-const SiPixelFedCablingMapGPU* SiPixelFedCablingMapGPUWrapper::getGPUProductAsync(cudaStream_t cudaStream) const {
-  const auto& data = gpuData_.dataForCurrentDeviceAsync(cudaStream, [this](GPUData& data, cudaStream_t stream) {
-    // allocate
-    cudaCheck(cudaMalloc(&data.cablingMapDevice, sizeof(SiPixelFedCablingMapGPU)));
-
-    // transfer
-    cudaCheck(cudaMemcpyAsync(
-        data.cablingMapDevice, this->cablingMapHost, sizeof(SiPixelFedCablingMapGPU), cudaMemcpyDefault, stream));
-  });
-  return data.cablingMapDevice;
+SiPixelFedCablingMapGPUWrapper::~SiPixelFedCablingMapGPUWrapper() {
+  cudaCheck(cudaFree(cablingMap_));
+  cudaCheck(cudaFree(modToUnpDefault_));
 }
-
-const unsigned char* SiPixelFedCablingMapGPUWrapper::getModToUnpAllAsync(cudaStream_t cudaStream) const {
-  const auto& data =
-      modToUnp_.dataForCurrentDeviceAsync(cudaStream, [this](ModulesToUnpack& data, cudaStream_t stream) {
-        cudaCheck(cudaMalloc((void**)&data.modToUnpDefault, pixelgpudetails::MAX_SIZE_BYTE_BOOL));
-        cudaCheck(cudaMemcpyAsync(data.modToUnpDefault,
-                                  this->modToUnpDefault.data(),
-                                  this->modToUnpDefault.size() * sizeof(unsigned char),
-                                  cudaMemcpyDefault,
-                                  stream));
-      });
-  return data.modToUnpDefault;
-}
-
-SiPixelFedCablingMapGPUWrapper::GPUData::~GPUData() { cudaCheck(cudaFree(cablingMapDevice)); }
-
-SiPixelFedCablingMapGPUWrapper::ModulesToUnpack::~ModulesToUnpack() { cudaCheck(cudaFree(modToUnpDefault)); }

--- a/src/cudauvm/CondFormats/SiPixelFedCablingMapGPUWrapper.h
+++ b/src/cudauvm/CondFormats/SiPixelFedCablingMapGPUWrapper.h
@@ -2,8 +2,6 @@
 #define RecoLocalTracker_SiPixelClusterizer_SiPixelFedCablingMapGPUWrapper_h
 
 #include "CUDACore/ESProduct.h"
-#include "CUDACore/CUDAHostAllocator.h"
-#include "CUDACore/device_unique_ptr.h"
 #include "CondFormats/SiPixelFedCablingMapGPU.h"
 
 #include <cuda_runtime.h>
@@ -12,35 +10,23 @@
 
 class SiPixelFedCablingMapGPUWrapper {
 public:
-  explicit SiPixelFedCablingMapGPUWrapper(SiPixelFedCablingMapGPU const &cablingMap,
-                                          std::vector<unsigned char> modToUnp);
+  explicit SiPixelFedCablingMapGPUWrapper(SiPixelFedCablingMapGPU const& cablingMap,
+                                          std::vector<unsigned char> const& modToUnp);
   ~SiPixelFedCablingMapGPUWrapper();
 
   bool hasQuality() const { return hasQuality_; }
 
   // returns pointer to GPU memory
-  const SiPixelFedCablingMapGPU *getGPUProductAsync(cudaStream_t cudaStream) const;
+  const SiPixelFedCablingMapGPU* cablingMap() const { return cablingMap_; }
 
   // returns pointer to GPU memory
-  const unsigned char *getModToUnpAllAsync(cudaStream_t cudaStream) const;
+  const unsigned char* modToUnpAll() const { return modToUnpDefault_; }
 
 private:
-  std::vector<unsigned char, CUDAHostAllocator<unsigned char>> modToUnpDefault;
   bool hasQuality_;
 
-  SiPixelFedCablingMapGPU *cablingMapHost = nullptr;  // pointer to struct in CPU
-
-  struct GPUData {
-    ~GPUData();
-    SiPixelFedCablingMapGPU *cablingMapDevice = nullptr;  // pointer to struct in GPU
-  };
-  cms::cuda::ESProduct<GPUData> gpuData_;
-
-  struct ModulesToUnpack {
-    ~ModulesToUnpack();
-    unsigned char *modToUnpDefault = nullptr;  // pointer to GPU
-  };
-  cms::cuda::ESProduct<ModulesToUnpack> modToUnp_;
+  SiPixelFedCablingMapGPU* cablingMap_ = nullptr;
+  unsigned char* modToUnpDefault_ = nullptr;
 };
 
 #endif

--- a/src/cudauvm/CondFormats/SiPixelGainCalibrationForHLTGPU.h
+++ b/src/cudauvm/CondFormats/SiPixelGainCalibrationForHLTGPU.h
@@ -8,21 +8,14 @@ struct SiPixelGainForHLTonGPU_DecodingStructure;
 
 class SiPixelGainCalibrationForHLTGPU {
 public:
-  explicit SiPixelGainCalibrationForHLTGPU(SiPixelGainForHLTonGPU const &gain, std::vector<char> gainData);
+  explicit SiPixelGainCalibrationForHLTGPU(SiPixelGainForHLTonGPU const& gain, std::vector<char> const& gainData);
   ~SiPixelGainCalibrationForHLTGPU();
 
-  const SiPixelGainForHLTonGPU *getGPUProductAsync(cudaStream_t cudaStream) const;
-  const SiPixelGainForHLTonGPU *getCPUProduct() const { return gainForHLTonHost_; }
+  const SiPixelGainForHLTonGPU* get() const { return gainForHLT_; }
 
 private:
-  SiPixelGainForHLTonGPU *gainForHLTonHost_ = nullptr;
-  std::vector<char> gainData_;
-  struct GPUData {
-    ~GPUData();
-    SiPixelGainForHLTonGPU *gainForHLTonGPU = nullptr;
-    SiPixelGainForHLTonGPU_DecodingStructure *gainDataOnGPU = nullptr;
-  };
-  cms::cuda::ESProduct<GPUData> gpuData_;
+  SiPixelGainForHLTonGPU* gainForHLT_ = nullptr;
+  SiPixelGainForHLTonGPU_DecodingStructure* gainData_ = nullptr;
 };
 
 #endif  // CalibTracker_SiPixelESProducers_interface_SiPixelGainCalibrationForHLTGPU_h

--- a/src/cudauvm/bin/main.cc
+++ b/src/cudauvm/bin/main.cc
@@ -88,6 +88,13 @@ int main(int argc, char** argv) {
   }
   std::cout << "Found " << numberOfDevices << " devices" << std::endl;
 
+#ifdef CUDAUVM_DISABLE_ADVICE
+  std::cout << "cudaMemAdvise() calls are disabled" << std::endl;
+#endif
+#ifdef CUDAUVM_DISABLE_PREFETCH
+  std::cout << "cudaMemPrefetchAsync() calls are disabled" << std::endl;
+#endif
+
   // Initialize EventProcessor
   std::vector<std::string> edmodules;
   std::vector<std::string> esmodules;

--- a/src/cudauvm/plugin-SiPixelClusterizer/SiPixelRawToClusterCUDA.cc
+++ b/src/cudauvm/plugin-SiPixelClusterizer/SiPixelRawToClusterCUDA.cc
@@ -72,8 +72,8 @@ void SiPixelRawToClusterCUDA::acquire(const edm::Event& iEvent,
                              ") differs the one from SiPixelFedCablingMapGPUWrapper. Please fix your configuration.");
   }
   // get the GPU product already here so that the async transfer can begin
-  const auto* gpuMap = hgpuMap.getGPUProductAsync(ctx.stream());
-  const unsigned char* gpuModulesToUnpack = hgpuMap.getModToUnpAllAsync(ctx.stream());
+  const auto* gpuMap = hgpuMap.cablingMap();
+  const unsigned char* gpuModulesToUnpack = hgpuMap.modToUnpAll();
 
   auto const& hgains = iSetup.get<SiPixelGainCalibrationForHLTGPU>();
   // get the GPU product already here so that the async transfer can begin

--- a/src/cudauvm/plugin-SiPixelClusterizer/SiPixelRawToClusterCUDA.cc
+++ b/src/cudauvm/plugin-SiPixelClusterizer/SiPixelRawToClusterCUDA.cc
@@ -77,7 +77,7 @@ void SiPixelRawToClusterCUDA::acquire(const edm::Event& iEvent,
 
   auto const& hgains = iSetup.get<SiPixelGainCalibrationForHLTGPU>();
   // get the GPU product already here so that the async transfer can begin
-  const auto* gpuGains = hgains.getGPUProductAsync(ctx.stream());
+  const auto* gpuGains = hgains.get();
 
   auto const& fedIds_ = iSetup.get<SiPixelFedIds>().fedIds();
 

--- a/src/cudauvm/plugin-SiPixelRecHits/SiPixelRecHitCUDA.cc
+++ b/src/cudauvm/plugin-SiPixelRecHits/SiPixelRecHitCUDA.cc
@@ -53,9 +53,7 @@ void SiPixelRecHitCUDA::produce(edm::Event& iEvent, const edm::EventSetup& es) {
     std::cout << "Clusters/Hits Overflow " << nHits << " >= " << TrackingRecHit2DSOAView::maxHits() << std::endl;
   }
 
-  ctx.emplace(iEvent,
-              tokenHit_,
-              gpuAlgo_.makeHitsAsync(digis, clusters, bs, fcpe.getGPUProductAsync(ctx.stream()), ctx.stream()));
+  ctx.emplace(iEvent, tokenHit_, gpuAlgo_.makeHitsAsync(digis, clusters, bs, fcpe.get(), ctx.stream()));
 }
 
 DEFINE_FWK_MODULE(SiPixelRecHitCUDA);


### PR DESCRIPTION
Part of #43. Kind of equivalent to https://github.com/cms-patatrack/cmssw/pull/157.

By default `cudaMemAdvise()` and `cudaMemPrefetchAsync()` are enabled, but there are compile-time switches to disable them.