### PR TITLE
[kokkostest] Add ScopedContextAcquire and test external worker

### DIFF
--- a/src/kokkostest/KokkosCore/Product.h
+++ b/src/kokkostest/KokkosCore/Product.h
@@ -3,19 +3,45 @@
 
 #include "KokkosCore/ProductBase.h"
 
+namespace edm {
+  template <typename T>
+  class Wrapper;
+}
+
 namespace cms {
   namespace kokkos {
+    namespace impl {
+      template <typename ExecSpace>
+      class ScopedContextGetterBase;
+    }
+    template <typename ExecSpace>
+    class ScopedContextProduce;
+
     template <typename T>
     class Product : public ProductBase {
     public:
       Product() = default;
-      Product(std::unique_ptr<impl::ExecSpaceSpecificBase> spaceSpecific, T data)
-          : ProductBase(std::move(spaceSpecific)) {}
 
       Product(const Product&) = delete;
       Product& operator=(const Product&) = delete;
       Product(Product&&) = default;
       Product& operator=(Product&&) = default;
+
+    private:
+      template <typename ExecSpace>
+      friend class impl::ScopedContextGetterBase;
+      template <typename ExecSpace>
+      friend class ScopedContextProduce;
+      friend class edm::Wrapper<Product<T>>;
+
+      explicit Product(std::unique_ptr<impl::ExecSpaceSpecificBase> spaceSpecific, T data)
+          : ProductBase(std::move(spaceSpecific)), data_(std::move(data)) {}
+
+      template <typename... Args>
+      explicit Product(std::unique_ptr<impl::ExecSpaceSpecificBase> spaceSpecific, Args&&... args)
+          : ProductBase(std::move(spaceSpecific)), data_(std::forward<Args>(args)...) {}
+
+      T data_;
     };
   }  // namespace kokkos
 }  // namespace cms

