### PR TITLE
[kokkos] Initialize and use only the backend(s) given at the command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ USER_CXXFLAGS :=
 HOST_CXXFLAGS := -O2 -fPIC -fdiagnostics-show-option -felide-constructors -fmessage-length=0 -fno-math-errno -ftree-vectorize -fvisibility-inlines-hidden --param vect-max-version-for-alias-checks=50 -msse3 -pipe -pthread -Xassembler --compress-debug-sections -Werror=address -Wall -Werror=array-bounds -Wno-attributes -Werror=conversion-null -Werror=delete-non-virtual-dtor -Wno-deprecated -Werror=format-contains-nul -Werror=format -Wno-long-long -Werror=main -Werror=missing-braces -Werror=narrowing -Wno-non-template-friend -Wnon-virtual-dtor -Werror=overflow -Werror=overlength-strings -Wparentheses -Werror=pointer-arith -Wno-psabi -Werror=reorder -Werror=return-local-addr -Wreturn-type -Werror=return-type -Werror=sign-compare -Werror=strict-aliasing -Wstrict-overflow -Werror=switch -Werror=type-limits -Wunused -Werror=unused-but-set-variable -Wno-unused-local-typedefs -Werror=unused-value -Wno-error=unused-variable -Wno-vla -Werror=write-strings
 export CXXFLAGS := -std=c++17 $(HOST_CXXFLAGS) $(USER_CXXFLAGS)
 export LDFLAGS := -pthread -Wl,-E -lstdc++fs
-export LDFLAGS_NVCC := --linker-options '-E' --linker-options '-lstdc++fs'
+export LDFLAGS_NVCC := -ccbin $(CXX) --linker-options '-E' --linker-options '-lstdc++fs'
 export SO_LDFLAGS := -Wl,-z,defs
 export SO_LDFLAGS_NVCC := --linker-options '-z,defs'
 

--- a/src/kokkos/KokkosCore/kokkosConfig.h
+++ b/src/kokkos/KokkosCore/kokkosConfig.h
@@ -2,6 +2,7 @@
 #define KokkosCore_kokkosConfig_h
 
 #include <Kokkos_Core.hpp>
+#include "KokkosCore/kokkosConfigCommon.h"
 
 #ifdef KOKKOS_BACKEND_SERIAL
 using KokkosExecSpace = Kokkos::Serial;
@@ -10,6 +11,18 @@ using KokkosExecSpace = Kokkos::Serial;
 using KokkosExecSpace = Kokkos::Cuda;
 #define KOKKOS_NAMESPACE kokkos_cuda
 #endif
+
+// this is meant mostly for unit tests
+template <typename ExecSpace>
+struct KokkosBackend;
+template <>
+struct KokkosBackend<Kokkos::Serial> {
+  static constexpr auto value = kokkos_common::InitializeScopeGuard::Backend::SERIAL;
+};
+template <>
+struct KokkosBackend<Kokkos::Cuda> {
+  static constexpr auto value = kokkos_common::InitializeScopeGuard::Backend::CUDA;
+};
 
 // trick to force expanding KOKKOS_NAMESPACE before stringification inside DEFINE_FWK_MODULE
 #define DEFINE_FWK_KOKKOS_MODULE2(name) DEFINE_FWK_MODULE(name)

--- a/src/kokkos/KokkosCore/kokkosConfigCommon.h
+++ b/src/kokkos/KokkosCore/kokkosConfigCommon.h
@@ -1,6 +1,7 @@
 #ifndef KokkosCore_kokkosConfigCommon_h
 #define KokkosCore_kokkosConfigCommon_h
 
+#include <vector>
 #include <memory>
 
 // This header needs to be #included in a file that may not be
