### PR TITLE
[kokkos] Finalize SiPixelRawToCluster module

### DIFF
--- a/src/kokkos/KokkosDataFormats/SiPixelClustersKokkos.h
+++ b/src/kokkos/KokkosDataFormats/SiPixelClustersKokkos.h
@@ -11,7 +11,7 @@ public:
       : moduleStart_d{"moduleStart_d", maxClusters + 1},
         clusInModule_d{"clusInModule_d", maxClusters},
         moduleId_d{"moduleId_d", maxClusters},
-        clusModuleStart_d{"clusModuleStart_d", maxClusters} {}
+        clusModuleStart_d{"clusModuleStart_d", maxClusters + 1} {}
   ~SiPixelClustersKokkos() = default;
 
   SiPixelClustersKokkos(const SiPixelClustersKokkos &) = delete;

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToCluster.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToCluster.cc
@@ -145,6 +145,9 @@ namespace KOKKOS_NAMESPACE {
                                false  // debug
     );
 
+    // TODO: synchronize explicitly for now
+    KokkosExecSpace().fence();
+
     auto tmp = gpuAlgo_.getResults();
     iEvent.emplace(digiPutToken_, std::move(tmp.first));
     iEvent.emplace(clusterPutToken_, std::move(tmp.second));

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
@@ -512,8 +512,6 @@ namespace pixelgpudetails {
         Kokkos::RangePolicy<ExecSpace>(execSpace, 1025, gpuClustering::MaxNumModules + 1),
         KOKKOS_LAMBDA(const int &index) { moduleStart(index) += moduleStart(1024); });
 
-    execSpace.fence();
-
 #ifdef GPU_DEBUG
     Kokkos::parallel_for(
         "fillHitsModuleStart_debugA", Kokkos::RangePolicy<ExecSpace>(execSpace, 0, 1), KOKKOS_LAMBDA(const int &index) {
@@ -675,7 +673,6 @@ namespace KOKKOS_NAMESPACE {
                 gpuClustering::countModules(moduleInd_d, moduleStart_d, clusStart_d, wordCounter, i);
               });
         }
