### PR TITLE
Use CUDA_BASE and SYCL_BASE to choose targets to include in all, create hardware-specific test targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,24 @@ Options
 
 ### Additional make targets
 
+Note that the contents of `all`, `test`, and all `test_<arch>` targets
+are filtered based on the availability of compilers/toolchains. Essentially
+* by default programs using only GCC (or "host compiler") are included
+* if `CUDA_BASE` directory exists, programs using CUDA are included
+* if `SYCL_BASE` directory exists, programs using SYCL are included
+
 | Target                  | Description                                             |
 |-------------------------|---------------------------------------------------------|
 | `all` (default)         | Build all programs                                      |
+| `print_targets`         | Print the programs that would be built with `all`       |
+| `test`                  | Run all tests                                           |
+| `test_cpu`              | Run tests that use only CPU                             |
+| `test_nvidiagpu`        | Run tests that require NVIDIA GPU                       |
+| `test_intelgpu`         | Run tests that require Intel GPU                        |
+| `test_auto`             | Run tests that auto-discover the available hardware     |
+| `test_<program>`        | Run tests for program `<program>`                       |
+| `test_<program>_<arch>` | Run tests for program `<program>` that require `<arch>` |
 | `format`                | Format the code with `clang-format`                     |
-| `test`                  | Run all tests (each program with small number of events |
-| `test_cpu`              | Run tests for CPU test programs                         |
-| `test_cuda`             | Run tests for CUDA test programs                        |
 | `clean`                 | Remove all build artifacts                              |
 | `distclean`             | `clean` and remove all externals                        |
 | `dataclean`             | Remove downloaded data files                            |

--- a/src/alpaka/Makefile
+++ b/src/alpaka/Makefile
@@ -10,12 +10,14 @@ test_cpu: $(TARGET)
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --serial --tbb
 	@echo "Succeeded"
-test_cuda: $(TARGET)
+test_nvidiagpu: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --cuda
 	@echo "Succeeded"
-.PHONY: test_cpu test_cuda
+test_intelagpu:
+test_auto:
+.PHONY: test_cpu test_nvidiagpu test_intelgpu test_auto
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
@@ -113,7 +115,7 @@ test_$(2): run_$(1)
 endef
 $(foreach test,$(TESTS_SERIAL_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
 $(foreach test,$(TESTS_TBB_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
-$(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),cuda)))
+$(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),nvidiagpu)))
 
 -include $(ALL_DEPENDS)
 

--- a/src/alpakatest/Makefile
+++ b/src/alpakatest/Makefile
@@ -10,12 +10,14 @@ test_cpu: $(TARGET)
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --serial --tbb
 	@echo "Succeeded"
-test_cuda: $(TARGET)
+test_nvidiagpu: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --cuda
 	@echo "Succeeded"
-.PHONY: test_cpu test_cuda
+test_intelagpu:
+test_auto:
+.PHONY: test_cpu test_nvidiagpu test_intelgpu test_auto
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
@@ -114,7 +116,7 @@ test_$(2): run_$(1)
 endef
 $(foreach test,$(TESTS_SERIAL_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
 $(foreach test,$(TESTS_TBB_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
-$(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),cuda)))
+$(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),nvidiagpu)))
 
 -include $(ALL_DEPENDS)
 

--- a/src/cuda/Makefile
+++ b/src/cuda/Makefile
@@ -6,12 +6,14 @@ EXTERNAL_DEPENDS := $(cuda_EXTERNAL_DEPENDS)
 
 $(TARGET):
 test_cpu:
-test_cuda: $(TARGET)
+test_nvidiagpu: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2
 	@echo "Succeeded"
-.PHONY: test_cpu test_cuda
+test_intelagpu:
+test_auto:
+.PHONY: test_cpu test_nvidiagpu test_intelgpu test_auto
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
@@ -77,7 +79,7 @@ test_$(2): run_$(1)
 endef
 $(foreach test,$(TESTS_EXE_CPU),$(eval $(call RUNTEST_template,$(test),cpu)))
 TEST_EXE_CUDA_RUN := $(filter-out $(TEST_DIR)/$(TARGET_NAME)/testEigenGPUNoFit,$(TESTS_EXE_CUDA))
