### PR TITLE
[kokkos] Migrate two RecHit kernels to Kokkos

### DIFF
--- a/src/kokkos/DataFormats/approx_atan2.h
+++ b/src/kokkos/DataFormats/approx_atan2.h
@@ -1,0 +1,290 @@
+#ifndef DataFormatsMathAPPROX_ATAN2_H
+#define DataFormatsMathAPPROX_ATAN2_H
+
+/*
+ * approximate atan2 evaluations
+ *
+ * Polynomials were obtained using Sollya scripts (in comments below)
+ *
+ *
+*/
+
+/*
+f= atan((1-x)/(1+x))-atan(1);
+I=[-1+10^(-4);1.0];
+filename="atan.txt";
+print("") > filename;
+for deg from 3 to 11 do begin
+  p = fpminimax(f, deg,[|1,23...|],I, floating, absolute); 
+  display=decimal;
+  acc=floor(-log2(sup(supnorm(p, f, I, absolute, 2^(-20)))));
+  print( "   // degree = ", deg, 
+         "  => absolute accuracy is ",  acc, "bits" ) >> filename;
+  print("template<> constexpr float approx_atan2f_P<", deg, ">(float x){") >> filename;
+  display=hexadecimal;
+  print(" return ", horner(p) , ";") >> filename;
+  print("}") >> filename;
+end;
+*/
+
+#include <cstdint>
+#include <cmath>
+#include <limits>
+#include <algorithm>
+
+// float
+
+template <int DEGREE>
+constexpr float approx_atan2f_P(float x);
+
+// degree =  3   => absolute accuracy is  7 bits
+template <>
+constexpr float approx_atan2f_P<3>(float x) {
+  return x * (float(-0xf.8eed2p-4) + x * x * float(0x3.1238p-4));
+}
+
+// degree =  5   => absolute accuracy is  10 bits
+template <>
+constexpr float approx_atan2f_P<5>(float x) {
+  auto z = x * x;
+  return x * (float(-0xf.ecfc8p-4) + z * (float(0x4.9e79dp-4) + z * float(-0x1.44f924p-4)));
+}
+
+// degree =  7   => absolute accuracy is  13 bits
+template <>
+constexpr float approx_atan2f_P<7>(float x) {
+  auto z = x * x;
+  return x * (float(-0xf.fcc7ap-4) + z * (float(0x5.23886p-4) + z * (float(-0x2.571968p-4) + z * float(0x9.fb05p-8))));
+}
+
+// degree =  9   => absolute accuracy is  16 bits
+template <>
+constexpr float approx_atan2f_P<9>(float x) {
+  auto z = x * x;
+  return x * (float(-0xf.ff73ep-4) +
+              z * (float(0x5.48ee1p-4) +
+                   z * (float(-0x2.e1efe8p-4) + z * (float(0x1.5cce54p-4) + z * float(-0x5.56245p-8)))));
+}
+
+// degree =  11   => absolute accuracy is  19 bits
+template <>
+constexpr float approx_atan2f_P<11>(float x) {
+  auto z = x * x;
+  return x * (float(-0xf.ffe82p-4) +
+              z * (float(0x5.526c8p-4) +
+                   z * (float(-0x3.18bea8p-4) +
+                        z * (float(0x1.dce3bcp-4) + z * (float(-0xd.7a64ap-8) + z * float(0x3.000eap-8))))));
+}
+
+// degree =  13   => absolute accuracy is  21 bits
+template <>
+constexpr float approx_atan2f_P<13>(float x) {
+  auto z = x * x;
+  return x * (float(-0xf.fffbep-4) +
+              z * (float(0x5.54adp-4) +
+                   z * (float(-0x3.2b4df8p-4) +
+                        z * (float(0x2.1df79p-4) +
+                             z * (float(-0x1.46081p-4) + z * (float(0x8.99028p-8) + z * float(-0x1.be0bc4p-8)))))));
+}
+
+// degree =  15   => absolute accuracy is  24 bits
+template <>
+constexpr float approx_atan2f_P<15>(float x) {
+  auto z = x * x;
+  return x * (float(-0xf.ffff4p-4) +
+              z * (float(0x5.552f9p-4 + z * (float(-0x3.30f728p-4) +
+                                             z * (float(0x2.39826p-4) +
+                                                  z * (float(-0x1.8a880cp-4) +
+                                                       z * (float(0xe.484d6p-8) +
+                                                            z * (float(-0x5.93d5p-8) + z * float(0x1.0875dcp-8)))))))));
+}
+
+template <int DEGREE>
+constexpr float unsafe_atan2f_impl(float y, float x) {
+  constexpr float pi4f = 3.1415926535897932384626434 / 4;
+  constexpr float pi34f = 3.1415926535897932384626434 * 3 / 4;
+
+  auto r = (std::abs(x) - std::abs(y)) / (std::abs(x) + std::abs(y));
+  if (x < 0)
+    r = -r;
+
+  auto angle = (x >= 0) ? pi4f : pi34f;
+  angle += approx_atan2f_P<DEGREE>(r);
+
+  return ((y < 0)) ? -angle : angle;
+}
+
+template <int DEGREE>
+constexpr float unsafe_atan2f(float y, float x) {
+  return unsafe_atan2f_impl<DEGREE>(y, x);
+}
+
+template <int DEGREE>
+constexpr float safe_atan2f(float y, float x) {
+  return unsafe_atan2f_impl<DEGREE>(y, (y == 0.f) & (x == 0.f) ? 0.2f : x);
+  // return (y==0.f)&(x==0.f) ? 0.f :  unsafe_atan2f_impl<DEGREE>( y, x);
+}
+
+// integer...
+/*
+  f= (2^31/pi)*(atan((1-x)/(1+x))-atan(1));
+  I=[-1+10^(-4);1.0];
+  p = fpminimax(f, [|1,3,5,7,9,11|],[|23...|],I, floating, absolute);
+ */
+
+template <int DEGREE>
+constexpr float approx_atan2i_P(float x);
+
+// degree =  3   => absolute accuracy is  6*10^6
+template <>
+constexpr float approx_atan2i_P<3>(float x) {
+  auto z = x * x;
+  return x * (-664694912.f + z * 131209024.f);
+}
+
+// degree =  5   => absolute accuracy is  4*10^5
+template <>
+constexpr float approx_atan2i_P<5>(float x) {
+  auto z = x * x;
+  return x * (-680392064.f + z * (197338400.f + z * (-54233256.f)));
+}
+
+// degree =  7   => absolute accuracy is  6*10^4
+template <>
+constexpr float approx_atan2i_P<7>(float x) {
+  auto z = x * x;
+  return x * (-683027840.f + z * (219543904.f + z * (-99981040.f + z * 26649684.f)));
+}
+
+// degree =  9   => absolute accuracy is  8000
+template <>
+constexpr float approx_atan2i_P<9>(float x) {
+  auto z = x * x;
+  return x * (-683473920.f + z * (225785056.f + z * (-123151184.f + z * (58210592.f + z * (-14249276.f)))));
+}
+
+// degree =  11   => absolute accuracy is  1000
+template <>
+constexpr float approx_atan2i_P<11>(float x) {
+  auto z = x * x;
+  return x *
+         (-683549696.f + z * (227369312.f + z * (-132297008.f + z * (79584144.f + z * (-35987016.f + z * 8010488.f)))));
+}
+
+// degree =  13   => absolute accuracy is  163
+template <>
+constexpr float approx_atan2i_P<13>(float x) {
+  auto z = x * x;
+  return x * (-683562624.f +
+              z * (227746080.f +
+                   z * (-135400128.f + z * (90460848.f + z * (-54431464.f + z * (22973256.f + z * (-4657049.f)))))));
+}
+
+template <>
+constexpr float approx_atan2i_P<15>(float x) {
+  auto z = x * x;
+  return x * (-683562624.f +
+              z * (227746080.f +
+                   z * (-135400128.f + z * (90460848.f + z * (-54431464.f + z * (22973256.f + z * (-4657049.f)))))));
+}
+
+template <int DEGREE>
+constexpr int unsafe_atan2i_impl(float y, float x) {
+  constexpr long long maxint = (long long)(std::numeric_limits<int>::max()) + 1LL;
+  constexpr int pi4 = int(maxint / 4LL);
+  constexpr int pi34 = int(3LL * maxint / 4LL);
+
+  auto r = (std::abs(x) - std::abs(y)) / (std::abs(x) + std::abs(y));
+  if (x < 0)
+    r = -r;
+
+  auto angle = (x >= 0) ? pi4 : pi34;
+  angle += int(approx_atan2i_P<DEGREE>(r));
+  // angle += int(std::round(approx_atan2i_P<DEGREE>(r)));
+
+  return (y < 0) ? -angle : angle;
+}
+
+template <int DEGREE>
+constexpr int unsafe_atan2i(float y, float x) {
+  return unsafe_atan2i_impl<DEGREE>(y, x);
+}
+
+// short (16bits)
+
+template <int DEGREE>
+constexpr float approx_atan2s_P(float x);
+
+// degree =  3   => absolute accuracy is  53
+template <>
+constexpr float approx_atan2s_P<3>(float x) {
+  auto z = x * x;
+  return x * ((-10142.439453125f) + z * 2002.0908203125f);
+}
+// degree =  5   => absolute accuracy is  7
+template <>
+constexpr float approx_atan2s_P<5>(float x) {
+  auto z = x * x;
+  return x * ((-10381.9609375f) + z * ((3011.1513671875f) + z * (-827.538330078125f)));
+}
+// degree =  7   => absolute accuracy is  2
+template <>
+constexpr float approx_atan2s_P<7>(float x) {
+  auto z = x * x;
+  return x * ((-10422.177734375f) + z * (3349.97412109375f + z * ((-1525.589599609375f) + z * 406.64190673828125f)));
+}
+// degree =  9   => absolute accuracy is 1
+template <>
+constexpr float approx_atan2s_P<9>(float x) {
+  auto z = x * x;
+  return x * ((-10428.984375f) + z * (3445.20654296875f + z * ((-1879.137939453125f) +
+                                                               z * (888.22314453125f + z * (-217.42669677734375f)))));
+}
+
+template <int DEGREE>
+constexpr short unsafe_atan2s_impl(float y, float x) {
+  constexpr int maxshort = (int)(std::numeric_limits<short>::max()) + 1;
+  constexpr short pi4 = short(maxshort / 4);
+  constexpr short pi34 = short(3 * maxshort / 4);
+
+  auto r = (std::abs(x) - std::abs(y)) / (std::abs(x) + std::abs(y));
+  if (x < 0)
+    r = -r;
+
+  auto angle = (x >= 0) ? pi4 : pi34;
+  angle += short(approx_atan2s_P<DEGREE>(r));
+
+  return (y < 0) ? -angle : angle;
+}
+
+template <int DEGREE>
+constexpr short unsafe_atan2s(float y, float x) {
+  return unsafe_atan2s_impl<DEGREE>(y, x);
+}
+
+constexpr int phi2int(float x) {
+  constexpr float p2i = ((long long)(std::numeric_limits<int>::max()) + 1LL) / M_PI;
+  return std::round(x * p2i);
+}
+
+constexpr float int2phi(int x) {
+  constexpr float i2p = M_PI / ((long long)(std::numeric_limits<int>::max()) + 1LL);
+  return float(x) * i2p;
+}
+
+constexpr double int2dphi(int x) {
+  constexpr double i2p = M_PI / ((long long)(std::numeric_limits<int>::max()) + 1LL);
+  return x * i2p;
+}
+
+constexpr short phi2short(float x) {
+  constexpr float p2i = ((int)(std::numeric_limits<short>::max()) + 1) / M_PI;
+  return std::round(x * p2i);
+}
+
+constexpr float short2phi(short x) {
+  constexpr float i2p = M_PI / ((int)(std::numeric_limits<short>::max()) + 1);
+  return float(x) * i2p;
+}
+
+#endif

