### PR TITLE
[cudauvm] Need to unset memory advise in BeamSpotCUDA destructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ This program contains developments after CMSSW_11_1_0_pre4.
 
 The purpose of this program is to test the performance of the CUDA managed memory.
 
+To disable `cudaMemAdvise(cudaMemAdviseSetReadMostly)`, compile with
+```
+make cudauvm ... USER_CXXFLAGS="-DCUDAUVM_DISABLE_ADVISE"
+```
+
+To disable `cudaMemPrefetchAsync`, compile with
+```
+make cudauvm ... USER_CXXFLAGS="-DCUDAUVM_DISABLE_PREFETCH"
+```
+
 #### `kokkos` and `kokkostest`
 
 If `nvcc` is not in your `$PATH`, the build recipe is

--- a/src/cudauvm/CUDADataFormats/BeamSpotCUDA.cc
+++ b/src/cudauvm/CUDADataFormats/BeamSpotCUDA.cc
@@ -2,8 +2,9 @@
 
 #include "CUDACore/cudaCheck.h"
 #include "CUDACore/managed_unique_ptr.h"
+#include "CUDACore/ScopedSetDevice.h"
 
-BeamSpotCUDA::BeamSpotCUDA(Data const& data_h, int device, cudaStream_t stream) {
+BeamSpotCUDA::BeamSpotCUDA(Data const& data_h, int device, cudaStream_t stream): device_(device) {
   data_d_ = cms::cuda::make_managed_unique<Data>(stream);
   *data_d_ = data_h;
 #ifndef CUDAUVM_DISABLE_ADVISE
@@ -11,5 +12,13 @@ BeamSpotCUDA::BeamSpotCUDA(Data const& data_h, int device, cudaStream_t stream) 
 #endif
 #ifndef CUDAUVM_DISABLE_PREFETCH
   cudaCheck(cudaMemPrefetchAsync(data_d_.get(), sizeof(Data), device, stream));
+#endif
+}
+
+BeamSpotCUDA::~BeamSpotCUDA() {
+#ifndef CUDAUVM_DISABLE_ADVISE
+  // need to make sure a CUDA context is initialized for a thread
+  cms::cuda::ScopedSetDevice(0);
+  cudaCheck(cudaMemAdvise(data_d_.get(), sizeof(Data), cudaMemAdviseUnsetReadMostly, device_));
 #endif
 }

--- a/src/cudauvm/CUDADataFormats/BeamSpotCUDA.cc
+++ b/src/cudauvm/CUDADataFormats/BeamSpotCUDA.cc
@@ -6,7 +6,7 @@
 BeamSpotCUDA::BeamSpotCUDA(Data const& data_h, int device, cudaStream_t stream) {
   data_d_ = cms::cuda::make_managed_unique<Data>(stream);
   *data_d_ = data_h;
-#ifndef CUDAUVM_DISABLE_ADVICE
+#ifndef CUDAUVM_DISABLE_ADVISE
   cudaCheck(cudaMemAdvise(data_d_.get(), sizeof(Data), cudaMemAdviseSetReadMostly, device));
 #endif
 #ifndef CUDAUVM_DISABLE_PREFETCH

--- a/src/cudauvm/CUDADataFormats/BeamSpotCUDA.h
+++ b/src/cudauvm/CUDADataFormats/BeamSpotCUDA.h
@@ -5,6 +5,8 @@
 
 #include <cuda_runtime.h>
 
+#include <thread>
+
 class BeamSpotCUDA {
 public:
   // alignas(128) doesn't really make sense as there is only one
@@ -22,11 +24,13 @@ public:
 
   BeamSpotCUDA() = default;
   BeamSpotCUDA(Data const& data_h, int device, cudaStream_t stream);
+  ~BeamSpotCUDA();
 
   Data const* data() const { return data_d_.get(); }
 
 private:
   cms::cuda::managed::unique_ptr<Data> data_d_;
+  int device_;
 };
 
 #endif

--- a/src/cudauvm/CondFormats/PixelCPEFast.cc
+++ b/src/cudauvm/CondFormats/PixelCPEFast.cc
@@ -39,7 +39,7 @@ PixelCPEFast::PixelCPEFast(std::string const &path) {
   m_params->m_averageGeometry = m_averageGeometry;
 
   for (int device = 0, ndev = cms::cuda::deviceCount(); device < ndev; ++device) {
-#ifndef CUDAUVM_DISABLE_ADVICE
+#ifndef CUDAUVM_DISABLE_ADVISE
     cudaCheck(cudaMemAdvise(m_params, sizeof(pixelCPEforGPU::ParamsOnGPU), cudaMemAdviseSetReadMostly, device));
     cudaCheck(cudaMemAdvise(m_commonParams, sizeof(pixelCPEforGPU::CommonParams), cudaMemAdviseSetReadMostly, device));
     cudaCheck(

--- a/src/cudauvm/CondFormats/SiPixelFedCablingMapGPUWrapper.cc
+++ b/src/cudauvm/CondFormats/SiPixelFedCablingMapGPUWrapper.cc
@@ -22,7 +22,7 @@ SiPixelFedCablingMapGPUWrapper::SiPixelFedCablingMapGPUWrapper(SiPixelFedCabling
   cudaCheck(cudaMallocManaged(&modToUnpDefault_, modToUnp.size()));
   std::copy(modToUnp.begin(), modToUnp.end(), modToUnpDefault_);
   for (int device = 0, ndev = cms::cuda::deviceCount(); device < ndev; ++device) {
-#ifndef CUDAUVM_DISABLE_ADVICE
+#ifndef CUDAUVM_DISABLE_ADVISE
     cudaCheck(cudaMemAdvise(cablingMap_, sizeof(SiPixelFedCablingMapGPU), cudaMemAdviseSetReadMostly, device));
     cudaCheck(cudaMemAdvise(modToUnpDefault_, sizeof(modToUnp.size()), cudaMemAdviseSetReadMostly, device));
 #endif

--- a/src/cudauvm/CondFormats/SiPixelGainCalibrationForHLTGPU.cc
+++ b/src/cudauvm/CondFormats/SiPixelGainCalibrationForHLTGPU.cc
@@ -18,7 +18,7 @@ SiPixelGainCalibrationForHLTGPU::SiPixelGainCalibrationForHLTGPU(SiPixelGainForH
 
   std::memcpy(gainData_, gainData.data(), gainData.size());
   for (int device = 0, ndev = cms::cuda::deviceCount(); device < ndev; ++device) {
-#ifndef CUDAUVM_DISABLE_ADVICE
+#ifndef CUDAUVM_DISABLE_ADVISE
     cudaCheck(cudaMemAdvise(gainForHLT_, sizeof(SiPixelGainForHLTonGPU), cudaMemAdviseSetReadMostly, device));
     cudaCheck(cudaMemAdvise(gainData_, gainData.size(), cudaMemAdviseSetReadMostly, device));
 #endif

--- a/src/cudauvm/bin/main.cc
+++ b/src/cudauvm/bin/main.cc
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
   }
   std::cout << "Found " << numberOfDevices << " devices" << std::endl;
 
-#ifdef CUDAUVM_DISABLE_ADVICE
+#ifdef CUDAUVM_DISABLE_ADVISE
   std::cout << "cudaMemAdvise() calls are disabled" << std::endl;
 #endif
 #ifdef CUDAUVM_DISABLE_PREFETCH


### PR DESCRIPTION
While (slowly) working on the raw-to-cluster part, it occurred to me that it `cudaMemAdvise()` is used with a cached allocation, it better be un-done before returning the memory to the cache.

At first I got weird errors
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  
.../pixeltrack-standalone/src/cudauvm/CUDADataFormats/BeamSpotCUDA.cc, line 22:
cudaCheck(cudaMemAdvise(data_d_.get(), sizeof(Data), cudaMemAdviseUnsetReadMostly, device_));
cudaErrorDeviceUninitialized: invalid device context
```
(usually with `./cudauvm --validation`). It turned out that in these cases the destructor was run in a different thread than the constructor (i.e. the process was started with one thread, and TBB created a second thread because of`enqueue()` call), and the other thread did not have CUDA context initialized yet. By quick experimentation I guess the `cudaSetDevice()` would be the simplest CUDA runtime API function call that leads to CUDA context being initialized for a thread.

This PR also renames the `CUDAUVM_DISABLE_ADVICE` macro to `CUDAUVM_DISABLE_ADVISE` to be consistent with the CUDA runtime API function name.