-        KokkosExecSpace().fence();
 
         // read the number of modules into a data member, used by getProduct())
         Kokkos::deep_copy(

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
@@ -730,7 +730,7 @@ namespace KOKKOS_NAMESPACE {
         // last element holds the number of all clusters
         Kokkos::deep_copy(KokkosExecSpace(),
                           Kokkos::subview(nModules_Clusters_h, 1),
-                          Kokkos::subview(clusters_d.moduleStart(), ::gpuClustering::MaxNumModules));
+                          Kokkos::subview(clusters_d.clusModuleStart(), ::gpuClustering::MaxNumModules));
 
 #ifdef GPU_DEBUG
         KokkosExecSpace().fence();

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
@@ -578,10 +578,6 @@ namespace KOKKOS_NAMESPACE {
       }
       clusters_d = SiPixelClustersKokkos<KokkosExecSpace>(::gpuClustering::MaxNumModules);
 
-      // #ifdef TODO
-      //       nModules_Clusters_h = cms::cuda::make_host_unique<uint32_t[]>(2, stream);
-      // #endif
-
       if (wordCounter)  // protect in case of empty event....
       {
         assert(0 == wordCounter % 2);

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
@@ -491,16 +491,16 @@ namespace pixelgpudetails {
     // blockPrefixScan(moduleStart + 1, moduleStart + 1, 1024, ws);
     Kokkos::parallel_scan(
         "fillHitsModuleStart_scanA",
-        Kokkos::RangePolicy<ExecSpace>(execSpace, 1, 1024),
+        Kokkos::RangePolicy<ExecSpace>(execSpace, 1, 1025),
         KOKKOS_LAMBDA(const int &i, float &upd, const bool &final) {
-          upd += moduleStart[i + 1];
+          upd += moduleStart[i];
           if (final)
-            moduleStart[i + 1] = upd;
+            moduleStart[i] = upd;
         });
     // blockPrefixScan(moduleStart + 1025, moduleStart + 1025, gpuClustering::MaxNumModules - 1024, ws);
     Kokkos::parallel_scan(
         "fillHitsModuleStart_scanB",
-        Kokkos::RangePolicy<ExecSpace>(execSpace, 1025, gpuClustering::MaxNumModules - 1024),
+        Kokkos::RangePolicy<ExecSpace>(execSpace, 1025, 1025 + gpuClustering::MaxNumModules - 1024),
         KOKKOS_LAMBDA(const int &i, float &upd, const bool &final) {
           upd += moduleStart[i];
           if (final)

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.h
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.h
@@ -177,22 +177,13 @@ namespace KOKKOS_NAMESPACE {
                              bool includeErrors,
                              bool debug /*,
                                           cudaStream_t stream*/);
-#ifdef TODO
 
-      std::pair<SiPixelDigisCUDA, SiPixelClustersCUDA> getResults() {
-        digis_d.setNModulesDigis(nModules_Clusters_h[0], nDigis);
-        clusters_d.setNClusters(nModules_Clusters_h[1]);
-        // need to explicitly deallocate while the associated CUDA
-        // stream is still alive
-        //
-        // technically the statement above is not true anymore now that
-        // the CUDA streams are cached within the cms::cuda::StreamCache, but it is
-        // still better to release as early as possible
-        nModules_Clusters_h.reset();
+      std::pair<SiPixelDigisKokkos<KokkosExecSpace>, SiPixelClustersKokkos<KokkosExecSpace>> getResults() {
+        digis_d.setNModulesDigis(nModules_Clusters_h(0), nDigis);
+        clusters_d.setNClusters(nModules_Clusters_h(1));
         return std::make_pair(std::move(digis_d), std::move(clusters_d));
       }
-#endif
-      SiPixelDigiErrorsKokkos<KokkosExecSpace>&& getErrors() { return std::move(digiErrors_d); }
+      SiPixelDigiErrorsKokkos<KokkosExecSpace> getErrors() { return std::move(digiErrors_d); }
 
     private:
       uint32_t nDigis = 0;

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.h
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.h
@@ -189,7 +189,7 @@ namespace KOKKOS_NAMESPACE {
       uint32_t nDigis = 0;
 
       // Data to be put in the event
-      Kokkos::View<uint32_t*, KokkosExecSpace> nModules_Clusters_h;
+      Kokkos::View<uint32_t*, KokkosExecSpace>::HostMirror nModules_Clusters_h;
 
       SiPixelDigisKokkos<KokkosExecSpace> digis_d;
       SiPixelClustersKokkos<KokkosExecSpace> clusters_d;

--- a/src/kokkos/plugin-Validation/kokkos/CountValidator.cc
+++ b/src/kokkos/plugin-Validation/kokkos/CountValidator.cc
@@ -43,10 +43,10 @@ namespace KOKKOS_NAMESPACE {
   CountValidator::CountValidator(edm::ProductRegistry& reg)
       : digiClusterCountToken_(reg.consumes<DigiClusterCount>()),
         trackCountToken_(reg.consumes<TrackCount>()),
-        vertexCountToken_(reg.consumes<VertexCount>())
+        vertexCountToken_(reg.consumes<VertexCount>()),
+	digiToken_(reg.consumes<SiPixelDigisKokkos<KokkosExecSpace>>()),
+        clusterToken_(reg.consumes<SiPixelClustersKokkos<KokkosExecSpace>>())
 #ifdef TODO
-            digiToken_(reg.consumes<SiPixelDigisKokkos<KokkosExecSpace>>()),
-        clusterToken_(reg.consumes<SiPixelClustersKokkos<KokkosExecSpace>>()),
         trackToken_(reg.consumes<Kokkos::View<pixelTrack::TrackSoA, KokkosExecSpace>::HostMirror>()),
         vertexToken_(reg.consumes<Kokkos::View<ZVertexSoA, KokkosExecSpace>::HostMirror>())
 #endif
@@ -59,7 +59,6 @@ namespace KOKKOS_NAMESPACE {
 
     ss << "Event " << iEvent.eventID() << " ";
 
-#ifdef TODO
     {
       auto const& count = iEvent.get(digiClusterCountToken_);
       auto const& digis = iEvent.get(digiToken_);
@@ -79,6 +78,7 @@ namespace KOKKOS_NAMESPACE {
       }
     }
 
+#ifdef TODO
     {
       auto const& count = iEvent.get(trackCountToken_);
       auto const& tracks = iEvent.get(trackToken_);

--- a/src/kokkos/plugin-Validation/kokkos/CountValidator.cc
+++ b/src/kokkos/plugin-Validation/kokkos/CountValidator.cc
@@ -44,10 +44,10 @@ namespace KOKKOS_NAMESPACE {
       : digiClusterCountToken_(reg.consumes<DigiClusterCount>()),
         trackCountToken_(reg.consumes<TrackCount>()),
         vertexCountToken_(reg.consumes<VertexCount>()),
-	digiToken_(reg.consumes<SiPixelDigisKokkos<KokkosExecSpace>>()),
+        digiToken_(reg.consumes<SiPixelDigisKokkos<KokkosExecSpace>>()),
         clusterToken_(reg.consumes<SiPixelClustersKokkos<KokkosExecSpace>>())
 #ifdef TODO
-        trackToken_(reg.consumes<Kokkos::View<pixelTrack::TrackSoA, KokkosExecSpace>::HostMirror>()),
+            trackToken_(reg.consumes<Kokkos::View<pixelTrack::TrackSoA, KokkosExecSpace>::HostMirror>()),
         vertexToken_(reg.consumes<Kokkos::View<ZVertexSoA, KokkosExecSpace>::HostMirror>())
 #endif
   {


### PR DESCRIPTION
This PR makes several updates to `SiPixelRawToCluster` module
* Enable the event products
* Various fixes
* Remove unnecessary fences

With this PR the module runs for both serial and CUDA backends, and passes the (simple counting) validation for both.