--- a/src/kokkos/KokkosDataFormats/SiPixelClustersKokkos.h
+++ b/src/kokkos/KokkosDataFormats/SiPixelClustersKokkos.h
@@ -38,27 +38,25 @@ public:
   Kokkos::View<uint32_t const *, MemorySpace> c_moduleId() const { return moduleId_d; }
   Kokkos::View<uint32_t const *, MemorySpace> c_clusModuleStart() const { return clusModuleStart_d; }
 
-#ifdef TODO
   class DeviceConstView {
   public:
     // DeviceConstView() = default;
 
-    __device__ __forceinline__ uint32_t moduleStart(int i) const { return __ldg(moduleStart_ + i); }
-    __device__ __forceinline__ uint32_t clusInModule(int i) const { return __ldg(clusInModule_ + i); }
-    __device__ __forceinline__ uint32_t moduleId(int i) const { return __ldg(moduleId_ + i); }
-    __device__ __forceinline__ uint32_t clusModuleStart(int i) const { return __ldg(clusModuleStart_ + i); }
+    KOKKOS_INLINE_FUNCTION uint32_t moduleStart(int i) const { return moduleStart_[i]; }
+    KOKKOS_INLINE_FUNCTION uint32_t clusInModule(int i) const { return clusInModule_[i]; }
+    KOKKOS_INLINE_FUNCTION uint32_t moduleId(int i) const { return moduleId_[i]; }
+    KOKKOS_INLINE_FUNCTION uint32_t clusModuleStart(int i) const { return clusModuleStart_[i]; }
 
     friend SiPixelClustersKokkos;
 
-    //   private:
-    uint32_t const *moduleStart_;
-    uint32_t const *clusInModule_;
-    uint32_t const *moduleId_;
-    uint32_t const *clusModuleStart_;
+    // private:
+    Kokkos::View<uint32_t const *, MemorySpace> moduleStart_;
+    Kokkos::View<uint32_t const *, MemorySpace> clusInModule_;
+    Kokkos::View<uint32_t const *, MemorySpace> moduleId_;
+    Kokkos::View<uint32_t const *, MemorySpace> clusModuleStart_;
   };
 
-  DeviceConstView *view() const { return view_d.get(); }
-#endif
+  DeviceConstView view() const { return DeviceConstView{moduleStart_d, clusInModule_d, moduleId_d, clusModuleStart_d}; }
 
 private:
   Kokkos::View<uint32_t *, MemorySpace> moduleStart_d;   // index of the first pixel of each module

