### PR TITLE
[kokkos] Replace Nx parallel_scan() with one parallel_scan()+2x parallel_for() in HistoContainer finalize()

### DIFF
--- a/src/kokkos/KokkosCore/HistoContainer.h
+++ b/src/kokkos/KokkosCore/HistoContainer.h
@@ -87,6 +87,7 @@ namespace cms {
     template <typename Histo, typename ExecSpace>
     inline void launchFinalize(Kokkos::View<Histo, ExecSpace> h, ExecSpace const& execSpace) {
       Kokkos::parallel_scan(
+          "launchFinalize",
           Kokkos::RangePolicy<ExecSpace>(execSpace, 0, Histo::totbins()),
           KOKKOS_LAMBDA(const int& i, float& upd, const bool& final) {
             upd += h().off[i];


### PR DESCRIPTION
This is a more performance workaround for Kokkos not providing team-wide prefix scan.