### PR TITLE
[kokkostest] Polishing the "device framework" prototype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,8 @@ test_auto: $(TEST_AUTO_TARGETS)
 .PHONY: test_nvidiagpu $(TEST_NVIDIAGPU_TARGETS)
 .PHONY: test_intelgpu $(TEST_INTELGPU_TARGETS)
 .PHONY: test_auto $(TEST_AUTO_TARGETS)
-.PHONY: environment print_targets format clean distclean dataclean
+.PHONY: format $(patsubst %,format_%,$(TARGETS_ALL))
+.PHONY: environment print_targets clean distclean dataclean
 .PHONY: external_tbb external_cub external_eigen external_kokkos external_kokkos_clean
 
 environment: env.sh
@@ -308,8 +309,14 @@ print_targets:
 	@echo "Following program targets are available"
 	@echo $(TARGETS)
 
-format:
-	$(CLANG_FORMAT) -i $(shell find src -name "*.h" -o -name "*.cc" -o -name "*.cu")
+define FORMAT_template
+format_$(1):
+	@echo "Formatting $(1)"
+	@$(CLANG_FORMAT) -i $$(shell find $(SRC_DIR)/$(1) -name "*.h" -o -name "*.cc" -o -name "*.cu")
+endef
+$(foreach target,$(TARGETS_ALL),$(eval $(call FORMAT_template,$(target))))
+
+format: $(patsubst %,format_%,$(TARGETS_ALL))
 
 clean:
 	rm -fR lib obj test $(TARGETS_ALL)