--- a/src/kokkos/KokkosDataFormats/SiPixelDigisKokkos.h
+++ b/src/kokkos/KokkosDataFormats/SiPixelDigisKokkos.h
@@ -63,17 +63,15 @@ public:
 
   class DeviceConstView {
   public:
-#ifdef TODO
-    __device__ __forceinline__ uint16_t xx(int i) const { return __ldg(xx_ + i); }
-    __device__ __forceinline__ uint16_t yy(int i) const { return __ldg(yy_ + i); }
-    __device__ __forceinline__ uint16_t adc(int i) const { return __ldg(adc_ + i); }
-    __device__ __forceinline__ uint16_t moduleInd(int i) const { return __ldg(moduleInd_ + i); }
-    __device__ __forceinline__ int32_t clus(int i) const { return __ldg(clus_ + i); }
+    KOKKOS_INLINE_FUNCTION uint16_t xx(int i) const { return xx_[i]; }
+    KOKKOS_INLINE_FUNCTION uint16_t yy(int i) const { return yy_[i]; }
+    KOKKOS_INLINE_FUNCTION uint16_t adc(int i) const { return adc_[i]; }
+    KOKKOS_INLINE_FUNCTION uint16_t moduleInd(int i) const { return moduleInd_[i]; }
+    KOKKOS_INLINE_FUNCTION int32_t clus(int i) const { return clus_[i]; }
 
     friend class SiPixelDigisKokkos;
 
     // private:
-#endif
     Kokkos::View<uint16_t const*, MemorySpace> xx_;
     Kokkos::View<uint16_t const*, MemorySpace> yy_;
     Kokkos::View<uint16_t const*, MemorySpace> adc_;

--- a/src/kokkos/KokkosDataFormats/TrackingRecHit2DKokkos.h
+++ b/src/kokkos/KokkosDataFormats/TrackingRecHit2DKokkos.h
@@ -1,0 +1,159 @@
+#ifndef CUDADataFormats_TrackingRecHit_interface_TrackingRecHit2DHeterogeneous_h
+#define CUDADataFormats_TrackingRecHit_interface_TrackingRecHit2DHeterogeneous_h
+
+#include "KokkosDataFormats/TrackingRecHit2DSOAView.h"
+#ifdef TODO
+#include "CUDADataFormats/HeterogeneousSoA.h"
+#endif
+
+template <typename MemorySpace>
+class TrackingRecHit2DKokkos {
+public:
+#ifdef TODO
+  using Hist = TrackingRecHit2DSOAView::Hist;
+#endif
+
+  TrackingRecHit2DKokkos() = default;
+
+  template <typename ExecSpace>
+  explicit TrackingRecHit2DKokkos(uint32_t nHits,
+                                  Kokkos::View<pixelCPEforGPU::ParamsOnGPU const, MemorySpace> cpeParams,
+                                  Kokkos::View<uint32_t const*, MemorySpace> hitsModuleStart,
+                                  ExecSpace const& execSpace);
+
+  ~TrackingRecHit2DKokkos() = default;
+
+  TrackingRecHit2DKokkos(const TrackingRecHit2DKokkos&) = delete;
+  TrackingRecHit2DKokkos& operator=(const TrackingRecHit2DKokkos&) = delete;
+  TrackingRecHit2DKokkos(TrackingRecHit2DKokkos&&) = default;
+  TrackingRecHit2DKokkos& operator=(TrackingRecHit2DKokkos&&) = default;
+
+#ifdef TODO
+  TrackingRecHit2DSOAView* view() { return m_view.get(); }
+  TrackingRecHit2DSOAView const* view() const { return m_view.get(); }
+
+  auto nHits() const { return m_nHits; }
+
+  auto hitsModuleStart() const { return m_hitsModuleStart; }
+  auto hitsLayerStart() { return m_hitsLayerStart; }
+  auto phiBinner() { return m_hist; }
+  auto iphi() { return m_iphi; }
+
+  // only the local coord and detector index
+  cms::cuda::host::unique_ptr<float[]> localCoordToHostAsync(cudaStream_t stream) const;
+  cms::cuda::host::unique_ptr<uint16_t[]> detIndexToHostAsync(cudaStream_t stream) const;
+  cms::cuda::host::unique_ptr<uint32_t[]> hitsModuleStartToHostAsync(cudaStream_t stream) const;
+#endif
+
+private:
+#ifdef TODO
+  static constexpr uint32_t n16 = 4;
+  static constexpr uint32_t n32 = 9;
+  static_assert(sizeof(uint32_t) == sizeof(float));  // just stating the obvious
+
+  unique_ptr<uint16_t[]> m_store16;  //!
+  unique_ptr<float[]> m_store32;     //!
+
+  unique_ptr<TrackingRecHit2DSOAView::Hist> m_HistStore;                        //!
+  unique_ptr<TrackingRecHit2DSOAView::AverageGeometry> m_AverageGeometryStore;  //!
+
+  unique_ptr<TrackingRecHit2DSOAView> m_view;  //!
+#endif
+
+  uint32_t m_nHits;
+  Kokkos::View<uint32_t const*, MemorySpace> m_hitsModuleStart;  // needed for legacy, this is on GPU!
+#ifdef TODO
+
+  // needed as kernel params...
+  Hist* m_hist;
+  uint32_t* m_hitsLayerStart;
+  int16_t* m_iphi;
+#endif
+};
+
+template <typename MemorySpace>
+template <typename ExecSpace>
+TrackingRecHit2DKokkos<MemorySpace>::TrackingRecHit2DKokkos(uint32_t nHits,
+                                                            Kokkos::View<pixelCPEforGPU::ParamsOnGPU const, MemorySpace> cpeParams,
+                                                            Kokkos::View<uint32_t const*, MemorySpace>  hitsModuleStart,
+                                                            ExecSpace const& execSpace)
+: m_nHits(nHits), m_hitsModuleStart(std::move(hitsModuleStart)) {
+#ifdef TODO
+  auto view = Traits::template make_host_unique<TrackingRecHit2DSOAView>(stream);
+
+  view->m_nHits = nHits;
+  m_view = Traits::template make_device_unique<TrackingRecHit2DSOAView>(stream);
+  m_AverageGeometryStore = Traits::template make_device_unique<TrackingRecHit2DSOAView::AverageGeometry>(stream);
+  view->m_averageGeometry = m_AverageGeometryStore.get();
+  view->m_cpeParams = cpeParams;
+  view->m_hitsModuleStart = hitsModuleStart;
+
+  // if empy do not bother
+  if (0 == nHits) {
+    if
+#ifndef __CUDACC__
+        constexpr
+#endif
+        (std::is_same<Traits, cudaCompat::GPUTraits>::value) {
+      cms::cuda::copyAsync(m_view, view, stream);
+    } else {
+      m_view.reset(view.release());  // NOLINT: std::move() breaks CUDA version
+    }
+    return;
+  }
+
+  // the single arrays are not 128 bit alligned...
+  // the hits are actually accessed in order only in building
+  // if ordering is relevant they may have to be stored phi-ordered by layer or so
+  // this will break 1to1 correspondence with cluster and module locality
+  // so unless proven VERY inefficient we keep it ordered as generated
+  m_store16 = Traits::template make_device_unique<uint16_t[]>(nHits * n16, stream);
+  m_store32 = Traits::template make_device_unique<float[]>(nHits * n32 + 11, stream);
+  m_HistStore = Traits::template make_device_unique<TrackingRecHit2DSOAView::Hist>(stream);
+
+  auto get16 = [&](int i) { return m_store16.get() + i * nHits; };
+  auto get32 = [&](int i) { return m_store32.get() + i * nHits; };
+
+  // copy all the pointers
+  m_hist = view->m_hist = m_HistStore.get();
+
+  view->m_xl = get32(0);
+  view->m_yl = get32(1);
+  view->m_xerr = get32(2);
+  view->m_yerr = get32(3);
+
+  view->m_xg = get32(4);
+  view->m_yg = get32(5);
+  view->m_zg = get32(6);
+  view->m_rg = get32(7);
+
+  m_iphi = view->m_iphi = reinterpret_cast<int16_t*>(get16(0));
+
+  view->m_charge = reinterpret_cast<int32_t*>(get32(8));
+  view->m_xsize = reinterpret_cast<int16_t*>(get16(2));
+  view->m_ysize = reinterpret_cast<int16_t*>(get16(3));
+  view->m_detInd = get16(1);
+
+  m_hitsLayerStart = view->m_hitsLayerStart = reinterpret_cast<uint32_t*>(get32(n32));
+
+  // transfer view
+  if
+#ifndef __CUDACC__
+      constexpr
+#endif
+      (std::is_same<Traits, cudaCompat::GPUTraits>::value) {
+    cms::cuda::copyAsync(m_view, view, stream);
+  } else {
+    m_view.reset(view.release());  // NOLINT: std::move() breaks CUDA version
+  }
+#endif
+}
+
+#ifdef TODO
+using TrackingRecHit2DGPU = TrackingRecHit2DHeterogeneous<cudaCompat::GPUTraits>;
+using TrackingRecHit2DCUDA = TrackingRecHit2DHeterogeneous<cudaCompat::GPUTraits>;
+using TrackingRecHit2DCPU = TrackingRecHit2DHeterogeneous<cudaCompat::CPUTraits>;
+using TrackingRecHit2DHost = TrackingRecHit2DHeterogeneous<cudaCompat::HostTraits>;
+#endif
+
+#endif  // CUDADataFormats_TrackingRecHit_interface_TrackingRecHit2DHeterogeneous_h

--- a/src/kokkos/KokkosDataFormats/TrackingRecHit2DSOAView.h
+++ b/src/kokkos/KokkosDataFormats/TrackingRecHit2DSOAView.h
@@ -1,7 +1,7 @@
 #ifndef CUDADataFormats_TrackingRecHit_interface_TrackingRecHit2DSOAView_h
 #define CUDADataFormats_TrackingRecHit_interface_TrackingRecHit2DSOAView_h
 
-#include <cuda_runtime.h>
+#include <Kokkos_Core.hpp>
 
 #include "KokkosDataFormats/gpuClusteringConstants.h"
 #ifdef TODO
@@ -13,8 +13,6 @@ namespace pixelCPEforGPU {
   struct ParamsOnGPU;
 }
 
-#ifdef TODO
-template <typename MemorySpace>
 class TrackingRecHit2DSOAView {
 public:
   static constexpr uint32_t maxHits() { return gpuClustering::MaxNumClusters; }
@@ -27,60 +25,59 @@ public:
   using AverageGeometry = phase1PixelTopology::AverageGeometry;
 
   template <typename>
-  friend class TrackingRecHit2DHeterogeneous;
+  friend class TrackingRecHit2DKokkos;
 
-  __device__ __forceinline__ uint32_t nHits() const { return m_nHits; }
+  KOKKOS_INLINE_FUNCTION uint32_t nHits() const { return m_nHits; }
 
-  __device__ __forceinline__ float& xLocal(int i) { return m_xl[i]; }
-  __device__ __forceinline__ float xLocal(int i) const { return __ldg(m_xl + i); }
-  __device__ __forceinline__ float& yLocal(int i) { return m_yl[i]; }
-  __device__ __forceinline__ float yLocal(int i) const { return __ldg(m_yl + i); }
+  KOKKOS_INLINE_FUNCTION float& xLocal(int i) { return m_xl[i]; }
+  KOKKOS_INLINE_FUNCTION float xLocal(int i) const { return m_xl[i]; }
+  KOKKOS_INLINE_FUNCTION float& yLocal(int i) { return m_yl[i]; }
+  KOKKOS_INLINE_FUNCTION float yLocal(int i) const { return m_yl[i]; }
 
-  __device__ __forceinline__ float& xerrLocal(int i) { return m_xerr[i]; }
-  __device__ __forceinline__ float xerrLocal(int i) const { return __ldg(m_xerr + i); }
-  __device__ __forceinline__ float& yerrLocal(int i) { return m_yerr[i]; }
-  __device__ __forceinline__ float yerrLocal(int i) const { return __ldg(m_yerr + i); }
+  KOKKOS_INLINE_FUNCTION float& xerrLocal(int i) { return m_xerr[i]; }
+  KOKKOS_INLINE_FUNCTION float xerrLocal(int i) const { return m_xerr[i]; }
+  KOKKOS_INLINE_FUNCTION float& yerrLocal(int i) { return m_yerr[i]; }
+  KOKKOS_INLINE_FUNCTION float yerrLocal(int i) const { return m_yerr[i]; }
 
-  __device__ __forceinline__ float& xGlobal(int i) { return m_xg[i]; }
-  __device__ __forceinline__ float xGlobal(int i) const { return __ldg(m_xg + i); }
-  __device__ __forceinline__ float& yGlobal(int i) { return m_yg[i]; }
-  __device__ __forceinline__ float yGlobal(int i) const { return __ldg(m_yg + i); }
-  __device__ __forceinline__ float& zGlobal(int i) { return m_zg[i]; }
-  __device__ __forceinline__ float zGlobal(int i) const { return __ldg(m_zg + i); }
-  __device__ __forceinline__ float& rGlobal(int i) { return m_rg[i]; }
-  __device__ __forceinline__ float rGlobal(int i) const { return __ldg(m_rg + i); }
+  KOKKOS_INLINE_FUNCTION float& xGlobal(int i) { return m_xg[i]; }
+  KOKKOS_INLINE_FUNCTION float xGlobal(int i) const { return m_xg[i]; }
+  KOKKOS_INLINE_FUNCTION float& yGlobal(int i) { return m_yg[i]; }
+  KOKKOS_INLINE_FUNCTION float yGlobal(int i) const { return m_yg[i]; }
+  KOKKOS_INLINE_FUNCTION float& zGlobal(int i) { return m_zg[i]; }
+  KOKKOS_INLINE_FUNCTION float zGlobal(int i) const { return m_zg[i]; }
+  KOKKOS_INLINE_FUNCTION float& rGlobal(int i) { return m_rg[i]; }
+  KOKKOS_INLINE_FUNCTION float rGlobal(int i) const { return m_rg[i]; }
 
-  __device__ __forceinline__ int16_t& iphi(int i) { return m_iphi[i]; }
-  __device__ __forceinline__ int16_t iphi(int i) const { return __ldg(m_iphi + i); }
+  KOKKOS_INLINE_FUNCTION int16_t& iphi(int i) { return m_iphi[i]; }
+  KOKKOS_INLINE_FUNCTION int16_t iphi(int i) const { return m_iphi[i]; }
 
-  __device__ __forceinline__ int32_t& charge(int i) { return m_charge[i]; }
-  __device__ __forceinline__ int32_t charge(int i) const { return __ldg(m_charge + i); }
-  __device__ __forceinline__ int16_t& clusterSizeX(int i) { return m_xsize[i]; }
-  __device__ __forceinline__ int16_t clusterSizeX(int i) const { return __ldg(m_xsize + i); }
-  __device__ __forceinline__ int16_t& clusterSizeY(int i) { return m_ysize[i]; }
-  __device__ __forceinline__ int16_t clusterSizeY(int i) const { return __ldg(m_ysize + i); }
-  __device__ __forceinline__ uint16_t& detectorIndex(int i) { return m_detInd[i]; }
-  __device__ __forceinline__ uint16_t detectorIndex(int i) const { return __ldg(m_detInd + i); }
+  KOKKOS_INLINE_FUNCTION int32_t& charge(int i) { return m_charge[i]; }
+  KOKKOS_INLINE_FUNCTION int32_t charge(int i) const { return m_charge[i]; }
+  KOKKOS_INLINE_FUNCTION int16_t& clusterSizeX(int i) { return m_xsize[i]; }
+  KOKKOS_INLINE_FUNCTION int16_t clusterSizeX(int i) const { return m_xsize[i]; }
+  KOKKOS_INLINE_FUNCTION int16_t& clusterSizeY(int i) { return m_ysize[i]; }
+  KOKKOS_INLINE_FUNCTION int16_t clusterSizeY(int i) const { return m_ysize[i]; }
+  KOKKOS_INLINE_FUNCTION uint16_t& detectorIndex(int i) { return m_detInd[i]; }
+  KOKKOS_INLINE_FUNCTION uint16_t detectorIndex(int i) const { return m_detInd[i]; }
 
-  __device__ __forceinline__ pixelCPEforGPU::ParamsOnGPU const& cpeParams() const { return *m_cpeParams; }
+  KOKKOS_INLINE_FUNCTION pixelCPEforGPU::ParamsOnGPU const& cpeParams() const { return *m_cpeParams; }
 
-  __device__ __forceinline__ uint32_t hitsModuleStart(int i) const { return __ldg(m_hitsModuleStart + i); }
+  KOKKOS_INLINE_FUNCTION uint32_t hitsModuleStart(int i) const { return m_hitsModuleStart[i]; }
 
-  __device__ __forceinline__ uint32_t* hitsLayerStart() { return m_hitsLayerStart; }
-  __device__ __forceinline__ uint32_t const* hitsLayerStart() const { return m_hitsLayerStart; }
+  KOKKOS_INLINE_FUNCTION uint32_t* hitsLayerStart() { return m_hitsLayerStart; }
+  KOKKOS_INLINE_FUNCTION uint32_t const* hitsLayerStart() const { return m_hitsLayerStart; }
 
 #ifdef TODO
-  __device__ __forceinline__ Hist& phiBinner() { return *m_hist; }
-  __device__ __forceinline__ Hist const& phiBinner() const { return *m_hist; }
+  KOKKOS_INLINE_FUNCTION Hist& phiBinner() { return *m_hist; }
+  KOKKOS_INLINE_FUNCTION Hist const& phiBinner() const { return *m_hist; }
 #endif
 
-  __device__ __forceinline__ AverageGeometry& averageGeometry() { return *m_averageGeometry; }
-  __device__ __forceinline__ AverageGeometry const& averageGeometry() const { return *m_averageGeometry; }
+  KOKKOS_INLINE_FUNCTION AverageGeometry& averageGeometry() { return *m_averageGeometry; }
+  KOKKOS_INLINE_FUNCTION AverageGeometry const& averageGeometry() const { return *m_averageGeometry; }
 
 private:
   // local coord
-  Kokkos::View<float *, MemorySpace> m_xl;
-  Kokkos::View<float *, MemorySpace> m_yl;
+  float *m_xl, *m_yl;
   float *m_xerr, *m_yerr;
 
   // global coord
@@ -106,6 +103,5 @@ private:
 
   uint32_t m_nHits;
 };
-#endif
 
 #endif

--- a/src/kokkos/KokkosDataFormats/TrackingRecHit2DSOAView.h
+++ b/src/kokkos/KokkosDataFormats/TrackingRecHit2DSOAView.h
@@ -1,0 +1,111 @@
+#ifndef CUDADataFormats_TrackingRecHit_interface_TrackingRecHit2DSOAView_h
+#define CUDADataFormats_TrackingRecHit_interface_TrackingRecHit2DSOAView_h
+
+#include <cuda_runtime.h>
+
+#include "KokkosDataFormats/gpuClusteringConstants.h"
+#ifdef TODO
+#include "CUDACore/HistoContainer.h"
+#endif
+#include "Geometry/phase1PixelTopology.h"
+
+namespace pixelCPEforGPU {
+  struct ParamsOnGPU;
+}
+
+#ifdef TODO
+template <typename MemorySpace>
+class TrackingRecHit2DSOAView {
+public:
+  static constexpr uint32_t maxHits() { return gpuClustering::MaxNumClusters; }
+  using hindex_type = uint16_t;  // if above is <=2^16
+
+#ifdef TODO
+  using Hist = HistoContainer<int16_t, 128, gpuClustering::MaxNumClusters, 8 * sizeof(int16_t), uint16_t, 10>;
+#endif
+
+  using AverageGeometry = phase1PixelTopology::AverageGeometry;
+
+  template <typename>
+  friend class TrackingRecHit2DHeterogeneous;
+
+  __device__ __forceinline__ uint32_t nHits() const { return m_nHits; }
+
+  __device__ __forceinline__ float& xLocal(int i) { return m_xl[i]; }
+  __device__ __forceinline__ float xLocal(int i) const { return __ldg(m_xl + i); }
+  __device__ __forceinline__ float& yLocal(int i) { return m_yl[i]; }
+  __device__ __forceinline__ float yLocal(int i) const { return __ldg(m_yl + i); }
+
+  __device__ __forceinline__ float& xerrLocal(int i) { return m_xerr[i]; }
+  __device__ __forceinline__ float xerrLocal(int i) const { return __ldg(m_xerr + i); }
+  __device__ __forceinline__ float& yerrLocal(int i) { return m_yerr[i]; }
+  __device__ __forceinline__ float yerrLocal(int i) const { return __ldg(m_yerr + i); }
+
+  __device__ __forceinline__ float& xGlobal(int i) { return m_xg[i]; }
+  __device__ __forceinline__ float xGlobal(int i) const { return __ldg(m_xg + i); }
+  __device__ __forceinline__ float& yGlobal(int i) { return m_yg[i]; }
+  __device__ __forceinline__ float yGlobal(int i) const { return __ldg(m_yg + i); }
+  __device__ __forceinline__ float& zGlobal(int i) { return m_zg[i]; }
+  __device__ __forceinline__ float zGlobal(int i) const { return __ldg(m_zg + i); }
+  __device__ __forceinline__ float& rGlobal(int i) { return m_rg[i]; }
+  __device__ __forceinline__ float rGlobal(int i) const { return __ldg(m_rg + i); }
+
+  __device__ __forceinline__ int16_t& iphi(int i) { return m_iphi[i]; }
+  __device__ __forceinline__ int16_t iphi(int i) const { return __ldg(m_iphi + i); }
+
+  __device__ __forceinline__ int32_t& charge(int i) { return m_charge[i]; }
+  __device__ __forceinline__ int32_t charge(int i) const { return __ldg(m_charge + i); }
+  __device__ __forceinline__ int16_t& clusterSizeX(int i) { return m_xsize[i]; }
+  __device__ __forceinline__ int16_t clusterSizeX(int i) const { return __ldg(m_xsize + i); }
+  __device__ __forceinline__ int16_t& clusterSizeY(int i) { return m_ysize[i]; }
+  __device__ __forceinline__ int16_t clusterSizeY(int i) const { return __ldg(m_ysize + i); }
+  __device__ __forceinline__ uint16_t& detectorIndex(int i) { return m_detInd[i]; }
+  __device__ __forceinline__ uint16_t detectorIndex(int i) const { return __ldg(m_detInd + i); }
+
+  __device__ __forceinline__ pixelCPEforGPU::ParamsOnGPU const& cpeParams() const { return *m_cpeParams; }
+
+  __device__ __forceinline__ uint32_t hitsModuleStart(int i) const { return __ldg(m_hitsModuleStart + i); }
+
+  __device__ __forceinline__ uint32_t* hitsLayerStart() { return m_hitsLayerStart; }
+  __device__ __forceinline__ uint32_t const* hitsLayerStart() const { return m_hitsLayerStart; }
+
+#ifdef TODO
+  __device__ __forceinline__ Hist& phiBinner() { return *m_hist; }
+  __device__ __forceinline__ Hist const& phiBinner() const { return *m_hist; }
+#endif
+
+  __device__ __forceinline__ AverageGeometry& averageGeometry() { return *m_averageGeometry; }
+  __device__ __forceinline__ AverageGeometry const& averageGeometry() const { return *m_averageGeometry; }
+
+private:
+  // local coord
+  Kokkos::View<float *, MemorySpace> m_xl;
+  Kokkos::View<float *, MemorySpace> m_yl;
+  float *m_xerr, *m_yerr;
+
+  // global coord
+  float *m_xg, *m_yg, *m_zg, *m_rg;
+  int16_t* m_iphi;
+
+  // cluster properties
+  int32_t* m_charge;
+  int16_t* m_xsize;
+  int16_t* m_ysize;
+  uint16_t* m_detInd;
+
+  // supporting objects
+  AverageGeometry* m_averageGeometry;  // owned (corrected for beam spot: not sure where to host it otherwise)
+  pixelCPEforGPU::ParamsOnGPU const* m_cpeParams;  // forwarded from setup, NOT owned
+  uint32_t const* m_hitsModuleStart;               // forwarded from clusters
+
+  uint32_t* m_hitsLayerStart;
+
+#ifdef TODO
+  Hist* m_hist;
+#endif
+
+  uint32_t m_nHits;
+};
+#endif
+
+#endif

--- a/src/kokkos/plugin-SiPixelRecHits/kokkos/PixelRecHits.cc
+++ b/src/kokkos/plugin-SiPixelRecHits/kokkos/PixelRecHits.cc
@@ -1,0 +1,98 @@
+// C++ headers
+#include <algorithm>
+#include <numeric>
+
+// CMSSW headers
+#ifdef TODO
+#include "plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.h"  // !
+#include "plugin-SiPixelClusterizer/gpuClusteringConstants.h"               // !
+#endif
+
+#include "CondFormats/pixelCPEforGPU.h"
+
+#include "PixelRecHits.h"
+#include "gpuPixelRecHits.h"
+
+#ifdef TODO
+namespace {
+  __global__ void setHitsLayerStart(uint32_t const* __restrict__ hitsModuleStart,
+                                    pixelCPEforGPU::ParamsOnGPU const* cpeParams,
+                                    uint32_t* hitsLayerStart) {
+    auto i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    assert(0 == hitsModuleStart[0]);
+
+    if (i < 11) {
+      hitsLayerStart[i] = hitsModuleStart[cpeParams->layerGeometry().layerStart[i]];
+#ifdef GPU_DEBUG
+      printf("LayerStart %d %d: %d\n", i, cpeParams->layerGeometry().layerStart[i], hitsLayerStart[i]);
+#endif
+    }
+  }
+}  // namespace
+#endif
+
+namespace KOKKOS_NAMESPACE {
+
+  namespace pixelgpudetails {
+
+    TrackingRecHit2DKokkos<KokkosExecSpace> PixelRecHitGPUKernel::makeHitsAsync(
+        SiPixelDigisKokkos<KokkosExecSpace> const& digis_d,
+        SiPixelClustersKokkos<KokkosExecSpace> const& clusters_d,
+        BeamSpotKokkos<KokkosExecSpace> const& bs_d,
+        Kokkos::View<pixelCPEforGPU::ParamsOnGPU const, KokkosExecSpace> const& cpeParams,
+        KokkosExecSpace const& execSpace) const {
+      auto nHits = clusters_d.nClusters();
+      TrackingRecHit2DKokkos<KokkosExecSpace> hits_d(nHits, cpeParams, clusters_d.clusModuleStart(), execSpace);
+
+      auto nDigis = digis_d.nDigis();
+      auto digisView = digis_d.view();
+      auto clustersView = clusters_d.view();
+      auto hitsView = hits_d.view();
+
+      using TeamPolicy = Kokkos::TeamPolicy<KokkosExecSpace>;
+      using MemberType = TeamPolicy::member_type;
+
+#ifdef GPU_DEBUG
+      std::cout << "launching getHits kernel for " << digis.nModules() << " teams" << std::endl;
+#endif
+
+      if (digis_d.nModules() > 0) {  // protect from empty events
+        // one team for each active module (with digis)
+        TeamPolicy policy(execSpace, digis_d.nModules(), 128);  // TODO: see if can use Kokkos::AUTO()
+        Kokkos::parallel_for(
+            policy.set_scratch_size(0, Kokkos::PerTeam(sizeof(pixelCPEforGPU::ClusParams))),
+            KOKKOS_LAMBDA(MemberType const& teamMember) {
+              gpuPixelRecHits::getHits(
+                  cpeParams.data(), bs_d.data(), digisView, nDigis, clustersView, hitsView, teamMember);
+            });
+      }
+
+#ifdef GPU_DEBUG
+      execSpace.fence();
+#endif
+
+#ifdef TODO
+      // assuming full warp of threads is better than a smaller number...
+      if (nHits) {
+        setHitsLayerStart<<<1, 32, 0, stream>>>(clusters_d.clusModuleStart(), cpeParams, hits_d.hitsLayerStart());
+        cudaCheck(cudaGetLastError());
+      }
+
+      if (nHits) {
+        auto hws = cms::cuda::make_device_unique<uint8_t[]>(TrackingRecHit2DSOAView::Hist::wsSize(), stream);
+        cms::cuda::fillManyFromVector(
+            hits_d.phiBinner(), hws.get(), 10, hits_d.iphi(), hits_d.hitsLayerStart(), nHits, 256, stream);
+        cudaCheck(cudaGetLastError());
+      }
+
+#ifdef GPU_DEBUG
+      cudaDeviceSynchronize();
+      cudaCheck(cudaGetLastError());
+#endif
+#endif
+      return hits_d;
+    }
+
+  }  // namespace pixelgpudetails
+}  // namespace KOKKOS_NAMESPACE

--- a/src/kokkos/plugin-SiPixelRecHits/kokkos/PixelRecHits.h
+++ b/src/kokkos/plugin-SiPixelRecHits/kokkos/PixelRecHits.h
@@ -1,0 +1,35 @@
+#ifndef RecoLocalTracker_SiPixelRecHits_plugins_PixelRecHits_h
+#define RecoLocalTracker_SiPixelRecHits_plugins_PixelRecHits_h
+
+#include <cstdint>
+
+#include "KokkosCore/kokkosConfig.h"
+
+#include "KokkosDataFormats/BeamSpotKokkos.h"
+#include "KokkosDataFormats/SiPixelClustersKokkos.h"
+#include "KokkosDataFormats/SiPixelDigisKokkos.h"
+#include "KokkosDataFormats/TrackingRecHit2DKokkos.h"
+
+namespace KOKKOS_NAMESPACE {
+  namespace pixelgpudetails {
+    class PixelRecHitGPUKernel {
+    public:
+      PixelRecHitGPUKernel() = default;
+      ~PixelRecHitGPUKernel() = default;
+
+      PixelRecHitGPUKernel(const PixelRecHitGPUKernel&) = delete;
+      PixelRecHitGPUKernel(PixelRecHitGPUKernel&&) = delete;
+      PixelRecHitGPUKernel& operator=(const PixelRecHitGPUKernel&) = delete;
+      PixelRecHitGPUKernel& operator=(PixelRecHitGPUKernel&&) = delete;
+
+      TrackingRecHit2DKokkos<KokkosExecSpace> makeHitsAsync(
+          SiPixelDigisKokkos<KokkosExecSpace> const& digis_d,
+          SiPixelClustersKokkos<KokkosExecSpace> const& clusters_d,
+          BeamSpotKokkos<KokkosExecSpace> const& bs_d,
+          Kokkos::View<pixelCPEforGPU::ParamsOnGPU const, KokkosExecSpace> const& cpeParams,
+          KokkosExecSpace const& execSpace) const;
+    };
+  }  // namespace pixelgpudetails
+}  // namespace KOKKOS_NAMESPACE
+
+#endif  // RecoLocalTracker_SiPixelRecHits_plugins_PixelRecHits_h

--- a/src/kokkos/plugin-SiPixelRecHits/kokkos/SiPixelRecHitKokkos.cc
+++ b/src/kokkos/plugin-SiPixelRecHits/kokkos/SiPixelRecHitKokkos.cc
@@ -1,0 +1,71 @@
+#include <cuda_runtime.h>
+
+#include "KokkosDataFormats/BeamSpotKokkos.h"
+#include "KokkosDataFormats/SiPixelClustersKokkos.h"
+#include "KokkosDataFormats/SiPixelDigisKokkos.h"
+#ifdef TODO
+#include "CUDADataFormats/TrackingRecHit2DCUDA.h"
+#endif
+#include "Framework/EventSetup.h"
+#include "Framework/Event.h"
+#include "Framework/PluginFactory.h"
+#include "Framework/EDProducer.h"
+#include "CondFormats/PixelCPEFast.h"
+
+#ifdef TODO
+#include "PixelRecHits.h"  // TODO : spit product from kernel
+#endif
+
+#include "KokkosCore/kokkosConfig.h"
+
+namespace KOKKOS_NAMESPACE {
+  class SiPixelRecHitKokkos : public edm::EDProducer {
+  public:
+    explicit SiPixelRecHitKokkos(edm::ProductRegistry& reg);
+    ~SiPixelRecHitKokkos() override = default;
+
+  private:
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+    // The mess with inputs will be cleaned up when migrating to the new framework
+    edm::EDGetTokenT<BeamSpotKokkos<KokkosExecSpace>> tBeamSpot;
+    edm::EDGetTokenT<SiPixelClustersKokkos<KokkosExecSpace>> token_;
+    edm::EDGetTokenT<SiPixelDigisKokkos<KokkosExecSpace>> tokenDigi_;
+
+#ifdef TODO
+    edm::EDPutTokenT<cms::cuda::Product<TrackingRecHit2DCUDA>> tokenHit_;
+
+    pixelgpudetails::PixelRecHitGPUKernel gpuAlgo_;
+#endif
+  };
+
+  SiPixelRecHitKokkos::SiPixelRecHitKokkos(edm::ProductRegistry& reg)
+      : tBeamSpot(reg.consumes<BeamSpotKokkos<KokkosExecSpace>>()),
+        token_(reg.consumes<SiPixelClustersKokkos<KokkosExecSpace>>()),
+        tokenDigi_(reg.consumes<SiPixelDigisKokkos<KokkosExecSpace>>())
+#ifdef TODO
+        tokenHit_(reg.produces<cms::cuda::Product<TrackingRecHit2DCUDA>>())
+#endif
+  {}
+
+  void SiPixelRecHitKokkos::produce(edm::Event& iEvent, const edm::EventSetup& es) {
+    auto const& fcpe = es.get<PixelCPEFast<KokkosExecSpace>>();
+
+    auto const& bs = iEvent.get(tBeamSpot);
+    auto const& clusters = iEvent.get(token_);
+    auto const& digis = iEvent.get(tokenDigi_);
+
+#ifdef TODO
+    auto nHits = clusters.nClusters();
+    if (nHits >= TrackingRecHit2DSOAView::maxHits()) {
+      std::cout << "Clusters/Hits Overflow " << nHits << " >= " << TrackingRecHit2DSOAView::maxHits() << std::endl;
+    }
+
+    ctx.emplace(iEvent,
+                tokenHit_,
+                gpuAlgo_.makeHitsAsync(digis, clusters, bs, fcpe.getGPUProductAsync(ctx.stream()), ctx.stream()));
+#endif
+  }
+}  // namespace KOKKOS_NAMESPACE
+
+DEFINE_FWK_KOKKOS_MODULE(SiPixelRecHitKokkos);

--- a/src/kokkos/plugin-SiPixelRecHits/kokkos/SiPixelRecHitKokkos.cc
+++ b/src/kokkos/plugin-SiPixelRecHits/kokkos/SiPixelRecHitKokkos.cc
@@ -3,18 +3,14 @@
 #include "KokkosDataFormats/BeamSpotKokkos.h"
 #include "KokkosDataFormats/SiPixelClustersKokkos.h"
 #include "KokkosDataFormats/SiPixelDigisKokkos.h"
-#ifdef TODO
-#include "CUDADataFormats/TrackingRecHit2DCUDA.h"
-#endif
+#include "KokkosDataFormats/TrackingRecHit2DKokkos.h"
 #include "Framework/EventSetup.h"
 #include "Framework/Event.h"
 #include "Framework/PluginFactory.h"
 #include "Framework/EDProducer.h"
 #include "CondFormats/PixelCPEFast.h"
 
-#ifdef TODO
 #include "PixelRecHits.h"  // TODO : spit product from kernel
-#endif
 
 #include "KokkosCore/kokkosConfig.h"
 
@@ -32,21 +28,16 @@ namespace KOKKOS_NAMESPACE {
     edm::EDGetTokenT<SiPixelClustersKokkos<KokkosExecSpace>> token_;
     edm::EDGetTokenT<SiPixelDigisKokkos<KokkosExecSpace>> tokenDigi_;
 
-#ifdef TODO
-    edm::EDPutTokenT<cms::cuda::Product<TrackingRecHit2DCUDA>> tokenHit_;
+    edm::EDPutTokenT<TrackingRecHit2DKokkos<KokkosExecSpace>> tokenHit_;
 
     pixelgpudetails::PixelRecHitGPUKernel gpuAlgo_;
-#endif
   };
 
   SiPixelRecHitKokkos::SiPixelRecHitKokkos(edm::ProductRegistry& reg)
       : tBeamSpot(reg.consumes<BeamSpotKokkos<KokkosExecSpace>>()),
         token_(reg.consumes<SiPixelClustersKokkos<KokkosExecSpace>>()),
-        tokenDigi_(reg.consumes<SiPixelDigisKokkos<KokkosExecSpace>>())
-#ifdef TODO
-        tokenHit_(reg.produces<cms::cuda::Product<TrackingRecHit2DCUDA>>())
-#endif
-  {}
+        tokenDigi_(reg.consumes<SiPixelDigisKokkos<KokkosExecSpace>>()),
+        tokenHit_(reg.produces<TrackingRecHit2DKokkos<KokkosExecSpace>>()) {}
 
   void SiPixelRecHitKokkos::produce(edm::Event& iEvent, const edm::EventSetup& es) {
     auto const& fcpe = es.get<PixelCPEFast<KokkosExecSpace>>();
@@ -55,16 +46,12 @@ namespace KOKKOS_NAMESPACE {
     auto const& clusters = iEvent.get(token_);
     auto const& digis = iEvent.get(tokenDigi_);
 
-#ifdef TODO
     auto nHits = clusters.nClusters();
     if (nHits >= TrackingRecHit2DSOAView::maxHits()) {
       std::cout << "Clusters/Hits Overflow " << nHits << " >= " << TrackingRecHit2DSOAView::maxHits() << std::endl;
     }
 
-    ctx.emplace(iEvent,
-                tokenHit_,
-                gpuAlgo_.makeHitsAsync(digis, clusters, bs, fcpe.getGPUProductAsync(ctx.stream()), ctx.stream()));
-#endif
+    iEvent.emplace(tokenHit_, gpuAlgo_.makeHitsAsync(digis, clusters, bs, fcpe.params(), KokkosExecSpace()));
   }
 }  // namespace KOKKOS_NAMESPACE
 

--- a/src/kokkos/plugin-SiPixelRecHits/kokkos/gpuPixelRecHits.h
+++ b/src/kokkos/plugin-SiPixelRecHits/kokkos/gpuPixelRecHits.h
@@ -1,0 +1,218 @@
+#ifndef RecoLocalTracker_SiPixelRecHits_plugins_gpuPixelRecHits_h
+#define RecoLocalTracker_SiPixelRecHits_plugins_gpuPixelRecHits_h
+
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+
+#include "KokkosDataFormats/BeamSpotKokkos.h"
+#include "KokkosDataFormats/TrackingRecHit2DKokkos.h"
+#include "CondFormats/pixelCPEforGPU.h"
+#include "DataFormats/approx_atan2.h"
+
+namespace KOKKOS_NAMESPACE {
+  namespace gpuPixelRecHits {
+    KOKKOS_INLINE_FUNCTION void getHits(pixelCPEforGPU::ParamsOnGPU const* __restrict__ cpeParams,
+                                        BeamSpotPOD const* __restrict__ bs,
+                                        SiPixelDigisKokkos<KokkosExecSpace>::DeviceConstView pdigis,
+                                        int numElements,
+                                        SiPixelClustersKokkos<KokkosExecSpace>::DeviceConstView pclusters,
+                                        TrackingRecHit2DSOAView* hits,
+                                        Kokkos::TeamPolicy<KokkosExecSpace>::member_type const& teamMember) {
+      // FIXME
+      // the compiler seems NOT to optimize loads from views (even in a simple test case)
+      // The whole gimnastic here of copying or not is a pure heuristic exercise that seems to produce the fastest code with the above signature
+      // not using views (passing a gazzilion of array pointers) seems to produce the fastest code (but it is harder to mantain)
+
+      assert(hits);
+
+      auto const& digis = pdigis;
+      auto const& clusters = pclusters;
+
+      // copy average geometry corrected by beamspot . FIXME (move it somewhere else???)
+      if (0 == teamMember.league_rank()) {
+        // this is refence in CUDA, but that leads to TeamThreadRange to not compile because the lambda itself is const
+        auto agc = &hits->averageGeometry();
+        auto const& ag = cpeParams->averageGeometry();
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(teamMember, TrackingRecHit2DSOAView::AverageGeometry::numberOfLaddersInBarrel),
+            [=](int il) {
+              agc->ladderZ[il] = ag.ladderZ[il] - bs->z;
+              agc->ladderX[il] = ag.ladderX[il] - bs->x;
+              agc->ladderY[il] = ag.ladderY[il] - bs->y;
+              agc->ladderR[il] = sqrt(agc->ladderX[il] * agc->ladderX[il] + agc->ladderY[il] * agc->ladderY[il]);
+              agc->ladderMinZ[il] = ag.ladderMinZ[il] - bs->z;
+              agc->ladderMaxZ[il] = ag.ladderMaxZ[il] - bs->z;
+            });
+        if (0 == teamMember.team_rank()) {
+          agc->endCapZ[0] = ag.endCapZ[0] - bs->z;
+          agc->endCapZ[1] = ag.endCapZ[1] - bs->z;
+          //         printf("endcapZ %f %f\n",agc.endCapZ[0],agc.endCapZ[1]);
+        }
+      }
+
+      // to be moved in common namespace...
+      constexpr uint16_t InvId = 9999;  // must be > MaxNumModules
+      constexpr int32_t MaxHitsInIter = pixelCPEforGPU::MaxHitsInIter;
+
+      using ClusParams = pixelCPEforGPU::ClusParams;
+
+      // as usual one block per module
+      ClusParams* clusParams = reinterpret_cast<ClusParams*>(teamMember.team_shmem().get_shmem(sizeof(ClusParams)));
+
+      auto me = clusters.moduleId(teamMember.league_rank());
+      int nclus = clusters.clusInModule(me);
+
+      if (0 == nclus)
+        return;
+
+#ifdef GPU_DEBUG
+      if (teamMember.team_rank() == 0) {
+        auto k = first;
+        while (digis.moduleInd(k) == InvId)
+          ++k;
+        assert(digis.moduleInd(k) == me);
+      }
+#endif
+
+#ifdef GPU_DEBUG
+      if (me % 100 == 1)
+        if (teamMember.team_rank() == 0)
+          printf("hitbuilder: %d clusters in module %d. will write at %d\n", nclus, me, clusters.clusModuleStart(me));
+#endif
+
+      for (int startClus = 0, endClus = nclus; startClus < endClus; startClus += MaxHitsInIter) {
+        auto first = clusters.moduleStart(1 + teamMember.league_rank());
+
+        int nClusInIter = std::min(MaxHitsInIter, endClus - startClus);
+        int lastClus = startClus + nClusInIter;
+        assert(nClusInIter <= nclus);
+        assert(nClusInIter > 0);
+        assert(lastClus <= nclus);
+
+        assert(nclus > MaxHitsInIter || (0 == startClus && nClusInIter == nclus && lastClus == nclus));
+
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, nClusInIter), [=](int ic) {
+          clusParams->minRow[ic] = std::numeric_limits<uint32_t>::max();
+          clusParams->maxRow[ic] = 0;
+          clusParams->minCol[ic] = std::numeric_limits<uint32_t>::max();
+          clusParams->maxCol[ic] = 0;
+          clusParams->charge[ic] = 0;
+          clusParams->Q_f_X[ic] = 0;
+          clusParams->Q_l_X[ic] = 0;
+          clusParams->Q_f_Y[ic] = 0;
+          clusParams->Q_l_Y[ic] = 0;
+        });
+
+        first += teamMember.team_rank();
+        teamMember.team_barrier();
+
+        // one thead per "digi"
+
+        // TODO: can't use parallel_for+TeamThreadRange because of the break
+        for (int i = first; i < numElements; i += teamMember.team_size()) {
+          auto id = digis.moduleInd(i);
+          if (id == InvId)
+            continue;
+          if (id != me)
+            break;  // end of module
+          auto cl = digis.clus(i);
+          if (cl < startClus || cl >= lastClus)
+            continue;
+          auto x = digis.xx(i);
+          auto y = digis.yy(i);
+          cl -= startClus;
+          assert(cl >= 0);
+          assert(cl < MaxHitsInIter);
+          Kokkos::atomic_min_fetch<uint32_t>(&clusParams->minRow[cl], x);
+          Kokkos::atomic_max_fetch<uint32_t>(&clusParams->maxRow[cl], x);
+          Kokkos::atomic_min_fetch<uint32_t>(&clusParams->minCol[cl], y);
+          Kokkos::atomic_max_fetch<uint32_t>(&clusParams->maxCol[cl], y);
+        }
+
+        teamMember.team_barrier();
+
+        // TODO: can't use parallel_for+TeamThreadRange because of the break
+        for (int i = first; i < numElements; i += teamMember.team_size()) {
+          auto id = digis.moduleInd(i);
+          if (id == InvId)
+            continue;  // not valid
+          if (id != me)
+            break;  // end of module
+          auto cl = digis.clus(i);
+          if (cl < startClus || cl >= lastClus)
+            continue;
+          cl -= startClus;
+          assert(cl >= 0);
+          assert(cl < MaxHitsInIter);
+          auto x = digis.xx(i);
+          auto y = digis.yy(i);
+          auto ch = digis.adc(i);
+          Kokkos::atomic_add<int32_t>(&clusParams->charge[cl], ch);
+          if (clusParams->minRow[cl] == x)
+            Kokkos::atomic_add<int32_t>(&clusParams->Q_f_X[cl], ch);
+          if (clusParams->maxRow[cl] == x)
+            Kokkos::atomic_add<int32_t>(&clusParams->Q_l_X[cl], ch);
+          if (clusParams->minCol[cl] == y)
+            Kokkos::atomic_add<int32_t>(&clusParams->Q_f_Y[cl], ch);
+          if (clusParams->maxCol[cl] == y)
+            Kokkos::atomic_add<int32_t>(&clusParams->Q_l_Y[cl], ch);
+        }
+
+        teamMember.team_barrier();
+        // next one cluster per thread...
+
+        first = clusters.clusModuleStart(me) + startClus;
+
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, nClusInIter), [=](int ic) {
+          auto h = first + ic;  // output index in global memory
+
+          // this cannot happen anymore
+          if (h >= TrackingRecHit2DSOAView::maxHits())
+            // TODO: was 'break', OTOH comment above says "should not happen", so maybe 'return' is ok
+            return;  // overflow...
+          assert(h < hits->nHits());
+          assert(h < clusters.clusModuleStart(me + 1));
+
+          pixelCPEforGPU::position(cpeParams->commonParams(), cpeParams->detParams(me), *clusParams, ic);
+          pixelCPEforGPU::errorFromDB(cpeParams->commonParams(), cpeParams->detParams(me), *clusParams, ic);
+
+          // store it
+
+          hits->charge(h) = clusParams->charge[ic];
+
+          hits->detectorIndex(h) = me;
+
+          float xl, yl;
+          hits->xLocal(h) = xl = clusParams->xpos[ic];
+          hits->yLocal(h) = yl = clusParams->ypos[ic];
+
+          hits->clusterSizeX(h) = clusParams->xsize[ic];
+          hits->clusterSizeY(h) = clusParams->ysize[ic];
+
+          hits->xerrLocal(h) = clusParams->xerr[ic] * clusParams->xerr[ic];
+          hits->yerrLocal(h) = clusParams->yerr[ic] * clusParams->yerr[ic];
+
+          // keep it local for computations
+          float xg, yg, zg;
+          // to global and compute phi...
+          cpeParams->detParams(me).frame.toGlobal(xl, yl, xg, yg, zg);
+          // here correct for the beamspot...
+          xg -= bs->x;
+          yg -= bs->y;
+          zg -= bs->z;
+
+          hits->xGlobal(h) = xg;
+          hits->yGlobal(h) = yg;
+          hits->zGlobal(h) = zg;
+
+          hits->rGlobal(h) = std::sqrt(xg * xg + yg * yg);
+          hits->iphi(h) = unsafe_atan2s<7>(yg, xg);
+        });
+        teamMember.team_barrier();
+      }  // end loop on batches
+    }
+  }  // namespace gpuPixelRecHits
+}  // namespace KOKKOS_NAMESPACE
+
+#endif  // RecoLocalTracker_SiPixelRecHits_plugins_gpuPixelRecHits_h

