### PR TITLE
[cudauvm] Add a macro to allow disabling the use of managed memory in BeamSpotToCUDA module

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ $ ./kokkos --cuda
    * `--cuda` for CUDA backend
 * Use of multiple threads (`--numberOfThreads`) has not been tested and likely does not work correctly. Concurrent events (`--numberOfStreams`) works.
 
-| Make variable            | Description |
-------------------------------------------
-| `CUDA_BASE`              | Path to CUDA installation |
-| `CMAKE`                  | Path to CMake executable (by default assume `cmake` is found in `$PATH`)) |
+| Make variable            | Description                                                                                                                             |
+|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `CUDA_BASE`              | Path to CUDA installation                                                                                                               |
+| `CMAKE`                  | Path to CMake executable (by default assume `cmake` is found in `$PATH`))                                                               |
 | `KOKKOS_CUDA_ARCH`       | Target CUDA architecture for Kokkos build, currently needs to be exact. (default: `70`, possible values: `70`, `75`; trivial to extend) |
-| `KOKKOS_HOST_PARALLEL`   | Host-parallel backend (default empty, possible values: empty, `PTHREAD) |
-| `KOKKOS_DEVICE_PARALLEL` | Device-parallel backend (default `CUDA`, possible values: empty, `CUDA`) |
+| `KOKKOS_HOST_PARALLEL`   | Host-parallel backend (default empty, possible values: empty, `PTHREAD)                                                                 |
+| `KOKKOS_DEVICE_PARALLEL` | Device-parallel backend (default `CUDA`, possible values: empty, `CUDA`)                                                                |
 
 ## Code structure
 

--- a/README.md
+++ b/README.md
@@ -128,17 +128,22 @@ This program contains developments after CMSSW_11_1_0_pre4.
 
 #### `cudauvm`
 
-The purpose of this program is to test the performance of the CUDA managed memory.
-
-To disable `cudaMemAdvise(cudaMemAdviseSetReadMostly)`, compile with
+The purpose of this program is to test the performance of the CUDA
+managed memory. There are various macros that can be used to switch on
+and off various behaviors. The default behavior is to use use managed
+memory only for those memory blocks that are used for memory
+transfers, call `cudaMemPrefetchAsync()`, and
+`cudaMemAdvise(cudaMemAdviseSetReadMostly)`. The macros can be set at
+compile time along
 ```
 make cudauvm ... USER_CXXFLAGS="-DCUDAUVM_DISABLE_ADVISE"
 ```
 
-To disable `cudaMemPrefetchAsync`, compile with
-```
-make cudauvm ... USER_CXXFLAGS="-DCUDAUVM_DISABLE_PREFETCH"
-```
+| Macro                                | Effect                                              |
+|--------------------------------------|-----------------------------------------------------|
+| `-DCUDAUVM_DISABLE_ADVISE`           | Disable `cudaMemPrefetchAsync`                      |
+| `-DCUDAUVM_DISABLE_PREFETCH`         | Disable `cudaMemAdvise(cudaMemAdviseSetReadMostly)` |
+| `-DCUDAUVM_DISABLE_MANAGED_BEAMSPOT` | Disable managed memory in `BeamSpotToCUDA`          |
 
 #### `kokkos` and `kokkostest`
 

--- a/src/cudauvm/CUDADataFormats/BeamSpotCUDA.cc
+++ b/src/cudauvm/CUDADataFormats/BeamSpotCUDA.cc
@@ -4,7 +4,13 @@
 #include "CUDACore/managed_unique_ptr.h"
 #include "CUDACore/ScopedSetDevice.h"
 
-BeamSpotCUDA::BeamSpotCUDA(Data const& data_h, int device, cudaStream_t stream): device_(device) {
+#ifdef CUDAUVM_DISABLE_MANAGED_BEAMSPOT
+BeamSpotCUDA::BeamSpotCUDA(Data const* data_h, cudaStream_t stream) {
+  data_d_ = cms::cuda::make_device_unique<Data>(stream);
+  cudaCheck(cudaMemcpyAsync(data_d_.get(), data_h, sizeof(Data), cudaMemcpyHostToDevice, stream));
+}
+#else
+BeamSpotCUDA::BeamSpotCUDA(Data const& data_h, int device, cudaStream_t stream) : device_(device) {
   data_d_ = cms::cuda::make_managed_unique<Data>(stream);
   *data_d_ = data_h;
 #ifndef CUDAUVM_DISABLE_ADVISE
@@ -14,11 +20,14 @@ BeamSpotCUDA::BeamSpotCUDA(Data const& data_h, int device, cudaStream_t stream):
   cudaCheck(cudaMemPrefetchAsync(data_d_.get(), sizeof(Data), device, stream));
 #endif
 }
+#endif  // CUDAUVM_DISABLE_MANAGED_BEAMSPOT
 
 BeamSpotCUDA::~BeamSpotCUDA() {
+#ifndef CUDAUVM_DISABLE_MANAGED_BEAMSPOT
 #ifndef CUDAUVM_DISABLE_ADVISE
   // need to make sure a CUDA context is initialized for a thread
   cms::cuda::ScopedSetDevice(0);
   cudaCheck(cudaMemAdvise(data_d_.get(), sizeof(Data), cudaMemAdviseUnsetReadMostly, device_));
+#endif
 #endif
 }

--- a/src/cudauvm/CUDADataFormats/BeamSpotCUDA.h
+++ b/src/cudauvm/CUDADataFormats/BeamSpotCUDA.h
@@ -1,7 +1,11 @@
 #ifndef CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h
 #define CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h
 
+#ifdef CUDAUVM_DISABLE_MANAGED_BEAMSPOT
+#include "CUDACore/device_unique_ptr.h"
+#else
 #include "CUDACore/managed_unique_ptr.h"
+#endif
 
 #include <cuda_runtime.h>
 
@@ -23,14 +27,22 @@ public:
   };
 
   BeamSpotCUDA() = default;