--- a/src/kokkostest/KokkosCore/ProductBase.h
+++ b/src/kokkostest/KokkosCore/ProductBase.h
@@ -39,10 +39,11 @@ namespace cms {
 
         void recordEvent() {}
         void enqueueCallback(edm::WaitingTaskWithArenaHolder withArenaHolder) {
+          space_.fence();
           auto holder = withArenaHolder.makeWaitingTaskHolderAndRelease();
           holder.doneWaiting(nullptr);
         }
-        void synchronizeWith(ExecSpaceSpecific const&) const {}
+        void synchronizeWith(ExecSpaceSpecific const& other) const { other.execSpace().fence(); }
 
         ExecSpace const& execSpace() const { return space_; }
 

--- a/src/kokkostest/KokkosCore/kokkosConfig.h
+++ b/src/kokkostest/KokkosCore/kokkosConfig.h
@@ -37,6 +37,12 @@ struct KokkosBackend<Kokkos::Cuda> {
 };
 #endif
 
+// shorthand because this will be used a lot
+template <typename T>
+auto hintLightWeight(T&& policy) {
+  return Kokkos::Experimental::require(policy, Kokkos::Experimental::WorkItemProperty::HintLightWeight);
+}
+
 // trick to force expanding KOKKOS_NAMESPACE before stringification inside DEFINE_FWK_MODULE
 #define DEFINE_FWK_KOKKOS_MODULE2(name) DEFINE_FWK_MODULE(name)
 #define DEFINE_FWK_KOKKOS_MODULE(name) DEFINE_FWK_KOKKOS_MODULE2(KOKKOS_NAMESPACE::name)

--- a/src/kokkostest/plugin-Test1/kokkos/kokkosAlgo1.cc
+++ b/src/kokkostest/plugin-Test1/kokkos/kokkosAlgo1.cc
@@ -30,15 +30,15 @@ namespace KOKKOS_NAMESPACE {
 
     Kokkos::View<float*, KokkosExecSpace> d_c{"d_c", NUM_VALUES};
     Kokkos::parallel_for(
-        Kokkos::RangePolicy<KokkosExecSpace>(execSpace, 0, NUM_VALUES),
+        hintLightWeight(Kokkos::RangePolicy<KokkosExecSpace>(execSpace, 0, NUM_VALUES)),
         KOKKOS_LAMBDA(const size_t i) { d_c[i] = d_a[i] + d_b[i]; });
 
     Kokkos::View<float**, KokkosExecSpace> d_ma{"d_ma", NUM_VALUES, NUM_VALUES};
     Kokkos::View<float**, KokkosExecSpace> d_mb{"d_mb", NUM_VALUES, NUM_VALUES};
     Kokkos::View<float**, KokkosExecSpace> d_mc{"d_mc", NUM_VALUES, NUM_VALUES};
 
-    auto policy =
-        Kokkos::MDRangePolicy<KokkosExecSpace, Kokkos::Rank<2>>(execSpace, {{0, 0}}, {{NUM_VALUES, NUM_VALUES}});
+    auto policy = hintLightWeight(
+        Kokkos::MDRangePolicy<KokkosExecSpace, Kokkos::Rank<2>>(execSpace, {{0, 0}}, {{NUM_VALUES, NUM_VALUES}}));
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(const size_t row, const size_t col) { vectorProd(d_a, d_b, d_ma, row, col); });
     Kokkos::parallel_for(
@@ -53,7 +53,8 @@ namespace KOKKOS_NAMESPACE {
         });
 
     Kokkos::parallel_for(
-        Kokkos::RangePolicy<KokkosExecSpace>(execSpace, 0, NUM_VALUES), KOKKOS_LAMBDA(const size_t row) {
+        hintLightWeight(Kokkos::RangePolicy<KokkosExecSpace>(execSpace, 0, NUM_VALUES)),
+        KOKKOS_LAMBDA(const size_t row) {
           float tmp = 0;
           for (int i = 0; i < NUM_VALUES; ++i) {
             tmp += d_ma(row, i) * d_b[i];

--- a/src/kokkostest/plugin-Test2/kokkos/kokkosAlgo2.cc
+++ b/src/kokkostest/plugin-Test2/kokkos/kokkosAlgo2.cc
@@ -30,15 +30,15 @@ namespace KOKKOS_NAMESPACE {
 
     Kokkos::View<float*, KokkosExecSpace> d_c{"d_c", NUM_VALUES};
     Kokkos::parallel_for(
-        Kokkos::RangePolicy<KokkosExecSpace>(execSpace, 0, NUM_VALUES),
+        hintLightWeight(Kokkos::RangePolicy<KokkosExecSpace>(execSpace, 0, NUM_VALUES)),
         KOKKOS_LAMBDA(const size_t i) { d_c[i] = d_a[i] + d_b[i]; });
 
     Kokkos::View<float**, KokkosExecSpace> d_ma{"d_ma", NUM_VALUES, NUM_VALUES};
     Kokkos::View<float**, KokkosExecSpace> d_mb{"d_mb", NUM_VALUES, NUM_VALUES};
     Kokkos::View<float**, KokkosExecSpace> d_mc{"d_mc", NUM_VALUES, NUM_VALUES};
 
-    auto policy =
-        Kokkos::MDRangePolicy<KokkosExecSpace, Kokkos::Rank<2>>(execSpace, {{0, 0}}, {{NUM_VALUES, NUM_VALUES}});
+    auto policy = hintLightWeight(
+        Kokkos::MDRangePolicy<KokkosExecSpace, Kokkos::Rank<2>>(execSpace, {{0, 0}}, {{NUM_VALUES, NUM_VALUES}}));
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(const size_t row, const size_t col) { vectorProd(d_a, d_b, d_ma, row, col); });
     Kokkos::parallel_for(
@@ -53,7 +53,8 @@ namespace KOKKOS_NAMESPACE {
         });
 
     Kokkos::parallel_for(
-        Kokkos::RangePolicy<KokkosExecSpace>(execSpace, 0, NUM_VALUES), KOKKOS_LAMBDA(const size_t row) {
+        hintLightWeight(Kokkos::RangePolicy<KokkosExecSpace>(execSpace, 0, NUM_VALUES)),
+        KOKKOS_LAMBDA(const size_t row) {
           float tmp = 0;
           for (int i = 0; i < NUM_VALUES; ++i) {
             tmp += d_ma(row, i) * d_b[i];


### PR DESCRIPTION
In general the execution space `fence()` needs to be called at the synchronization points (which are treated differently with CUDA by using events and callback functions).

The `HintLightWeight` should disable the constant cache optimization of Kokkos, which prohibits concurrent calls to `parallel_X`. I created a helper function reduce the necessary boilerplace on client code.

I also improved a bit the `make format` implementation because I was confused by "No such file or directory" error I was getting (in the end it was caused by something else, but the new structure helped to pinpoint it).