### PR TITLE
[kokkos] Update Kokkos to 3.1.01, require target CUDA architecture to be specified explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,15 +103,23 @@ export KOKKOS_INSTALL := $(KOKKOS_BASE)/install
 KOKKOS_LIBDIR := $(KOKKOS_INSTALL)/lib
 export KOKKOS_LIB := $(KOKKOS_LIBDIR)/libkokkoscore.a
 KOKKOS_MAKEFILE := $(KOKKOS_BUILD)/Makefile
+KOKKOS_CUDA_ARCH := 70
+KOKKOS_CMAKE_CUDA_ARCH := 70
+ifeq ($(KOKKOS_CUDA_ARCH),70)
+  KOKKOS_CMAKE_CUDA_ARCH := -DKokkos_ARCH_VOLTA70=On
+else ifeq ($(KOKKOS_CUDA_ARCH),75)
+  KOKKOS_CMAKE_CUDA_ARCH := -DKokkos_ARCH_TURING75=On
+else
+  $(error Unsupported KOKKOS_CUDA_ARCH $(KOKKOS_CUDA_ARCH). Likely it is sufficient just add another case in the Makefile)
+endif
 KOKKOS_CMAKEFLAGS := -DCMAKE_INSTALL_PREFIX=$(KOKKOS_INSTALL) \
                      -DCMAKE_INSTALL_LIBDIR=lib \
                      -DKokkos_CXX_STANDARD=14 \
-                     -DCMAKE_CXX_COMPILER=$(KOKKOS_SRC)/bin/nvcc_wrapper -DKokkos_ENABLE_CUDA=On -DKokkos_ENABLE_CUDA_CONSTEXPR=On -DKokkos_ENABLE_CUDA_LAMBDA=On -DKokkos_CUDA_DIR=$(CUDA_BASE) -DKokkos_ARCH_VOLTA70=On
+                     -DCMAKE_CXX_COMPILER=$(KOKKOS_SRC)/bin/nvcc_wrapper -DKokkos_ENABLE_CUDA=On -DKokkos_ENABLE_CUDA_CONSTEXPR=On -DKokkos_ENABLE_CUDA_LAMBDA=On -DKokkos_CUDA_DIR=$(CUDA_BASE) $(KOKKOS_CMAKE_CUDA_ARCH)
 # if without CUDA, replace the above line with
 #                     -DCMAKE_CXX_COMPILER=g++
 export KOKKOS_DEPS := $(KOKKOS_LIB)
 export KOKKOS_CXXFLAGS := -I$(KOKKOS_INSTALL)/include
-KOKKOS_CUDA_ARCH := 70
 $(eval $(call CUFLAGS_template,$(KOKKOS_CUDA_ARCH),KOKKOS_))
 KOKKOS_CUDA_CUFLAGS := $(KOKKOS_NVCC_COMMON) $(USER_CUDAFLAGS)
 export KOKKOS_CUFLAGS := $(KOKKOS_CUDA_CUFLAGS) -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
@@ -261,7 +269,7 @@ $(CUPLA_BASE)/lib: $(CUPLA_BASE) $(ALPAKA_DEPS) $(BOOST_DEPS) $(TBB_DEPS) $(CUDA
 external_kokkos: $(KOKKOS_LIB)
 
 $(KOKKOS_SRC):
-	git clone --branch 3.0.00 https://github.com/kokkos/kokkos.git $@
+	git clone --branch 3.1.01 https://github.com/kokkos/kokkos.git $@
 
 $(KOKKOS_BUILD):
 	mkdir -p $@

--- a/README.md
+++ b/README.md
@@ -119,10 +119,13 @@ If `nvcc` is not in your `$PATH`, the build recipe is
 ```bash
 $ make environment [CUDA_BASE=...]
 $ source env.sh
-$ make -j N kokkos [CUDA_BASE=...]
+$ make -j N kokkos [CUDA_BASE=...] [KOKKOS_CUDA_ARCH=...]
 $ ./kokkos --cuda
 ```
 * Note that if `CUDA_BASE` needs to be set, it needs to be set for both `make` commands.
+* The target CUDA architecture needs to be set explicitly with `KOKKOS_CUDA_ARCH`
+  * Default value is `70` (7.0) for Volta
+  * Other accepted values are `75` (Turing), the list can be extended as neeeded
 * The CMake executable can be set with `CMAKE` in case the default one is too old.
 * The backend(s) need to be set explicitly via command line parameters (`--serial` for CPU serial backend, `--cuda` for CUDA backend)
 * Use of multiple threads (`--numberOfThreads`) has not been tested and likely does not work correctly. Concurrent events (`--numberOfStreams`) works.


### PR DESCRIPTION
The CUDA target architecture defaults to `70` (Volta). Currently only `75` (Turing) is listed as an alternative. More are easy to add, these just suffice my immediate needs.

When updating local code run
```
make clean
rm -fR external/kokkos
```