--- a/src/kokkostest/KokkosCore/ScopedContext.h
+++ b/src/kokkostest/KokkosCore/ScopedContext.h
@@ -22,7 +22,7 @@ namespace cms {
       template <typename T>
       std::unique_ptr<Product<T>> wrap(T data) {
         // make_unique doesn't work because of private constructor
-        return std::unique_ptr<Product<T>>(new Product<T>(execSpaceSpecific_, std::move(data)));
+        return std::unique_ptr<Product<T>>(new Product<T>(execSpaceSpecific_->cloneShareAll(), std::move(data)));
       }
 
       template <typename T, typename... Args>

--- a/src/kokkostest/KokkosCore/ScopedContext.h
+++ b/src/kokkostest/KokkosCore/ScopedContext.h
@@ -8,30 +8,67 @@
 
 namespace cms {
   namespace kokkos {
+    namespace impl {
+      template <typename ExecSpace>
+      class ScopedContextGetterBase {
+      public:
+        ExecSpace const& execSpace() const { return execSpaceSpecific_->execSpace(); }
+
+        template <typename T>
+        const T& get(const Product<T>& data) {
+          execSpaceSpecific_->synchronizeWith(data.template execSpaceSpecific<ExecSpace>());
+          return data.data_;
+        }
+
+        template <typename T>
+        const T& get(const edm::Event& iEvent, edm::EDGetTokenT<Product<T>> token) {
+          return get(iEvent.get(token));
+        }
+
+      protected:
+        ScopedContextGetterBase() : execSpaceSpecific_(std::make_unique<impl::ExecSpaceSpecific<ExecSpace>>()) {}
+
+        explicit ScopedContextGetterBase(const ProductBase& data)
+            : execSpaceSpecific_(data.execSpaceSpecific<ExecSpace>().cloneShareStream()) {}
+
+        ExecSpaceSpecific<ExecSpace>& execSpaceSpecific() { return *execSpaceSpecific_; }
+
+      private:
+        std::unique_ptr<ExecSpaceSpecific<ExecSpace>> execSpaceSpecific_;
+      };
+    }  // namespace impl
+
     template <typename ExecSpace>
-    class ScopedContextProduce {
+    class ScopedContextAcquire : public impl::ScopedContextGetterBase<ExecSpace> {
     public:
-      ScopedContextProduce() : execSpaceSpecific_(std::make_unique<impl::ExecSpaceSpecific<ExecSpace>>()) {}
-      explicit ScopedContextProduce(const ProductBase& data)
-          : execSpaceSpecific_(data.execSpaceSpecific<ExecSpace>().cloneShareStream()) {}
+      explicit ScopedContextAcquire(edm::WaitingTaskWithArenaHolder holder) : waitingTaskHolder_(std::move(holder)) {}
+      explicit ScopedContextAcquire(const ProductBase& data, edm::WaitingTaskWithArenaHolder holder)
+          : impl::ScopedContextGetterBase<ExecSpace>(data), waitingTaskHolder_(std::move(holder)) {}
 
-      ~ScopedContextProduce() { execSpaceSpecific_->recordEvent(); }
+      ~ScopedContextAcquire() { this->execSpaceSpecific().enqueueCallback(std::move(waitingTaskHolder_)); }
 
-      ExecSpace const& execSpace() const { return execSpaceSpecific_->execSpace(); }
+    private:
+      edm::WaitingTaskWithArenaHolder waitingTaskHolder_;
+    };
+
+    template <typename ExecSpace>
+    class ScopedContextProduce : public impl::ScopedContextGetterBase<ExecSpace> {
+    public:
+      ScopedContextProduce() = default;
+      explicit ScopedContextProduce(const ProductBase& data) : impl::ScopedContextGetterBase<ExecSpace>(data) {}
+
+      ~ScopedContextProduce() { this->execSpaceSpecific().recordEvent(); }
 
       template <typename T>
       std::unique_ptr<Product<T>> wrap(T data) {
         // make_unique doesn't work because of private constructor
-        return std::unique_ptr<Product<T>>(new Product<T>(execSpaceSpecific_->cloneShareAll(), std::move(data)));
+        return std::unique_ptr<Product<T>>(new Product<T>(this->execSpaceSpecific().cloneShareAll(), std::move(data)));
       }
 
       template <typename T, typename... Args>
       auto emplace(edm::Event& iEvent, edm::EDPutTokenT<T> token, Args&&... args) {
-        return iEvent.emplace(token, execSpaceSpecific_->cloneShareAll(), std::forward<Args>(args)...);
+        return iEvent.emplace(token, this->execSpaceSpecific().cloneShareAll(), std::forward<Args>(args)...);
       }
-
-    private:
-      std::unique_ptr<impl::ExecSpaceSpecific<ExecSpace>> execSpaceSpecific_;
     };
   }  // namespace kokkos
 }  // namespace cms

--- a/src/kokkostest/KokkosCore/kokkoshost/ProductBase.cc
+++ b/src/kokkostest/KokkosCore/kokkoshost/ProductBase.cc
@@ -1,9 +1,70 @@
+#include "CUDACore/cudaCheck.h"
+#include "CUDACore/eventWorkHasCompleted.h"
 #include "KokkosCore/ProductBase.h"
+
+namespace {
+  struct CallbackData {
+    edm::WaitingTaskWithArenaHolder holder;
+    int device;
+  };
+
+  void CUDART_CB cudaScopedContextCallback(cudaStream_t streamId, cudaError_t status, void* data) {
+    std::unique_ptr<CallbackData> guard{reinterpret_cast<CallbackData*>(data)};
+    edm::WaitingTaskWithArenaHolder& waitingTaskHolder = guard->holder;
+    int device = guard->device;
+    if (status == cudaSuccess) {
+      //std::cout << " GPU kernel finished (in callback) device " << device << " CUDA stream "
+      //          << streamId << std::endl;
+      waitingTaskHolder.doneWaiting(nullptr);
+    } else {
+      // wrap the exception in a try-catch block to let GDB "catch throw" break on it
+      try {
+        auto error = cudaGetErrorName(status);
+        auto message = cudaGetErrorString(status);
+        throw std::runtime_error("Callback of CUDA stream " +
+                                 std::to_string(reinterpret_cast<unsigned long>(streamId)) + " in device " +
+                                 std::to_string(device) + " error " + std::string(error) + ": " + std::string(message));
+      } catch (std::exception&) {
+        waitingTaskHolder.doneWaiting(std::current_exception());
+      }
+    }
+  }
+}  // namespace
 
 namespace cms {
   namespace kokkos {
     namespace impl {
       ExecSpaceSpecificBase::~ExecSpaceSpecificBase() = default;
-    }
-  }  // namespace kokkos
+
+      void ExecSpaceSpecific<Kokkos::Cuda>::enqueueCallback(edm::WaitingTaskWithArenaHolder holder) {
+        cudaCheck(cudaStreamAddCallback(
+            stream_.get(), cudaScopedContextCallback, new CallbackData{std::move(holder), device()}, 0));
+      }
+
+      void ExecSpaceSpecific<Kokkos::Cuda>::synchronizeWith(ExecSpaceSpecific const& other) {
+        if (device() != other.device()) {
+          // Eventually replace with prefetch to current device (assuming unified memory works)
+          // If we won't go to unified memory, need to figure out something else...
+          throw std::runtime_error("Handling data from multiple devices is not yet supported");
+        }
+
+        if (other.stream_.get() != stream_.get()) {
+          // Different streams, need to synchronize
+          if (not other.isAvailable()) {
+            // Event not yet occurred, so need to add synchronization
+            // here. Sychronization is done by making the CUDA stream to
+            // wait for an event, so all subsequent work in the stream
+            // will run only after the event has "occurred" (i.e. data
+            // product became available).
+            cudaCheck(cudaStreamWaitEvent(stream_.get(), other.event_.get(), 0),
+                      "Failed to make a stream to wait for an event");
+          }
+        }
+      }
+
+      bool ExecSpaceSpecific<Kokkos::Cuda>::isAvailable() const {
+        return cms::cuda::eventWorkHasCompleted(event_.get());
+      }
+    }  // namespace impl
+  }    // namespace kokkos
 }  // namespace cms

--- a/src/kokkostest/Makefile.deps
+++ b/src/kokkostest/Makefile.deps
@@ -1,3 +1,4 @@
 kokkostest_EXTERNAL_DEPENDS := TBB CUDA KOKKOS
+KokkosCore_DEPENDS := Framework
 Test1_DEPENDS := Framework DataFormats KokkosCore CUDACore
 Test2_DEPENDS := Framework KokkosCore CUDACore


### PR DESCRIPTION
This PR is a follow-up to https://github.com/cms-patatrack/pixeltrack-standalone/pull/58 and adds support for external worker.