### PR TITLE
various CUDA-related improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ export LIB_DIR := $(BASE_DIR)/lib
 export TEST_DIR := $(BASE_DIR)/test
 
 # System external definitions
-CUDA_BASE := /usr/local/cuda
+CUDA_BASE := /usr/local/cuda-10.2
 CUDA_LIBDIR := $(CUDA_BASE)/lib64
 USER_CUDAFLAGS :=
 export CUDA_DEPS := $(CUDA_BASE)/lib64/libcudart.so
@@ -36,7 +36,7 @@ export CUDA_TEST_CXXFLAGS := -DGPU_DEBUG
 export CUDA_LDFLAGS := -L$(CUDA_BASE)/lib64 -lcudart -lcudadevrt
 export CUDA_NVCC := $(CUDA_BASE)/bin/nvcc
 define CUFLAGS_template
-$(2)NVCC_FLAGS := $$(foreach ARCH,$(1),-gencode arch=compute_$$(ARCH),code=sm_$$(ARCH)) -Wno-deprecated-gpu-targets --expt-relaxed-constexpr --expt-extended-lambda --generate-line-info --source-in-ptx --cudart=shared
+$(2)NVCC_FLAGS := $$(foreach ARCH,$(1),-gencode arch=compute_$$(ARCH),code=sm_$$(ARCH)) -Wno-deprecated-gpu-targets -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --expt-relaxed-constexpr --expt-extended-lambda --generate-line-info --source-in-ptx --cudart=shared
 $(2)NVCC_COMMON := -std=c++14 -O3 $$($(2)NVCC_FLAGS) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS) $(USER_CXXFLAGS)'
 $(2)CUDA_CUFLAGS := -dc $$($(2)NVCC_COMMON) $(USER_CUDAFLAGS)
 $(2)CUDA_DLINKFLAGS := -dlink $$($(2)NVCC_COMMON)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ export CUDA_TEST_CXXFLAGS := -DGPU_DEBUG
 export CUDA_LDFLAGS := -L$(CUDA_BASE)/lib64 -lcudart -lcudadevrt
 export CUDA_NVCC := $(CUDA_BASE)/bin/nvcc
 define CUFLAGS_template
-$(2)NVCC_FLAGS := $$(foreach ARCH,$(1),-gencode arch=compute_$$(ARCH),code=sm_$$(ARCH)) --expt-relaxed-constexpr --expt-extended-lambda --generate-line-info --source-in-ptx --cudart=shared
+$(2)NVCC_FLAGS := $$(foreach ARCH,$(1),-gencode arch=compute_$$(ARCH),code=sm_$$(ARCH)) -Wno-deprecated-gpu-targets --expt-relaxed-constexpr --expt-extended-lambda --generate-line-info --source-in-ptx --cudart=shared
 $(2)NVCC_COMMON := -std=c++14 -O3 $$($(2)NVCC_FLAGS) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS) $(USER_CXXFLAGS)'
 $(2)CUDA_CUFLAGS := -dc $$($(2)NVCC_COMMON) $(USER_CUDAFLAGS)
 $(2)CUDA_DLINKFLAGS := -dlink $$($(2)NVCC_COMMON)

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ export BOOST_LDFLAGS := -L$(BOOST_BASE)/lib
 ALPAKA_BASE := $(EXTERNAL_BASE)/alpaka
 export ALPAKA_DEPS := $(ALPAKA_BASE)
 export ALPAKA_CXXFLAGS := -I$(ALPAKA_BASE)/include
-export ALPAKA_CUFLAGS := $(CUDA_CUFLAGS) -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
+export ALPAKA_CUFLAGS := $(CUDA_CUFLAGS)
 
 CUPLA_BASE := $(EXTERNAL_BASE)/cupla
 export CUPLA_DEPS := $(CUPLA_BASE)/lib
@@ -123,7 +123,7 @@ export KOKKOS_DEPS := $(KOKKOS_LIB)
 export KOKKOS_CXXFLAGS := -I$(KOKKOS_INSTALL)/include
 $(eval $(call CUFLAGS_template,$(KOKKOS_CUDA_ARCH),KOKKOS_))
 KOKKOS_CUDA_CUFLAGS := $(KOKKOS_NVCC_COMMON) $(USER_CUDAFLAGS)
-export KOKKOS_CUFLAGS := $(KOKKOS_CUDA_CUFLAGS) -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
+export KOKKOS_CUFLAGS := $(KOKKOS_CUDA_CUFLAGS)
 export KOKKOS_LDFLAGS := -L$(KOKKOS_INSTALL)/lib -lkokkoscore -ldl
 export KOKKOS_DLINKFLAGS := $(KOKKOS_CUDA_DLINKFLAGS)
 export NVCC_WRAPPER_DEFAULT_COMPILER := $(CXX)
@@ -160,7 +160,9 @@ env.sh: Makefile
 	@echo -n '$(CUPLA_LIBDIR):'                                             >> $@
 	@echo -n '$(KOKKOS_LIBDIR):'                                            >> $@
 	@echo '$$LD_LIBRARY_PATH'                                               >> $@
-	@echo 'export PATH=$$PATH:$(CUDA_BASE)/bin'                             >> $@
+	@echo -n 'export PATH='                                                 >> $@
+	@echo -n '$(CUDA_BASE)/bin:'                                            >> $@
+	@echo '$$PATH'                                                          >> $@
 
 define TARGET_template
 include src/$(1)/Makefile.deps

--- a/src/cudatest/plugin-Test1/gpuAlgo1.cu
+++ b/src/cudatest/plugin-Test1/gpuAlgo1.cu
@@ -40,7 +40,7 @@ namespace {
 
   template <typename T>
   __global__ void matrixMulVector(const T *a, const T *b, T *c, int numElements) {
-    int row = blockIdx.y * blockDim.y + threadIdx.y;
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (row < numElements) {
       T tmp = 0;

--- a/src/cudatest/plugin-Test2/gpuAlgo2.cu
+++ b/src/cudatest/plugin-Test2/gpuAlgo2.cu
@@ -40,7 +40,7 @@ namespace {
 
   template <typename T>
   __global__ void matrixMulVector(const T *a, const T *b, T *c, int numElements) {
-    int row = blockIdx.y * blockDim.y + threadIdx.y;
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (row < numElements) {
       T tmp = 0;


### PR DESCRIPTION
Hard code CUDA version 10.2, since CUDA 11.0 fails to run and CUDA 11.1 fails to build.
Silence CUDA warnings about deprecated architectures.
Remove duplicate use of `esa_on_defaulted_function_ignored`.
Fix a bug in the matrixMulVector test.
