### PR TITLE
[kokkos] Port track and vertex device-to-host transfer modules, and the validation module

### DIFF
--- a/src/kokkos/Makefile.deps
+++ b/src/kokkos/Makefile.deps
@@ -4,3 +4,4 @@ PixelTriplets_DEPENDS := Framework KokkosCore KokkosDataFormats
 PixelVertexFinding_DEPENDS := Framework KokkosCore KokkosDataFormats DataFormats CondFormats
 SiPixelClusterizer_DEPENDS := Framework KokkosCore KokkosDataFormats DataFormats CondFormats
 SiPixelRecHits_DEPENDS := Framework KokkosCore KokkosDataFormats DataFormats CondFormats
+Validation_DEPENDS := Framework KokkosCore KokkosDataFormats DataFormats

--- a/src/kokkos/bin/main.cc
+++ b/src/kokkos/bin/main.cc
@@ -97,6 +97,10 @@ int main(int argc, char** argv) {
       if (std::find(backends.begin(), backends.end(), backend) != backends.end()) {
         edmodules.emplace_back(prefix + "BeamSpotToKokkos");
         edmodules.emplace_back(prefix + "SiPixelRawToCluster");
+        if (validation) {
+          edmodules.emplace_back(prefix + "CountValidator");
+        }
+
         esmodules.emplace_back(prefix + "SiPixelFedCablingMapESProducer");
         esmodules.emplace_back(prefix + "SiPixelGainCalibrationForHLTESProducer");
         esmodules.emplace_back(prefix + "PixelCPEFastESProducer");

--- a/src/kokkos/bin/main.cc
+++ b/src/kokkos/bin/main.cc
@@ -97,6 +97,17 @@ int main(int argc, char** argv) {
       if (std::find(backends.begin(), backends.end(), backend) != backends.end()) {
         edmodules.emplace_back(prefix + "BeamSpotToKokkos");
         edmodules.emplace_back(prefix + "SiPixelRawToCluster");
+#ifdef TODO
+        edmodules.emplace_back(prefix + "SiPixelRecHitKokkos");
+        edmodules.emplace_back(prefix + "CAHitNtupletKokkos");
+        edmodules.emplace_back(prefix + "PixelVertexProducerKokkos");
+#endif
+        if (transfer) {
+#ifdef TODO
+          edmodules.emplace_back(prefix + "PixelTrackSoAFromKokkos");
+          edmodules.emplace_back(prefix + "PixelVertexSoAFromKokkos");
+#endif
+        }
         if (validation) {
           edmodules.emplace_back(prefix + "CountValidator");
         }
@@ -108,9 +119,6 @@ int main(int argc, char** argv) {
     };
     addModules("kokkos_serial::", Backend::SERIAL);
     addModules("kokkos_cuda::", Backend::CUDA);
-    if (transfer) {
-      // add modules for transfer
-    }
   }
   edm::EventProcessor processor(
       maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);

--- a/src/kokkos/plugin-PixelTriplets/kokkos/PixelTrackSoAFromKokkos.cc
+++ b/src/kokkos/plugin-PixelTriplets/kokkos/PixelTrackSoAFromKokkos.cc
@@ -1,0 +1,78 @@
+#include "KokkosCore/kokkosConfig.h"
+#include "KokkosDataFormats/PixelTrackKokkos.h"
+#include "Framework/EventSetup.h"
+#include "Framework/Event.h"
+#include "Framework/PluginFactory.h"
+#include "Framework/EDProducer.h"
+
+namespace KOKKOS_NAMESPACE {
+#ifdef TODO
+  class PixelTrackSoAFromKokkos : public edm::EDProducerExternalWork {
+#else
+  class PixelTrackSoAFromKokkos : public edm::EDProducer {
+#endif
+  public:
+    explicit PixelTrackSoAFromKokkos(edm::ProductRegistry& reg);
+    ~PixelTrackSoAFromKokkos() override = default;
+
+  private:
+#ifdef TODO
+    void acquire(edm::Event const& iEvent,
+                 edm::EventSetup const& iSetup,
+                 edm::WaitingTaskWithArenaHolder waitingTaskHolder) override;
+#endif
+    void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) override;
+
+    using TracksExecSpace = Kokkos::View<pixelTrack::TrackSoA, KokkosExecSpace>;
+    using TracksHostSpace = TracksExecSpace::HostMirror;
+
+    edm::EDGetTokenT<TracksExecSpace> tokenKokkos_;
+    edm::EDPutTokenT<TracksHostSpace> tokenSOA_;
+#ifdef TODO
+    cms::cuda::host::unique_ptr<pixelTrack::TrackSoA> m_soa;
+#endif
+  };
+
+  PixelTrackSoAFromKokkos::PixelTrackSoAFromKokkos(edm::ProductRegistry& reg)
+      : tokenKokkos_(reg.consumes<TracksExecSpace>()), tokenSOA_(reg.produces<TracksHostSpace>()) {}
+
+#ifdef TODO
+  void PixelTrackSoAFromKokkos::acquire(edm::Event const& iEvent,
+                                        edm::EventSetup const& iSetup,
+                                        edm::WaitingTaskWithArenaHolder waitingTaskHolder) {
+    cms::cuda::Product<PixelTrackHeterogeneous> const& inputDataWrapped = iEvent.get(tokenKokkos_);
+    cms::cuda::ScopedContextAcquire ctx{inputDataWrapped, std::move(waitingTaskHolder)};
+    auto const& inputData = ctx.get(inputDataWrapped);
+
+    m_soa = inputData.toHostAsync(ctx.stream());
+  }
+#endif
+
+  void PixelTrackSoAFromKokkos::produce(edm::Event& iEvent, edm::EventSetup const& iSetup) {
+    auto const& inputData = iEvent.get(tokenKokkos_);
+
+    /*
+  auto const & tsoa = *m_soa;
+  auto maxTracks = tsoa.stride();
+  std::cout << "size of SoA" << sizeof(tsoa) << " stride " << maxTracks << std::endl;
+
+  int32_t nt = 0;
+  for (int32_t it = 0; it < maxTracks; ++it) {
+    auto nHits = tsoa.nHits(it);
+    assert(nHits==int(tsoa.hitIndices.size(it)));
+    if (nHits == 0) break;  // this is a guard: maybe we need to move to nTracks...
+    nt++;
+  }
+  std::cout << "found " << nt << " tracks in cpu SoA at " << &tsoa << std::endl;
+  */
+
+    TracksHostSpace outputData("tracks");
+    Kokkos::deep_copy(KokkosExecSpace(), outputData, inputData);
+    KokkosExecSpace().fence();
+
+    // DO NOT  make a copy  (actually TWO....)
+    iEvent.emplace(tokenSOA_, std::move(outputData));
+  }
+}  // namespace KOKKOS_NAMESPACE
+
+DEFINE_FWK_KOKKOS_MODULE(PixelTrackSoAFromKokkos);

--- a/src/kokkos/plugin-PixelVertexFinding/kokkos/PixelVertexProducerKokkos.cc
+++ b/src/kokkos/plugin-PixelVertexFinding/kokkos/PixelVertexProducerKokkos.cc
@@ -40,8 +40,7 @@ namespace KOKKOS_NAMESPACE {
                   9       // chi2max
                   ),
         m_ptMin(0.5)  // 0.5 GeV
-  {
-  }
+  {}
 
   void PixelVertexProducerKokkos::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     auto const& tracks = iEvent.get(tokenTrack_);

--- a/src/kokkos/plugin-PixelVertexFinding/kokkos/PixelVertexSoAFromKokkos.cc
+++ b/src/kokkos/plugin-PixelVertexFinding/kokkos/PixelVertexSoAFromKokkos.cc
@@ -1,0 +1,62 @@
+#include "KokkosCore/kokkosConfig.h"
+#include "DataFormats/ZVertexSoA.h"
+#include "Framework/EventSetup.h"
+#include "Framework/Event.h"
+#include "Framework/PluginFactory.h"
+#include "Framework/EDProducer.h"
+#include "Framework/RunningAverage.h"
+
+namespace KOKKOS_NAMESPACE {
+#ifdef TODO
+  class PixelVertexSoAFromKokkos : public edm::EDProducerExternalWork {
+#else
+  class PixelVertexSoAFromKokkos : public edm::EDProducer {
+#endif
+  public:
+    explicit PixelVertexSoAFromKokkos(edm::ProductRegistry& reg);
+    ~PixelVertexSoAFromKokkos() override = default;
+
+  private:
+#ifdef TODO
+    void acquire(edm::Event const& iEvent,
+                 edm::EventSetup const& iSetup,
+                 edm::WaitingTaskWithArenaHolder waitingTaskHolder) override;
+#endif
+    void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) override;
+
+    using VerticesExecSpace = Kokkos::View<ZVertexSoA, KokkosExecSpace>;
+    using VerticesHostSpace = VerticesExecSpace::HostMirror;
+
+    edm::EDGetTokenT<VerticesExecSpace> tokenKokkos_;
+    edm::EDPutTokenT<VerticesHostSpace> tokenSOA_;
+#ifdef TODO
+    cms::cuda::host::unique_ptr<ZVertexSoA> m_soa;
+#endif
+  };
+
+  PixelVertexSoAFromKokkos::PixelVertexSoAFromKokkos(edm::ProductRegistry& reg)
+      : tokenKokkos_(reg.consumes<VerticesExecSpace>()), tokenSOA_(reg.produces<VerticesHostSpace>()) {}
+
+#ifdef TODO
+  void PixelVertexSoAFromKokkos::acquire(edm::Event const& iEvent,
+                                         edm::EventSetup const& iSetup,
+                                         edm::WaitingTaskWithArenaHolder waitingTaskHolder) {
+    auto const& inputDataWrapped = iEvent.get(tokenKokkos_);
+    cms::cuda::ScopedContextAcquire ctx{inputDataWrapped, std::move(waitingTaskHolder)};
+    auto const& inputData = ctx.get(inputDataWrapped);
+
+    m_soa = inputData.toHostAsync(ctx.stream());
+  }
+#endif
+
+  void PixelVertexSoAFromKokkos::produce(edm::Event& iEvent, edm::EventSetup const& iSetup) {
+    auto const& inputData = iEvent.get(tokenKokkos_);
+    VerticesHostSpace outputData("vertices");
+    Kokkos::deep_copy(KokkosExecSpace(), outputData, inputData);
+    KokkosExecSpace().fence();
+    // No copies....
+    iEvent.emplace(tokenSOA_, std::move(outputData));
+  }
+}  // namespace KOKKOS_NAMESPACE
+
+DEFINE_FWK_KOKKOS_MODULE(PixelVertexSoAFromKokkos);

--- a/src/kokkos/plugin-Validation/kokkos/CountValidator.cc
+++ b/src/kokkos/plugin-Validation/kokkos/CountValidator.cc
@@ -1,0 +1,121 @@
+#include "KokkosCore/kokkosConfig.h"
+#include "KokkosDataFormats/PixelTrackKokkos.h"
+#include "KokkosDataFormats/SiPixelClustersKokkos.h"
+#include "KokkosDataFormats/SiPixelDigisKokkos.h"
+#include "DataFormats/ZVertexSoA.h"
+#include "DataFormats/DigiClusterCount.h"
+#include "DataFormats/TrackCount.h"
+#include "DataFormats/VertexCount.h"
+#include "Framework/EventSetup.h"
+#include "Framework/Event.h"
+#include "Framework/PluginFactory.h"
+#include "Framework/EDProducer.h"
+
+#include <atomic>
+#include <iostream>
+#include <sstream>
+
+namespace {
+  std::atomic<int> allEvents{0};
+  std::atomic<int> goodEvents{0};
+}  // namespace
+
+namespace KOKKOS_NAMESPACE {
+
+  class CountValidator : public edm::EDProducer {
+  public:
+    explicit CountValidator(edm::ProductRegistry& reg);
+
+  private:
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+    void endJob() override;
+
+    edm::EDGetTokenT<DigiClusterCount> digiClusterCountToken_;
+    edm::EDGetTokenT<TrackCount> trackCountToken_;
+    edm::EDGetTokenT<VertexCount> vertexCountToken_;
+
+    edm::EDGetTokenT<SiPixelDigisKokkos<KokkosExecSpace>> digiToken_;
+    edm::EDGetTokenT<SiPixelClustersKokkos<KokkosExecSpace>> clusterToken_;
+    edm::EDGetTokenT<Kokkos::View<pixelTrack::TrackSoA, KokkosExecSpace>::HostMirror> trackToken_;
+    edm::EDGetTokenT<Kokkos::View<ZVertexSoA, KokkosExecSpace>::HostMirror> vertexToken_;
+  };
+
+  CountValidator::CountValidator(edm::ProductRegistry& reg)
+      : digiClusterCountToken_(reg.consumes<DigiClusterCount>()),
+        trackCountToken_(reg.consumes<TrackCount>()),
+        vertexCountToken_(reg.consumes<VertexCount>())
+#ifdef TODO
+            digiToken_(reg.consumes<SiPixelDigisKokkos<KokkosExecSpace>>()),
+        clusterToken_(reg.consumes<SiPixelClustersKokkos<KokkosExecSpace>>()),
+        trackToken_(reg.consumes<Kokkos::View<pixelTrack::TrackSoA, KokkosExecSpace>::HostMirror>()),
+        vertexToken_(reg.consumes<Kokkos::View<ZVertexSoA, KokkosExecSpace>::HostMirror>())
+#endif
+  {
+  }
+
+  void CountValidator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+    std::stringstream ss;
+    bool ok = true;
+
+    ss << "Event " << iEvent.eventID() << " ";
+
+#ifdef TODO
+    {
+      auto const& count = iEvent.get(digiClusterCountToken_);
+      auto const& digis = iEvent.get(digiToken_);
+      auto const& clusters = iEvent.get(clusterToken_);
+
+      if (digis.nModules() != count.nModules()) {
+        ss << "\n N(modules) is " << digis.nModules() << " expected " << count.nModules();
+        ok = false;
+      }
+      if (digis.nDigis() != count.nDigis()) {
+        ss << "\n N(digis) is " << digis.nDigis() << " expected " << count.nDigis();
+        ok = false;
+      }
+      if (clusters.nClusters() != count.nClusters()) {
+        ss << "\n N(clusters) is " << clusters.nClusters() << " expected " << count.nClusters();
+        ok = false;
+      }
+    }
+
+    {
+      auto const& count = iEvent.get(trackCountToken_);
+      auto const& tracks = iEvent.get(trackToken_);
+
+      if (tracks().m_nTracks != count.nTracks()) {
+        ss << "\n N(tracks) is " << tracks().m_nTracks << " expected " << count.nTracks();
+        ok = false;
+      }
+    }
+
+    {
+      auto const& count = iEvent.get(vertexCountToken_);
+      auto const& vertices = iEvent.get(vertexToken_);
+
+      if (vertices().nvFinal != count.nVertices()) {
+        ss << "\n N(vertices) is " << vertices().nvFinal << " expected " << count.nVertices();
+        ok = false;
+      }
+    }
+#endif
+
+    ++allEvents;
+    if (ok) {
+      ++goodEvents;
+    } else {
+      std::cout << ss.str() << std::endl;
+    }
+  }
+
+  void CountValidator::endJob() {
+    if (allEvents == goodEvents) {
+      std::cout << "CountValidator: all " << allEvents << " events passed validation\n";
+    } else {
+      std::cout << "CountValidator: " << (allEvents - goodEvents) << " events failed validation (see details above)\n";
+      throw std::runtime_error("CountValidator failed");
+    }
+  }
+}  // namespace KOKKOS_NAMESPACE
+
+DEFINE_FWK_KOKKOS_MODULE(CountValidator);

--- a/src/kokkos/plugins.txt
+++ b/src/kokkos/plugins.txt
@@ -10,3 +10,5 @@ kokkos_cuda::SiPixelGainCalibrationForHLTESProducer pluginSiPixelClusterizer.so
 kokkos_serial::SiPixelGainCalibrationForHLTESProducer pluginSiPixelClusterizer.so
 kokkos_cuda::PixelCPEFastESProducer pluginSiPixelRecHits.so
 kokkos_serial::PixelCPEFastESProducer pluginSiPixelRecHits.so
+kokkos_cuda::CountValidator pluginValidation.so
+kokkos_serial::CountValidator pluginValidation.so

--- a/src/kokkos/plugins.txt
+++ b/src/kokkos/plugins.txt
@@ -1,6 +1,14 @@
 BeamSpotESProducer pluginBeamSpotProducer.so
 kokkos_cuda::BeamSpotToKokkos pluginBeamSpotProducer.so
 kokkos_serial::BeamSpotToKokkos pluginBeamSpotProducer.so
+kokkos_cuda::CAHitNtupletKokkos pluginPixelTriplets.so
+kokkos_serial::CAHitNtupletKokkos pluginPixelTriplets.so
+kokkos_cuda::PixelTrackSoAFromKokkos pluginPixelTriplets.so
+kokkos_serial::PixelTrackSoAFromKokkos pluginPixelTriplets.so
+kokkos_cuda::PixelVertexProducerKokkos pluginPixelVertexFinding.so
+kokkos_serial::PixelVertexProducerKokkos pluginPixelVertexFinding.so
+kokkos_cuda::PixelVertexSoAFromKokkos pluginPixelVertexFinding.so
+kokkos_serial::PixelVertexSoAFromKokkos pluginPixelVertexFinding.so
 kokkos_cuda::SiPixelRawToCluster pluginSiPixelClusterizer.so
 kokkos_serial::SiPixelRawToCluster pluginSiPixelClusterizer.so
 SiPixelFedIdsESProducer pluginSiPixelClusterizer.so
@@ -10,5 +18,7 @@ kokkos_cuda::SiPixelGainCalibrationForHLTESProducer pluginSiPixelClusterizer.so
 kokkos_serial::SiPixelGainCalibrationForHLTESProducer pluginSiPixelClusterizer.so
 kokkos_cuda::PixelCPEFastESProducer pluginSiPixelRecHits.so
 kokkos_serial::PixelCPEFastESProducer pluginSiPixelRecHits.so
+kokkos_cuda::SiPixelRecHitKokkos pluginSiPixelRecHits.so
+kokkos_serial::SiPixelRecHitKokkos pluginSiPixelRecHits.so
 kokkos_cuda::CountValidator pluginValidation.so
 kokkos_serial::CountValidator pluginValidation.so


### PR DESCRIPTION
Also update `plugins.txt` and add placeholders to `main.cc`.

This PR should complete porting all the non-kernel ("boilerplate") module code to Kokkos.