@@ -8,7 +9,9 @@
 namespace kokkos_common {
   class InitializeScopeGuard {
   public:
-    InitializeScopeGuard();
+    enum class Backend { SERIAL, CUDA };
+
+    InitializeScopeGuard(std::vector<Backend> const& backends);
     ~InitializeScopeGuard();
 
   private:

--- a/src/kokkos/KokkosCore/kokkoshost/kokkosConfigCommon.cc
+++ b/src/kokkos/KokkosCore/kokkoshost/kokkosConfigCommon.cc
@@ -5,16 +5,26 @@
 namespace kokkos_common {
   class InitializeScopeGuard::Impl {
   public:
-    explicit Impl(const Kokkos::InitArguments& args) : guard(args) {}
+    explicit Impl(std::vector<Backend> const& backends, Kokkos::InitArguments const& args) {
+      Kokkos::Impl::pre_initialize(args);
+      if (std::find(backends.begin(), backends.end(), Backend::SERIAL) != backends.end()) {
+        Kokkos::Serial::impl_initialize();
+      }
+      if (std::find(backends.begin(), backends.end(), Backend::CUDA) != backends.end()) {
+        // CUDA execution space requires a host execution space as well
+        Kokkos::Serial::impl_initialize();
+        Kokkos::Cuda::impl_initialize();
+      }
+      Kokkos::Impl::post_initialize(args);
+    }
 
-  private:
-    Kokkos::ScopeGuard guard;
+    ~Impl() { Kokkos::finalize(); }
   };
 
-  InitializeScopeGuard::InitializeScopeGuard() {
+  InitializeScopeGuard::InitializeScopeGuard(std::vector<Backend> const& backends) {
     // for now pass in the default arguments
     Kokkos::InitArguments arguments;
-    pimpl_ = std::make_unique<Impl>(arguments);
+    pimpl_ = std::make_unique<Impl>(backends, arguments);
   }
 
   InitializeScopeGuard::~InitializeScopeGuard() = default;

--- a/src/kokkos/KokkosDataFormats/BeamSpotKokkos.h
+++ b/src/kokkos/KokkosDataFormats/BeamSpotKokkos.h
@@ -10,10 +10,11 @@ template <typename MemorySpace>
 class BeamSpotKokkos {
 public:
   BeamSpotKokkos() = default;
-  BeamSpotKokkos(BeamSpotPOD const* data) : data_d{"data_d"} {
+  template <typename ExecSpace>
+  BeamSpotKokkos(BeamSpotPOD const* data, ExecSpace const& execSpace) : data_d{"data_d"} {
     typename Kokkos::View<BeamSpotPOD, MemorySpace>::HostMirror data_h = Kokkos::create_mirror_view(data_d);
     std::memcpy(data_h.data(), data, sizeof(BeamSpotPOD));
-    Kokkos::deep_copy(data_d, data_h);
+    Kokkos::deep_copy(execSpace, data_d, data_h);
   }
 
   KOKKOS_INLINE_FUNCTION BeamSpotPOD const* data() const { return data_d.data(); }

--- a/src/kokkos/KokkosDataFormats/SiPixelDigiErrorsKokkos.h
+++ b/src/kokkos/KokkosDataFormats/SiPixelDigiErrorsKokkos.h
@@ -10,12 +10,13 @@ template <typename MemorySpace>
 class SiPixelDigiErrorsKokkos {
 public:
   SiPixelDigiErrorsKokkos() = default;
-  explicit SiPixelDigiErrorsKokkos(size_t maxFedWords, PixelFormatterErrors errors)
+  template <typename ExecSpace>
+  explicit SiPixelDigiErrorsKokkos(size_t maxFedWords, PixelFormatterErrors errors, ExecSpace const& execSpace)
       : data_d{"data_d", maxFedWords}, error_d{"error_d"}, error_h{"error_h"}, formatterErrors_h{std::move(errors)} {
     error_h.data()->construct(maxFedWords, data_d.data());
     assert(error_h.data()->empty());
     assert(error_h.data()->capacity() == static_cast<int>(maxFedWords));
-    Kokkos::deep_copy(error_d, error_h);
+    Kokkos::deep_copy(execSpace, error_d, error_h);
   }
   ~SiPixelDigiErrorsKokkos() = default;
 

--- a/src/kokkos/bin/main.cc
+++ b/src/kokkos/bin/main.cc
@@ -30,13 +30,12 @@ namespace {
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
         << std::endl;
   }
-
-  enum class Backend { SERIAL, CUDA };
 }  // namespace
 
 int main(int argc, char** argv) {
   // Parse command line arguments
   std::vector<std::string> args(argv, argv + argc);
+  using Backend = kokkos_common::InitializeScopeGuard::Backend;
   std::vector<Backend> backends;
   int numberOfThreads = 1;
   int numberOfStreams = 0;
@@ -87,7 +86,7 @@ int main(int argc, char** argv) {
   }
 
   // Initialize Kokkos
-  kokkos_common::InitializeScopeGuard kokkosGuard;
+  kokkos_common::InitializeScopeGuard kokkosGuard(backends);
 
   // Initialize EventProcessor
   std::vector<std::string> edmodules;

--- a/src/kokkos/plugin-BeamSpotProducer/kokkos/BeamSpotToKokkos.cc
+++ b/src/kokkos/plugin-BeamSpotProducer/kokkos/BeamSpotToKokkos.cc
@@ -24,7 +24,7 @@ namespace KOKKOS_NAMESPACE {
 
   void BeamSpotToKokkos::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     auto const& bsRaw = iSetup.get<BeamSpotPOD>();
-    BeamSpotKokkos<KokkosExecSpace> bs{&bsRaw};
+    BeamSpotKokkos<KokkosExecSpace> bs{&bsRaw, KokkosExecSpace()};
 
     iEvent.emplace(bsPutToken_, std::move(bs));
   }

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelFedCablingMapESProducer.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelFedCablingMapESProducer.cc
@@ -32,15 +32,14 @@ namespace KOKKOS_NAMESPACE {
     Kokkos::View<SiPixelFedCablingMapGPU, KokkosExecSpace> cablingMap_d("cablingMap_d");
     auto cablingMap_h = Kokkos::create_mirror_view(cablingMap_d);
     (*cablingMap_h.data()) = obj;
-    Kokkos::deep_copy(cablingMap_d, cablingMap_h);
+    Kokkos::deep_copy(KokkosExecSpace(), cablingMap_d, cablingMap_h);
     eventSetup.put(std::make_unique<SiPixelFedCablingMapGPUWrapper<KokkosExecSpace>>(std::move(cablingMap_d), true));
 
     Kokkos::View<unsigned char*, KokkosExecSpace> modToUnp_d("modToUnp_d", modToUnpDefSize);
     auto modToUnp_h = Kokkos::create_mirror_view(modToUnp_d);
     std::copy(modToUnpDefault.begin(), modToUnpDefault.end(), modToUnp_h.data());
-    Kokkos::deep_copy(modToUnp_d, modToUnp_h);
+    Kokkos::deep_copy(KokkosExecSpace(), modToUnp_d, modToUnp_h);
     eventSetup.put(std::make_unique<Kokkos::View<const unsigned char*, KokkosExecSpace>>(std::move(modToUnp_d)));
-    Kokkos::fence();
   }
 }  // namespace KOKKOS_NAMESPACE
 

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelGainCalibrationForHLTESProducer.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelGainCalibrationForHLTESProducer.cc
@@ -51,7 +51,7 @@ namespace KOKKOS_NAMESPACE {
         "ped_d", gainData.size() / sizeof(SiPixelGainForHLTonGPU_DecodingStructure));
     auto ped_h = Kokkos::create_mirror_view(ped_d);
     memcpy(ped_h.data(), gainData.data(), gainData.size());
-    Kokkos::deep_copy(ped_d, ped_h);
+    Kokkos::deep_copy(KokkosExecSpace(), ped_d, ped_h);
 
     typename SiPixelGainForHLTonGPU<KokkosExecSpace>::RangeAndColsWritableView rangeAndCols_d("rangeAndCols_d");
     auto rangeAndCols_h = Kokkos::create_mirror_view(rangeAndCols_d);
@@ -60,7 +60,7 @@ namespace KOKKOS_NAMESPACE {
           Kokkos::make_pair(Kokkos::make_pair(gain.rangeAndCols[i].first.first, gain.rangeAndCols[i].first.second),
                             gain.rangeAndCols[i].second);
     }
-    Kokkos::deep_copy(rangeAndCols_d, rangeAndCols_h);
+    Kokkos::deep_copy(KokkosExecSpace(), rangeAndCols_d, rangeAndCols_h);
 
     typename SiPixelGainForHLTonGPU<KokkosExecSpace>::FieldsWritableView fields_d("fields_d");
     auto fields_h = Kokkos::create_mirror_view(fields_d);
@@ -76,11 +76,10 @@ namespace KOKKOS_NAMESPACE {
     COPY(deadFlag_);
     COPY(noisyFlag_);
 #undef COPY
-    Kokkos::deep_copy(fields_d, fields_h);
+    Kokkos::deep_copy(KokkosExecSpace(), fields_d, fields_h);
 
     eventSetup.put(std::make_unique<SiPixelGainForHLTonGPU<KokkosExecSpace>>(
         std::move(ped_d), std::move(rangeAndCols_d), std::move(fields_d)));
-    Kokkos::fence();
   }
 }  // namespace KOKKOS_NAMESPACE
 

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
@@ -535,7 +535,8 @@ namespace KOKKOS_NAMESPACE {
 
       digis_d = SiPixelDigisKokkos<KokkosExecSpace>(pixelgpudetails::MAX_FED_WORDS);
       if (includeErrors) {
-        digiErrors_d = SiPixelDigiErrorsKokkos<KokkosExecSpace>(pixelgpudetails::MAX_FED_WORDS, std::move(errors));
+        digiErrors_d = SiPixelDigiErrorsKokkos<KokkosExecSpace>(
+            pixelgpudetails::MAX_FED_WORDS, std::move(errors), KokkosExecSpace());
       }
       clusters_d = SiPixelClustersKokkos<KokkosExecSpace>(::gpuClustering::MaxNumModules);
 
@@ -558,8 +559,8 @@ namespace KOKKOS_NAMESPACE {
         //Kokkos::View<unsigned char *, KokkosExecSpace> fedId_d("fedId_d", wordCounter);
         Kokkos::View<unsigned int *, KokkosExecSpace> word_d("word_d", MAX_FED_WORDS);
         Kokkos::View<unsigned char *, KokkosExecSpace> fedId_d("fedId_d", MAX_FED_WORDS);
-        Kokkos::deep_copy(word_d, wordFed.word());
-        Kokkos::deep_copy(fedId_d, wordFed.fedId());
+        Kokkos::deep_copy(KokkosExecSpace(), word_d, wordFed.word());
+        Kokkos::deep_copy(KokkosExecSpace(), fedId_d, wordFed.fedId());
 
         {
           // need Kokkos::Views as local variables to pass to the lambda

--- a/src/kokkos/test/kokkos/AtomicPairCounter_t.cc
+++ b/src/kokkos/test/kokkos/AtomicPairCounter_t.cc
@@ -69,7 +69,7 @@ void test() {
 }  // test()
 
 int main(void) {
-  kokkos_common::InitializeScopeGuard kokkosGuard;
+  kokkos_common::InitializeScopeGuard kokkosGuard({KokkosBackend<KokkosExecSpace>::value});
   test();
   return 0;
 }

--- a/src/kokkos/test/kokkos/AtomicPairCounter_t.cc
+++ b/src/kokkos/test/kokkos/AtomicPairCounter_t.cc
@@ -62,7 +62,7 @@ void test() {
           assert(m_d[ib] == k);
       });
 
-  Kokkos::deep_copy(dc_h, dc_d);
+  Kokkos::deep_copy(KokkosExecSpace(), dc_h, dc_d);
 
   std::cout << dc_h(0).get().n << ' ' << dc_h(0).get().m << std::endl;
 

--- a/src/kokkos/test/kokkos/clustering.cc
+++ b/src/kokkos/test/kokkos/clustering.cc
@@ -230,11 +230,11 @@ void test() {
     size_t size16 = n * sizeof(unsigned short);
     // size_t size8 = n * sizeof(uint8_t);
 
-    Kokkos::deep_copy(d_moduleStart, 0);
-    Kokkos::deep_copy(d_id, h_id);
-    Kokkos::deep_copy(d_x, h_x);
-    Kokkos::deep_copy(d_y, h_y);
-    Kokkos::deep_copy(d_adc, h_adc);
+    Kokkos::deep_copy(KokkosExecSpace(), d_moduleStart, 0);
+    Kokkos::deep_copy(KokkosExecSpace(), d_id, h_id);
+    Kokkos::deep_copy(KokkosExecSpace(), d_x, h_x);
+    Kokkos::deep_copy(KokkosExecSpace(), d_y, h_y);
+    Kokkos::deep_copy(KokkosExecSpace(), d_adc, h_adc);
 
     // Launch Kokkos Kernels
     std::cout << "Kokkos countModules kernel launch\n";

--- a/src/kokkos/test/kokkos/clustering.cc
+++ b/src/kokkos/test/kokkos/clustering.cc
@@ -391,7 +391,7 @@ void test() {
 }
 
 int main(void) {
-  kokkos_common::InitializeScopeGuard kokkosGuard;
+  kokkos_common::InitializeScopeGuard kokkosGuard({KokkosBackend<KokkosExecSpace>::value});
   test();
   return 0;
 }

--- a/src/kokkostest/KokkosCore/kokkosConfig.h
+++ b/src/kokkostest/KokkosCore/kokkosConfig.h
@@ -2,6 +2,7 @@
 #define KokkosCore_kokkosConfig_h
 
 #include <Kokkos_Core.hpp>
+#include "KokkosCore/kokkosConfigCommon.h"
 
 #ifdef KOKKOS_BACKEND_SERIAL
 using KokkosExecSpace = Kokkos::Serial;
@@ -10,6 +11,18 @@ using KokkosExecSpace = Kokkos::Serial;
 using KokkosExecSpace = Kokkos::Cuda;
 #define KOKKOS_NAMESPACE kokkos_cuda
 #endif
+
+// this is meant mostly for unit tests
+template <typename ExecSpace>
+struct KokkosBackend;
+template <>
+struct KokkosBackend<Kokkos::Serial> {
+  static constexpr auto value = kokkos_common::InitializeScopeGuard::Backend::SERIAL;
+};
+template <>
+struct KokkosBackend<Kokkos::Cuda> {
+  static constexpr auto value = kokkos_common::InitializeScopeGuard::Backend::CUDA;
+};
 
 // trick to force expanding KOKKOS_NAMESPACE before stringification inside DEFINE_FWK_MODULE
 #define DEFINE_FWK_KOKKOS_MODULE2(name) DEFINE_FWK_MODULE(name)

--- a/src/kokkostest/KokkosCore/kokkosConfigCommon.h
+++ b/src/kokkostest/KokkosCore/kokkosConfigCommon.h
@@ -1,6 +1,7 @@
 #ifndef KokkosCore_kokkosConfigCommon_h
 #define KokkosCore_kokkosConfigCommon_h
 
+#include <vector>
 #include <memory>
 
 // This header needs to be #included in a file that may not be
@@ -8,7 +9,9 @@
 namespace kokkos_common {
   class InitializeScopeGuard {
   public:
-    InitializeScopeGuard();
+    enum class Backend { SERIAL, CUDA };
+
+    InitializeScopeGuard(std::vector<Backend> const& backends);
     ~InitializeScopeGuard();
 
   private:

--- a/src/kokkostest/KokkosCore/kokkoshost/kokkosConfigCommon.cc
+++ b/src/kokkostest/KokkosCore/kokkoshost/kokkosConfigCommon.cc
@@ -5,16 +5,26 @@
 namespace kokkos_common {
   class InitializeScopeGuard::Impl {
   public:
-    explicit Impl(const Kokkos::InitArguments& args) : guard(args) {}
+    explicit Impl(std::vector<Backend> const& backends, Kokkos::InitArguments const& args) {
+      Kokkos::Impl::pre_initialize(args);
+      if (std::find(backends.begin(), backends.end(), Backend::SERIAL) != backends.end()) {
+        Kokkos::Serial::impl_initialize();
+      }
+      if (std::find(backends.begin(), backends.end(), Backend::CUDA) != backends.end()) {
+        // CUDA execution space requires a host execution space as well
+        Kokkos::Serial::impl_initialize();
+        Kokkos::Cuda::impl_initialize();
+      }
+      Kokkos::Impl::post_initialize(args);
+    }
 
-  private:
-    Kokkos::ScopeGuard guard;
+    ~Impl() { Kokkos::finalize(); }
   };
 
-  InitializeScopeGuard::InitializeScopeGuard() {
+  InitializeScopeGuard::InitializeScopeGuard(std::vector<Backend> const& backends) {
     // for now pass in the default arguments
     Kokkos::InitArguments arguments;
-    pimpl_ = std::make_unique<Impl>(arguments);
+    pimpl_ = std::make_unique<Impl>(backends, arguments);
   }
 
   InitializeScopeGuard::~InitializeScopeGuard() = default;

--- a/src/kokkostest/bin/main.cc
+++ b/src/kokkostest/bin/main.cc
@@ -30,13 +30,12 @@ namespace {
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
         << std::endl;
   }
-
-  enum class Backend { SERIAL, CUDA };
 }  // namespace
 
 int main(int argc, char** argv) {
   // Parse command line arguments
   std::vector<std::string> args(argv, argv + argc);
+  using Backend = kokkos_common::InitializeScopeGuard::Backend;
   std::vector<Backend> backends;
   int numberOfThreads = 1;
   int numberOfStreams = 0;
@@ -87,7 +86,7 @@ int main(int argc, char** argv) {
   }
 
   // Initialize Kokkos
-  kokkos_common::InitializeScopeGuard kokkosGuard;
+  kokkos_common::InitializeScopeGuard kokkosGuard(backends);
 
   // Initialize EventProcessor
   std::vector<std::string> edmodules;

--- a/src/kokkostest/plugin-Test1/kokkos/kokkosAlgo1.cc
+++ b/src/kokkostest/plugin-Test1/kokkos/kokkosAlgo1.cc
@@ -25,8 +25,9 @@ namespace KOKKOS_NAMESPACE {
       h_b[i] = i * i;
     }
 
-    Kokkos::deep_copy(d_a, h_a);
-    Kokkos::deep_copy(d_b, h_b);
+    // TODO: take the execuction space object from the caller
+    Kokkos::deep_copy(KokkosExecSpace(), d_a, h_a);
+    Kokkos::deep_copy(KokkosExecSpace(), d_b, h_b);
 
     Kokkos::View<float*, KokkosExecSpace> d_c{"d_c", NUM_VALUES};
     Kokkos::parallel_for(

--- a/src/kokkostest/plugin-Test2/kokkos/kokkosAlgo2.cc
+++ b/src/kokkostest/plugin-Test2/kokkos/kokkosAlgo2.cc
@@ -25,8 +25,8 @@ namespace KOKKOS_NAMESPACE {
       h_b[i] = i * i;
     }
 
-    Kokkos::deep_copy(d_a, h_a);
-    Kokkos::deep_copy(d_b, h_b);
+    Kokkos::deep_copy(KokkosExecSpace(), d_a, h_a);
+    Kokkos::deep_copy(KokkosExecSpace(), d_b, h_b);
 
     Kokkos::View<float*, KokkosExecSpace> d_c{"d_c", NUM_VALUES};
     Kokkos::parallel_for(

--- a/src/kokkostest/test/kokkos/world.cc
+++ b/src/kokkostest/test/kokkos/world.cc
@@ -4,7 +4,7 @@
 #include "KokkosCore/kokkosConfig.h"
 
 int main() {
-  kokkos_common::InitializeScopeGuard kokkosGuard;
+  kokkos_common::InitializeScopeGuard kokkosGuard({KokkosBackend<KokkosExecSpace>::value});
   std::cout << "World" << std::endl;
 
   Kokkos::parallel_for(


### PR DESCRIPTION
New attempt of https://github.com/cms-patatrack/pixeltrack-standalone/pull/33. Now also all execution space specific unit tests initialize only that unit test, i.e. all `X.serial` binaries can be run without a GPU.