+#ifdef CUDAUVM_DISABLE_MANAGED_BEAMSPOT
+  BeamSpotCUDA(Data const* data_h, cudaStream_t stream);
+#else
   BeamSpotCUDA(Data const& data_h, int device, cudaStream_t stream);
+#endif
   ~BeamSpotCUDA();
 
   Data const* data() const { return data_d_.get(); }
 
 private:
+#ifdef CUDAUVM_DISABLE_MANAGED_BEAMSPOT
+  cms::cuda::device::unique_ptr<Data> data_d_;
+#else
   cms::cuda::managed::unique_ptr<Data> data_d_;
   int device_;
+#endif
 };
 
 #endif

--- a/src/cudauvm/bin/main.cc
+++ b/src/cudauvm/bin/main.cc
@@ -94,6 +94,9 @@ int main(int argc, char** argv) {
 #ifdef CUDAUVM_DISABLE_PREFETCH
   std::cout << "cudaMemPrefetchAsync() calls are disabled" << std::endl;
 #endif
+#ifdef CUDAUVM_DISABLE_MANAGED_BEAMSPOT
+  std::cout << "Managed memory is disabled in BeamSpotToCUDA" << std::endl;
+#endif
 
   // Initialize EventProcessor
   std::vector<std::string> edmodules;

--- a/src/cudauvm/plugin-BeamSpotProducer/BeamSpotToCUDA.cc
+++ b/src/cudauvm/plugin-BeamSpotProducer/BeamSpotToCUDA.cc
@@ -5,6 +5,9 @@
 #include "Framework/PluginFactory.h"
 #include "Framework/EDProducer.h"
 #include "CUDACore/ScopedContext.h"
+#ifdef CUDAUVM_DISABLE_MANAGED_BEAMSPOT
+#include "CUDACore/host_noncached_unique_ptr.h"
+#endif
 
 #include <cuda_runtime.h>
 
@@ -19,17 +22,35 @@ public:
 
 private:
   edm::EDPutTokenT<cms::cuda::Product<BeamSpotCUDA>> bsPutToken_;
+
+#ifdef CUDAUVM_DISABLE_MANAGED_BEAMSPOT
+  cms::cuda::host::noncached::unique_ptr<BeamSpotCUDA::Data> bsHost;
+#endif
 };
 
 BeamSpotToCUDA::BeamSpotToCUDA(edm::ProductRegistry& reg)
-    : bsPutToken_{reg.produces<cms::cuda::Product<BeamSpotCUDA>>()} {}
+    : bsPutToken_(reg.produces<cms::cuda::Product<BeamSpotCUDA>>())
+#ifdef CUDAUVM_DISABLE_MANAGED_BEAMSPOT
+      ,
+      bsHost(cms::cuda::make_host_noncached_unique<BeamSpotCUDA::Data>(cudaHostAllocWriteCombined))
+#endif
+{
+}
 
 void BeamSpotToCUDA::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+#ifdef CUDAUVM_DISABLE_MANAGED_BEAMSPOT
+  *bsHost = iSetup.get<BeamSpotCUDA::Data>();
+#else
   auto const& bs = iSetup.get<BeamSpotCUDA::Data>();
+#endif
 
   cms::cuda::ScopedContextProduce ctx{iEvent.streamID()};
 
+#ifdef CUDAUVM_DISABLE_MANAGED_BEAMSPOT
+  ctx.emplace(iEvent, bsPutToken_, bsHost.get(), ctx.stream());
+#else
   ctx.emplace(iEvent, bsPutToken_, bs, ctx.device(), ctx.stream());
+#endif
 }
 
 DEFINE_FWK_MODULE(BeamSpotToCUDA);


### PR DESCRIPTION
My earlier approach for measuring the performance impact of gradually enabling managed memory in the modules would have required active work through them to measure the throughput properly for each PR, and would not allow proper way to reproduce the results later. I'm changing the approach to have per-module macros allow disabling the use of managed memory (even if that makes the `#ifdef` logic more messy).