-$(foreach test,$(TEST_EXE_CUDA_RUN),$(eval $(call RUNTEST_template,$(test),cuda)))
+$(foreach test,$(TEST_EXE_CUDA_RUN),$(eval $(call RUNTEST_template,$(test),nvidiagpu)))
 
 -include $(ALL_DEPENDS)
 

--- a/src/cudadev/Makefile
+++ b/src/cudadev/Makefile
@@ -6,12 +6,14 @@ EXTERNAL_DEPENDS := $(cudadev_EXTERNAL_DEPENDS)
 
 $(TARGET):
 test_cpu:
-test_cuda: $(TARGET)
+test_nvidiagpu: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2
 	@echo "Succeeded"
-.PHONY: test_cpu test_cuda
+test_intelagpu:
+test_auto:
+.PHONY: test_cpu test_nvidiagpu test_intelgpu test_auto
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
@@ -77,7 +79,7 @@ test_$(2): run_$(1)
 endef
 $(foreach test,$(TESTS_EXE_CPU),$(eval $(call RUNTEST_template,$(test),cpu)))
 TEST_EXE_CUDA_RUN := $(filter-out $(TEST_DIR)/$(TARGET_NAME)/testEigenGPUNoFit,$(TESTS_EXE_CUDA))
-$(foreach test,$(TEST_EXE_CUDA_RUN),$(eval $(call RUNTEST_template,$(test),cuda)))
+$(foreach test,$(TEST_EXE_CUDA_RUN),$(eval $(call RUNTEST_template,$(test),nvidiagpu)))
 
 -include $(ALL_DEPENDS)
 

--- a/src/cudatest/Makefile
+++ b/src/cudatest/Makefile
@@ -6,12 +6,14 @@ EXTERNAL_DEPENDS := $(cudatest_EXTERNAL_DEPENDS)
 
 $(TARGET):
 test_cpu:
-test_cuda: $(TARGET)
+test_nvidiagpu: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2
 	@echo "Succeeded"
-.PHONY: test_cpu test_cuda
+test_intelagpu:
+test_auto:
+.PHONY: test_cpu test_nvidiagpu test_intelgpu test_auto
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
@@ -76,7 +78,7 @@ run_$(1): $(1)
 test_$(2): run_$(1)
 endef
 $(foreach test,$(TESTS_EXE_CPU),$(eval $(call RUNTEST_template,$(test),cpu)))
-$(foreach test,$(TESTS_EXE_CUDA),$(eval $(call RUNTEST_template,$(test),cuda)))
+$(foreach test,$(TESTS_EXE_CUDA),$(eval $(call RUNTEST_template,$(test),nvidiagpu)))
 
 -include $(ALL_DEPENDS)
 

--- a/src/cudauvm/Makefile
+++ b/src/cudauvm/Makefile
@@ -6,12 +6,14 @@ EXTERNAL_DEPENDS := $(cudauvm_EXTERNAL_DEPENDS)
 
 $(TARGET):
 test_cpu:
-test_cuda: $(TARGET)
+test_nvidiagpu: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2
 	@echo "Succeeded"
-.PHONY: test_cpu test_cuda
+test_intelagpu:
+test_auto:
+.PHONY: test_cpu test_nvidiagpu test_intelgpu test_auto
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
@@ -77,7 +79,7 @@ test_$(2): run_$(1)
 endef
 $(foreach test,$(TESTS_EXE_CPU),$(eval $(call RUNTEST_template,$(test),cpu)))
 TEST_EXE_CUDA_RUN := $(filter-out $(TEST_DIR)/$(TARGET_NAME)/testEigenGPUNoFit,$(TESTS_EXE_CUDA))
