### PR TITLE
[kokkos] Update Kokkos to 3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ $(CUPLA_BASE)/lib: $(CUPLA_BASE) $(ALPAKA_DEPS) $(BOOST_DEPS) $(TBB_DEPS) $(CUDA
 external_kokkos: $(KOKKOS_LIB)
 
 $(KOKKOS_SRC):
-	git clone --branch 3.1.01 https://github.com/kokkos/kokkos.git $@
+	git clone --branch 3.2.00 https://github.com/kokkos/kokkos.git $@
 
 $(KOKKOS_BUILD):
 	mkdir -p $@


### PR DESCRIPTION
Requires either `make distclean` or `rm -fR external/kokkos`