### PR TITLE
[kokkos] Enable vertexing module

### DIFF
--- a/src/kokkos/bin/main.cc
+++ b/src/kokkos/bin/main.cc
@@ -99,14 +99,10 @@ int main(int argc, char** argv) {
         edmodules.emplace_back(prefix + "SiPixelRawToCluster");
         edmodules.emplace_back(prefix + "SiPixelRecHitKokkos");
         edmodules.emplace_back(prefix + "CAHitNtupletKokkos");
-#ifdef TODO
         edmodules.emplace_back(prefix + "PixelVertexProducerKokkos");
-#endif
         if (transfer) {
           edmodules.emplace_back(prefix + "PixelTrackSoAFromKokkos");
-#ifdef TODO
           edmodules.emplace_back(prefix + "PixelVertexSoAFromKokkos");
-#endif
         }
         if (validation) {
           edmodules.emplace_back(prefix + "CountValidator");

--- a/src/kokkos/plugin-Validation/kokkos/CountValidator.cc
+++ b/src/kokkos/plugin-Validation/kokkos/CountValidator.cc
@@ -46,12 +46,8 @@ namespace KOKKOS_NAMESPACE {
         vertexCountToken_(reg.consumes<VertexCount>()),
         digiToken_(reg.consumes<SiPixelDigisKokkos<KokkosExecSpace>>()),
         clusterToken_(reg.consumes<SiPixelClustersKokkos<KokkosExecSpace>>()),
-        trackToken_(reg.consumes<Kokkos::View<pixelTrack::TrackSoA, KokkosExecSpace>::HostMirror>())
-#ifdef TODO
-            vertexToken_(reg.consumes<Kokkos::View<ZVertexSoA, KokkosExecSpace>::HostMirror>())
-#endif
-  {
-  }
+        trackToken_(reg.consumes<Kokkos::View<pixelTrack::TrackSoA, KokkosExecSpace>::HostMirror>()),
+        vertexToken_(reg.consumes<Kokkos::View<ZVertexSoA, KokkosExecSpace>::HostMirror>()) {}
 
   void CountValidator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     std::stringstream ss;
@@ -88,7 +84,6 @@ namespace KOKKOS_NAMESPACE {
       }
     }
 
-#ifdef TODO
     {
       auto const& count = iEvent.get(vertexCountToken_);
       auto const& vertices = iEvent.get(vertexToken_);
@@ -98,7 +93,6 @@ namespace KOKKOS_NAMESPACE {
         ok = false;
       }
     }
-#endif
 
     ++allEvents;
     if (ok) {


### PR DESCRIPTION
Note that the serial backend current fails with
```
Kokkos::abort: Requested Team Size is too large!Aborted
```
and CUDA backend does not pass validation (possibly serial doesn't either).