-$(foreach test,$(TEST_EXE_CUDA_RUN),$(eval $(call RUNTEST_template,$(test),cuda)))
+$(foreach test,$(TEST_EXE_CUDA_RUN),$(eval $(call RUNTEST_template,$(test),nvidiagpu)))
 
 -include $(ALL_DEPENDS)
 

--- a/src/fwtest/Makefile
+++ b/src/fwtest/Makefile
@@ -10,8 +10,10 @@ test_cpu: $(TARGET)
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2
 	@echo "Succeeded"
-test_cuda:
-.PHONY: test_cpu test_cuda
+test_nvidiagpu:
+test_intelagpu:
+test_auto:
+.PHONY: test_cpu test_nvidiagpu test_intelgpu test_auto
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))

--- a/src/kokkos/Makefile
+++ b/src/kokkos/Makefile
@@ -10,12 +10,14 @@ test_cpu: $(TARGET)
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --serial
 	@echo "Succeeded"
-test_cuda: $(TARGET)
+test_nvidiagpu: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --cuda
 	@echo "Succeeded"
-.PHONY: test_cpu test_cuda
+test_intelagpu:
+test_auto:
+.PHONY: test_cpu test_nvidiagpu test_intelgpu test_auto
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
@@ -114,7 +116,7 @@ endef
 # VertexFinder_t.serial currently goes to infinite loop
 TESTS_SERIAL_EXE_RUN := $(filter-out $(TEST_DIR)/$(TARGET_NAME)/VertexFinder_t.serial,$(TESTS_SERIAL_EXE))
 $(foreach test,$(TESTS_SERIAL_EXE_RUN),$(eval $(call RUNTEST_template,$(test),cpu)))
-$(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),cuda)))
+$(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),nvidiagpu)))
 
 -include $(ALL_DEPENDS)
 

--- a/src/kokkostest/Makefile
+++ b/src/kokkostest/Makefile
@@ -10,12 +10,14 @@ test_cpu: $(TARGET)
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --serial
 	@echo "Succeeded"
-test_cuda: $(TARGET)
+test_nvidiagpu: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --cuda
 	@echo "Succeeded"
-.PHONY: test_cpu test_cuda
+test_intelagpu:
+test_auto:
+.PHONY: test_cpu test_nvidiagpu test_intelgpu test_auto
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
@@ -112,7 +114,7 @@ run_$(1): $(1)
 test_$(2): run_$(1)
 endef
 $(foreach test,$(TESTS_SERIAL_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
-$(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),cuda)))
+$(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),nvidiagpu)))
 
 -include $(ALL_DEPENDS)
 

--- a/src/sycltest/Makefile
+++ b/src/sycltest/Makefile
@@ -6,12 +6,14 @@ EXTERNAL_DEPENDS := $(sycltest_EXTERNAL_DEPENDS)
 
 $(TARGET):
 test_cpu:
-test_sycl: $(TARGET)
+test_nvidiagpu:
+test_intelagpu:
+test_auto: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2
 	@echo "Succeeded"
-.PHONY: test_cpu test_sycl
+.PHONY: test_cpu test_nvidiagpu test_intelgpu test_auto
 
 EXE_SRC := $(wildcard $(TARGET_DIR)/bin/*.cc)
 EXE_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(EXE_SRC:%=%.o))
@@ -67,7 +69,7 @@ run_$(1): $(1)
 	@echo "Succeeded"
 test_$(2): run_$(1)
 endef
-$(foreach test,$(TESTS_EXE_CPU),$(eval $(call RUNTEST_template,$(test),cpu)))
+$(foreach test,$(TESTS_EXE_CPU),$(eval $(call RUNTEST_template,$(test),auto)))
 
 -include $(ALL_DEPENDS)
 


### PR DESCRIPTION
New attempt to be more flexible with the build targets, based on the discussion in https://github.com/cms-patatrack/pixeltrack-standalone/pull/112.