--- a/src/kokkos/test/kokkos/threadTeam.cc
+++ b/src/kokkos/test/kokkos/threadTeam.cc
@@ -1,0 +1,56 @@
+#include "KokkosCore/kokkosConfigCommon.h"
+#include "KokkosCore/kokkosConfig.h"
+
+#include <iostream>
+
+namespace {
+  constexpr int TEAMS = 10;
+  constexpr int THREADS_PER_TEAM = 128;
+  constexpr int ELEMENTS_PER_TEAM = 1000;
+  constexpr int ELEMENTS = TEAMS * ELEMENTS_PER_TEAM;
+
+  KOKKOS_INLINE_FUNCTION void kernel(Kokkos::View<int*, KokkosExecSpace> data,
+                                     Kokkos::TeamPolicy<KokkosExecSpace>::member_type const& teamMember) {
+    //printf("%d %d %d\n", static_cast<int>(teamMember.league_rank()), static_cast<int>(teamMember.team_size()), static_cast<int>(teamMember.team_rank()));
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, ELEMENTS_PER_TEAM), [=](int i) {
+      data[teamMember.league_rank() * ELEMENTS_PER_TEAM + i] *= 10;
+      //printf("%d %d %d\n", static_cast<int>(teamMember.league_rank()), static_cast<int>(teamMember.team_size()), i);
+    });
+    /*
+    for (int i=0; i<ELEMENTS_PER_TEAM; i += teamMember.team_size()) {
+      data[teamMember.league_rank()*ELEMENTS_PER_TEAM + i] *= 10;
+    }
+    */
+  }
+}  // namespace
+
+void test() {
+  Kokkos::View<int*, KokkosExecSpace> data_d("data_d", ELEMENTS);
+  auto data_h = Kokkos::create_mirror_view(data_d);
+  for (int i = 0; i < ELEMENTS; ++i) {
+    data_h[i] = i;
+  }
+  Kokkos::deep_copy(KokkosExecSpace(), data_d, data_h);
+
+  using TeamPolicy = Kokkos::TeamPolicy<KokkosExecSpace>;
+  using MemberType = TeamPolicy::member_type;
+  //TeamPolicy policy(KokkosExecSpace(), TEAMS, THREADS_PER_TEAM);
+  TeamPolicy policy(KokkosExecSpace(), TEAMS, Kokkos::AUTO());
+  Kokkos::parallel_for(
+      policy, KOKKOS_LAMBDA(MemberType const& teamMember) { kernel(data_d, teamMember); });
+
+  Kokkos::deep_copy(KokkosExecSpace(), data_h, data_d);
+
+  KokkosExecSpace().fence();
+  for (int iTeam = 0; iTeam != TEAMS; ++iTeam) {
+    for (int i = 0; i < 10; ++i) {
+      std::cout << "Team " << iTeam << " element " << i << " " << data_h[iTeam * ELEMENTS_PER_TEAM + i] << std::endl;
+    }
+  }
+}
+
+int main() {
+  kokkos_common::InitializeScopeGuard kokkosGuard({KokkosBackend<KokkosExecSpace>::value});
+  test();
+  return 0;
+}


### PR DESCRIPTION
This PR migrates two of the RecHit kernels to Kokkos. The third one needs `HistoContainer`, and will be done after #62. They compile, but I can't test running them (yet).

This PR also adds a simple unit test to play with the Kokkos' thread teams. 