### PR TITLE
[alpakatest] Add cudatest tests to alpakatest tests

### DIFF
--- a/src/alpakatest/AlpakaCore/alpakaConfig.h
+++ b/src/alpakatest/AlpakaCore/alpakaConfig.h
@@ -5,12 +5,15 @@
 
 namespace alpaka_common {
   using Dim = alpaka::dim::DimInt<1u>;
+  using Dim2 = alpaka::dim::DimInt<2u>;
   using Idx = uint32_t;
   using Extent = uint32_t;
   using DevHost = alpaka::dev::DevCpu;
   using PltfHost = alpaka::pltf::Pltf<DevHost>;
   using WorkDiv = alpaka::workdiv::WorkDivMembers<Dim, Idx>;
+  using WorkDiv2 = alpaka::workdiv::WorkDivMembers<Dim2, Idx>;
   using Vec = alpaka::vec::Vec<Dim, Idx>;
+  using Vec2 = alpaka::vec::Vec<Dim2, Idx>;
 }  // namespace alpaka_common
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -18,8 +21,11 @@ namespace alpaka_common {
 namespace alpaka_cuda_async {
   using namespace alpaka_common;
   using Acc = alpaka::acc::AccGpuCudaRt<Dim, Extent>;
+  using Acc2 = alpaka::acc::AccGpuCudaRt<Dim2, Extent>;
   using DevAcc = alpaka::dev::Dev<Acc>;
+  using DevAcc2 = alpaka::dev::Dev<Acc2>;
   using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
   using Queue = alpaka::queue::QueueCudaRtNonBlocking;
 }  // namespace alpaka_cuda_async
 
@@ -35,8 +41,11 @@ namespace alpaka_cuda_async {
 namespace alpaka_serial_sync {
   using namespace alpaka_common;
   using Acc = alpaka::acc::AccCpuSerial<Dim, Extent>;
+  using Acc2 = alpaka::acc::AccCpuSerial<Dim2, Extent>;
   using DevAcc = alpaka::dev::Dev<Acc>;
+  using DevAcc2 = alpaka::dev::Dev<Acc2>;
   using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
   using Queue = alpaka::queue::QueueCpuBlocking;
 }  // namespace alpaka_serial_sync
 
@@ -52,8 +61,11 @@ namespace alpaka_serial_sync {
 namespace alpaka_tbb_async {
   using namespace alpaka_common;
   using Acc = alpaka::acc::AccCpuTbbBlocks<Dim, Extent>;
+  using Acc2 = alpaka::acc::AccCpuTbbBlocks<Dim2, Extent>;
   using DevAcc = alpaka::dev::Dev<Acc>;
+  using DevAcc2 = alpaka::dev::Dev<Acc2>;
   using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
   using Queue = alpaka::queue::QueueCpuNonBlocking;
 }  // namespace alpaka_tbb_async
 
@@ -69,8 +81,11 @@ namespace alpaka_tbb_async {
 namespace alpaka_omp2_async {
   using namespace alpaka_common;
   using Acc = alpaka::acc::AccCpuOmp2Blocks<Dim, Extent>;
+  using Acc2 = alpaka::acc::AccCpuOmp2Blocks<Dim2, Extent>;
   using DevAcc = alpaka::dev::Dev<Acc>;
+  using DevAcc2 = alpaka::dev::Dev<Acc2>;
   using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
   using Queue = alpaka::queue::QueueCpuNonBlocking;
 }  // namespace alpaka_omp2_async
 
@@ -86,8 +101,11 @@ namespace alpaka_omp2_async {
 namespace alpaka_omp4_async {
   using namespace alpaka_common;
   using Acc = alpaka::acc::AccCpuOmp4<Dim, Extent>;
+  using Acc2 = alpaka::acc::AccCpuOmp4<Dim2, Extent>;
   using DevAcc = alpaka::dev::Dev<Acc>;
+  using DevAcc2 = alpaka::dev::Dev<Acc2>;
   using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
   using Queue = alpaka::queue::QueueCpuNonBlocking;
 }  // namespace alpaka_omp4_async
 

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
@@ -3,101 +3,315 @@
 namespace {
   constexpr unsigned int NUM_VALUES = 1000;
 
+
   struct vectorAdd {
     template <typename T_Acc, typename T_Data>
     ALPAKA_FN_ACC void operator()(
-        T_Acc const &acc, T_Data const *a, T_Data const *b, T_Data *c, unsigned int numElements) const {
-      //uint32_t const gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
-      uint32_t const blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u]);
-      uint32_t const gridBlockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
-      uint32_t const blockThreadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
-      uint32_t const elemDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
 
-      uint32_t i = (blockThreadIdx + gridBlockIdx * blockDimension) * elemDimension;
-      if (i < numElements) {
-        c[i] = a[i] + b[i];
+      // Global thread index in grid
+      const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+      const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+
+      // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+      const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
+      const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
+      const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
+
+
+      for (uint32_t i = firstElementIdxGlobal; i < endElementIdxGlobal; ++i) {
+	c[i] = a[i] + b[i];
       }
+
     }
   };
 
-#ifdef TODO
-  template <typename T>
-  __global__ void vectorProd(const T *a, const T *b, T *c, int numElements) {
-    int row = blockIdx.y * blockDim.y + threadIdx.y;
-    int col = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if (row < numElements && col < numElements) {
-      c[row * numElements + col] = a[row] * b[col];
-    }
-  }
+  struct vectorProd {
+    template <typename T_Acc, typename T_Data>
+    ALPAKA_FN_ACC void operator()(
+				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
 
-  template <typename T>
-  __global__ void matrixMul(const T *a, const T *b, T *c, int numElements) {
-    int row = blockIdx.y * blockDim.y + threadIdx.y;
-    int col = blockIdx.x * blockDim.x + threadIdx.x;
+      // Global thread index in Dim2 grid
+      const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+      const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+      const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
 
-    if (row < numElements && col < numElements) {
-      T tmp = 0;
-      for (int i = 0; i < numElements; ++i) {
-        tmp += a[row * numElements + i] * b[i * numElements + col];
+      // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+      const auto& threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc));
+      const uint32_t threadDimensionX(threadDimension[0u]);
+      const uint32_t firstElementIdxGlobalX = threadIdxGlobalX * threadDimensionX;
+      const uint32_t endElementIdxGlobalXUncut = firstElementIdxGlobalX + threadDimensionX;
+      const uint32_t endElementIdxGlobalX = std::min(endElementIdxGlobalXUncut, numElements);
+
+      const uint32_t threadDimensionY(threadDimension[1u]);
+      const uint32_t firstElementIdxGlobalY = threadIdxGlobalY * threadDimensionY;
+      const uint32_t endElementIdxGlobalYUncut = firstElementIdxGlobalY + threadDimensionY;
+      const uint32_t endElementIdxGlobalY = std::min(endElementIdxGlobalYUncut, numElements);
+
+
+      for (uint32_t col = firstElementIdxGlobalX; col < endElementIdxGlobalX; ++col) {
+	for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {
+
+	  c[row + numElements * col] = a[row] * b[col];
+	}
       }
-      c[row * numElements + col] = tmp;
+
     }
-  }
+  };
 
-  template <typename T>
-  __global__ void matrixMulVector(const T *a, const T *b, T *c, int numElements) {
-    int row = blockIdx.y * blockDim.y + threadIdx.y;
 
-    if (row < numElements) {
-      T tmp = 0;
-      for (int i = 0; i < numElements; ++i) {
-        tmp += a[row * numElements + i] * b[i];
+  struct matrixMul {
+    template <typename T_Acc, typename T_Data>
+    ALPAKA_FN_ACC void operator()(
+				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
+
+      // Global thread index in Dim2 grid
+      const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+      const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+      const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
+
+      // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+      const auto& threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc));
+      const uint32_t threadDimensionX(threadDimension[0u]);
+      const uint32_t firstElementIdxGlobalX = threadIdxGlobalX * threadDimensionX;
+      const uint32_t endElementIdxGlobalXUncut = firstElementIdxGlobalX + threadDimensionX;
+      const uint32_t endElementIdxGlobalX = std::min(endElementIdxGlobalXUncut, numElements);
+
+      const uint32_t threadDimensionY(threadDimension[1u]);
+      const uint32_t firstElementIdxGlobalY = threadIdxGlobalY * threadDimensionY;
+      const uint32_t endElementIdxGlobalYUncut = firstElementIdxGlobalY + threadDimensionY;
+      const uint32_t endElementIdxGlobalY = std::min(endElementIdxGlobalYUncut, numElements);
+
+
+      for (uint32_t col = firstElementIdxGlobalX; col < endElementIdxGlobalX; ++col) {
+	for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {	
+
+	  T_Data tmp = 0;
+	  for (unsigned int i = 0; i < numElements; ++i) {
+	    tmp += a[row + numElements * i] * b[i + numElements * col];
+	  }
+	  c[row + numElements * col] = tmp;
+	}
       }
-      c[row] = tmp;
+
     }
-  }
-#endif
-}  // namespace
+  };
+
+
+  struct matrixMulVector {
+    template <typename T_Acc, typename T_Data>
+    ALPAKA_FN_ACC void operator()(
+				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
+
+      // Global thread index in grid
+      const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+      const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+
+      // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+      const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
+      const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
+      const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
+
+
+      for (uint32_t row = firstElementIdxGlobal; row < endElementIdxGlobal; ++row) {
+	T_Data tmp = 0;
+	for (unsigned int i = 0; i < numElements; ++i) {
+	  tmp += a[row * numElements + i] * b[i];
+	}
+	c[row] = tmp;
+      }
+
+    }
+  };
+
+
+
+  /* 
+     DEBUG ONLY
+     Obviously not optimized (and contains printf anyway), incorporated to verify results.
+  */
+  namespace debug {
+    constexpr float TOLERANCE_RATIO = 0.01;
+
+
+    struct verifyVectorAdd {
+      template <typename T_Acc, typename T_Data>
+      ALPAKA_FN_ACC void operator()(
+				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+
+	// Global thread index in grid
+	const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+	const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+
+	// Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+	const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
+	const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
+	const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
+
+
+	for (uint32_t i = firstElementIdxGlobal; i < endElementIdxGlobal; ++i) {
+
+	  // theoreticalResult = i+i^2 = i*(i+1)
+	  if (result[i] != i*(i+1)) { 
+	    printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n",
+		   i, result[i]
+		   );
+	  }
+	}
+	
+      }
+    };
+
+
+    struct verifyVectorProd {
+      template <typename T_Acc, typename T_Data>
+      ALPAKA_FN_ACC void operator()(
+				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+
+	const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+	const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+	const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
+
+
+	if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
+	  for (unsigned int row = 0; row < numElements; ++row) {
+	    for (unsigned int col = 0; col < numElements; ++col) {
+
+	      const T_Data theoreticalResult = static_cast<T_Data>(row)*col*col;
+	      const T_Data diff = result[row + numElements * col] - theoreticalResult;
+	      const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
+	      if (diff > tolerance || diff < -tolerance) {
+		printf("Wrong vectorProd results, row = %u, col = %u, c[row,col] = %f.\n",
+		       row, col, result[row * numElements + col]
+		       );
+	      }
+	    }
+	  }
+	}
+
+      }
+    };
+
+
+    struct verifyMatrixMul {
+      template <typename T_Acc, typename T_Data>
+      ALPAKA_FN_ACC void operator()(
+				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+
+	const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+	const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+	const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
+
+
+	if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
+	  const T_Data partialtheoreticalResult = static_cast<T_Data>(numElements-1)*(numElements-1)*numElements*numElements/4;
+	
+	  for (unsigned int row = 0; row < numElements; ++row) {
+	    for (unsigned int col = 0; col < numElements; ++col) {
+
+	      // theoreticalResult = row * col * (col+1) * Sum(k=1 to numElements-1, k^3)
+	      const T_Data theoreticalResult = static_cast<T_Data>(row)*col*(col+1)*partialtheoreticalResult;
+	      const T_Data diff = result[row + numElements * col] - theoreticalResult;
+	      const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
+	      
+	      if (diff > tolerance || diff < -tolerance) {
+		printf("Wrong matrix multiplication results, row = %u, col = %u, c[row,col] = %f, theoreticalResult = %f.\n",
+		       row, col, result[row * numElements + col], theoreticalResult
+		       );
+	      }
+	    }
+	  }
+	}
+
+      }
+    };
+
+
+    struct verifyMatrixMulVector {
+      template <typename T_Acc, typename T_Data>
+      ALPAKA_FN_ACC void operator()(
+				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+
+	const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+
+	if (threadIdxGlobal == 0) {
+	  const unsigned long int N = numElements - 1;
+	  const unsigned long int N2 = N*N;
+	  const unsigned long int N3 = N2 * N;
+	  const unsigned long int N4 = N2 * N2;
+	  const unsigned long int N5 = N4 * N;
+	  const T_Data partialtheoreticalResult = static_cast<T_Data>(N2)*(N+1)*(N+1)/4 * ((6*N5+15*N4+10*N3-N)/30 + (N+1)*(N+1)*N2/2 + N*(N+1)/2);
+
+
+	  for (unsigned int i = 0; i < numElements; ++i) {
+
+	    // theoreticalResult = N^2*(N+1)^2/4 * i * Sum(k=1 to N, k^2*(k+1)^2)
+	    const T_Data theoreticalResult = i * partialtheoreticalResult;
+	    const T_Data diff = result[i] - theoreticalResult;
+	    const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
+
+	    if (diff > tolerance || diff < -tolerance) {
+	      printf("Wrong matrix-vector multiplication results, i = %u, c[i] = %f, theoreticalResult = %f.\n",
+		     i, result[i], theoreticalResult
+		     );
+	    
+	    }
+	  }
+	}
+
+      }
+    };
+
+  } // namespace debug
+
+
+} // namespace
+
+
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   void alpakaAlgo1() {
-    const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
-    const DevAcc device(alpaka::pltf::getDevByIdx<PltfAcc>(0u));
-    const Vec size(NUM_VALUES);
 
+    const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
+    const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
+    const Vec size(NUM_VALUES);
     Queue queue(device);
 
+   
+    // Host data
     auto h_a_buf = alpaka::mem::buf::alloc<float, Idx>(host, size);
     auto h_b_buf = alpaka::mem::buf::alloc<float, Idx>(host, size);
     auto h_a = alpaka::mem::view::getPtrNative(h_a_buf);
     auto h_b = alpaka::mem::view::getPtrNative(h_b_buf);
-
     for (auto i = 0U; i < NUM_VALUES; i++) {
       h_a[i] = i;
       h_b[i] = i * i;
     }
 
+
+    // Device data
     auto d_a_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
     auto d_b_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
-
     alpaka::mem::view::copy(queue, d_a_buf, h_a_buf, size);
     alpaka::mem::view::copy(queue, d_b_buf, h_b_buf, size);
+    auto d_c_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
 
+
+    // Prepare 1D workDiv
     Vec elementsPerThread(Vec::all(1));
     Vec threadsPerBlock(Vec::all(32));
-    Vec blocksPerGrid(Vec::all((NUM_VALUES + 32 - 1) / 32));
+    const Vec blocksPerGrid(Vec::all((NUM_VALUES + 32 - 1) / 32));
 #if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || \
-    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
     // on the GPU, run with 32 threads in parallel per block, each looking at a single element
     // on the CPU, run serially with a single thread per block, over 32 elements
     std::swap(threadsPerBlock, elementsPerThread);
 #endif
-
     const WorkDiv workDiv(blocksPerGrid, threadsPerBlock, elementsPerThread);
 
-    auto d_c_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
 
+    // VECTOR ADDITION
     alpaka::queue::enqueue(queue,
                            alpaka::kernel::createTaskKernel<Acc>(workDiv,
                                                                  vectorAdd(),
@@ -106,29 +320,63 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                  alpaka::mem::view::getPtrNative(d_c_buf),
                                                                  NUM_VALUES));
 
-#ifdef TODO
-    vectorAdd<<<blocksPerGrid, threadsPerBlock, 0, stream>>>(d_a.get(), d_b.get(), d_c.get(), NUM_VALUES);
-
-    auto d_ma = cms::cuda::make_device_unique<float[]>(NUM_VALUES * NUM_VALUES, stream);
-    auto d_mb = cms::cuda::make_device_unique<float[]>(NUM_VALUES * NUM_VALUES, stream);
-    auto d_mc = cms::cuda::make_device_unique<float[]>(NUM_VALUES * NUM_VALUES, stream);
-    dim3 threadsPerBlock3{NUM_VALUES, NUM_VALUES};
-    dim3 blocksPerGrid3{1, 1};
-    if (NUM_VALUES * NUM_VALUES > 32) {
-      threadsPerBlock3.x = 32;
-      threadsPerBlock3.y = 32;
-      blocksPerGrid3.x = ceil(double(NUM_VALUES) / double(threadsPerBlock3.x));
-      blocksPerGrid3.y = ceil(double(NUM_VALUES) / double(threadsPerBlock3.y));
-    }
-    vectorProd<<<blocksPerGrid3, threadsPerBlock3, 0, stream>>>(d_a.get(), d_b.get(), d_ma.get(), NUM_VALUES);
-    vectorProd<<<blocksPerGrid3, threadsPerBlock3, 0, stream>>>(d_a.get(), d_c.get(), d_mb.get(), NUM_VALUES);
-    matrixMul<<<blocksPerGrid3, threadsPerBlock3, 0, stream>>>(d_ma.get(), d_mb.get(), d_mc.get(), NUM_VALUES);
-
-    matrixMulVector<<<blocksPerGrid, threadsPerBlock, 0, stream>>>(d_mc.get(), d_b.get(), d_c.get(), NUM_VALUES);
-
-    return d_a;
+    // Prepare 2D workDiv
+    Vec2 elementsPerThread2(1u, 1u);
+    const unsigned int threadsPerBlockSide = (NUM_VALUES < 32 ? NUM_VALUES : 32u);
+    Vec2 threadsPerBlock2(threadsPerBlockSide, threadsPerBlockSide);
+#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || \
+  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+    // on the GPU, run with 32 threads in parallel per block, each looking at a single element
+    // on the CPU, run serially with a single thread per block, over 32 elements
+    std::swap(threadsPerBlock2, elementsPerThread2);
 #endif
+    const unsigned int blocksPerGridSide = (NUM_VALUES <= 32 ? 1 : std::ceil(NUM_VALUES / 32.));
+    const Vec2 blocksPerGrid2(blocksPerGridSide, blocksPerGridSide);
+    const WorkDiv2 workDiv2(blocksPerGrid2, threadsPerBlock2, elementsPerThread2);
 
-    alpaka::wait::wait(queue);
+
+    // Device data
+    const Vec2 sizeSquare(NUM_VALUES, NUM_VALUES);
+    auto d_ma_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
+    auto d_mb_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
+    auto d_mc_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
+
+
+    // VECTOR MULTIPLICATION
+    alpaka::queue::enqueue(queue,
+			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+								  vectorProd(),
+								  alpaka::mem::view::getPtrNative(d_a_buf),
+								  alpaka::mem::view::getPtrNative(d_b_buf),
+								  alpaka::mem::view::getPtrNative(d_ma_buf),
+								  NUM_VALUES));
+
+    alpaka::queue::enqueue(queue,
+			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+								  vectorProd(),
+								  alpaka::mem::view::getPtrNative(d_a_buf),
+								  alpaka::mem::view::getPtrNative(d_c_buf),
+								  alpaka::mem::view::getPtrNative(d_mb_buf),
+								  NUM_VALUES));
+
+    // MATRIX MULTIPLICATION
+    alpaka::queue::enqueue(queue,
+			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+								  matrixMul(),
+								  alpaka::mem::view::getPtrNative(d_ma_buf),
+								  alpaka::mem::view::getPtrNative(d_mb_buf),
+								  alpaka::mem::view::getPtrNative(d_mc_buf),
+								  NUM_VALUES));
+
+    // MATRIX - VECTOR MULTIPLICATION
+    alpaka::queue::enqueue(queue,
+			   alpaka::kernel::createTaskKernel<Acc>(workDiv,
+								 matrixMulVector(),
+								 alpaka::mem::view::getPtrNative(d_mc_buf),
+								 alpaka::mem::view::getPtrNative(d_b_buf),
+								 alpaka::mem::view::getPtrNative(d_c_buf),
+								 NUM_VALUES));
+
+    alpaka::wait::wait(queue);    
   }
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+} // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
@@ -3,12 +3,13 @@
 namespace {
   constexpr unsigned int NUM_VALUES = 1000;
 
-
   struct vectorAdd {
     template <typename T_Acc, typename T_Data>
-    ALPAKA_FN_ACC void operator()(
-				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
-
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc,
+                                  const T_Data* __restrict__ a,
+                                  const T_Data* __restrict__ b,
+                                  T_Data* __restrict__ c,
+                                  unsigned int numElements) const {
       // Global thread index in grid
       const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
       const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
@@ -18,20 +19,19 @@ namespace {
       const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
       const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
 
-
       for (uint32_t i = firstElementIdxGlobal; i < endElementIdxGlobal; ++i) {
-	c[i] = a[i] + b[i];
+        c[i] = a[i] + b[i];
       }
-
     }
   };
-
 
   struct vectorProd {
     template <typename T_Acc, typename T_Data>
-    ALPAKA_FN_ACC void operator()(
-				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
-
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc,
+                                  const T_Data* __restrict__ a,
+                                  const T_Data* __restrict__ b,
+                                  T_Data* __restrict__ c,
+                                  unsigned int numElements) const {
       // Global thread index in Dim2 grid
       const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
       const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
@@ -49,23 +49,21 @@ namespace {
       const uint32_t endElementIdxGlobalYUncut = firstElementIdxGlobalY + threadDimensionY;
       const uint32_t endElementIdxGlobalY = std::min(endElementIdxGlobalYUncut, numElements);
 
-
       for (uint32_t col = firstElementIdxGlobalX; col < endElementIdxGlobalX; ++col) {
-	for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {
-
-	  c[row + numElements * col] = a[row] * b[col];
-	}
+        for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {
+          c[row + numElements * col] = a[row] * b[col];
+        }
       }
-
     }
   };
-
 
   struct matrixMul {
     template <typename T_Acc, typename T_Data>
-    ALPAKA_FN_ACC void operator()(
-				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
-
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc,
+                                  const T_Data* __restrict__ a,
+                                  const T_Data* __restrict__ b,
+                                  T_Data* __restrict__ c,
+                                  unsigned int numElements) const {
       // Global thread index in Dim2 grid
       const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
       const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
@@ -83,27 +81,25 @@ namespace {
       const uint32_t endElementIdxGlobalYUncut = firstElementIdxGlobalY + threadDimensionY;
       const uint32_t endElementIdxGlobalY = std::min(endElementIdxGlobalYUncut, numElements);
 
-
       for (uint32_t col = firstElementIdxGlobalX; col < endElementIdxGlobalX; ++col) {
-	for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {	
-
-	  T_Data tmp = 0;
-	  for (unsigned int i = 0; i < numElements; ++i) {
-	    tmp += a[row + numElements * i] * b[i + numElements * col];
-	  }
-	  c[row + numElements * col] = tmp;
-	}
+        for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {
+          T_Data tmp = 0;
+          for (unsigned int i = 0; i < numElements; ++i) {
+            tmp += a[row + numElements * i] * b[i + numElements * col];
+          }
+          c[row + numElements * col] = tmp;
+        }
       }
-
     }
   };
 
-
   struct matrixMulVector {
     template <typename T_Acc, typename T_Data>
-    ALPAKA_FN_ACC void operator()(
-				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
-
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc,
+                                  const T_Data* __restrict__ a,
+                                  const T_Data* __restrict__ b,
+                                  T_Data* __restrict__ c,
+                                  unsigned int numElements) const {
       // Global thread index in grid
       const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
       const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
@@ -113,19 +109,15 @@ namespace {
       const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
       const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
 
-
       for (uint32_t row = firstElementIdxGlobal; row < endElementIdxGlobal; ++row) {
-	T_Data tmp = 0;
-	for (unsigned int i = 0; i < numElements; ++i) {
-	  tmp += a[row * numElements + i] * b[i];
-	}
-	c[row] = tmp;
+        T_Data tmp = 0;
+        for (unsigned int i = 0; i < numElements; ++i) {
+          tmp += a[row * numElements + i] * b[i];
+        }
+        c[row] = tmp;
       }
-
     }
   };
-
-
 
   /* 
      DEBUG ONLY
@@ -134,151 +126,128 @@ namespace {
   namespace debug {
     constexpr float TOLERANCE_RATIO = 0.01;
 
-
     struct verifyVectorAdd {
       template <typename T_Acc, typename T_Data>
-      ALPAKA_FN_ACC void operator()(
-				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+      ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+        // Global thread index in grid
+        const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+        const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
 
-	// Global thread index in grid
-	const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
-	const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+        // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+        const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
+        const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
+        const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
 
-	// Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
-	const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
-	const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
-	const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
-
-
-	for (uint32_t i = firstElementIdxGlobal; i < endElementIdxGlobal; ++i) {
-
-	  // theoreticalResult = i+i^2 = i*(i+1)
-	  if (result[i] != i*(i+1)) { 
-	    printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n",
-		   i, result[i]
-		   );
-	  }
-	}
-	
+        for (uint32_t i = firstElementIdxGlobal; i < endElementIdxGlobal; ++i) {
+          // theoreticalResult = i+i^2 = i*(i+1)
+          if (result[i] != i * (i + 1)) {
+            printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);
+          }
+        }
       }
     };
-
 
     struct verifyVectorProd {
       template <typename T_Acc, typename T_Data>
-      ALPAKA_FN_ACC void operator()(
-				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+      ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+        const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+        const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+        const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
 
-	const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
-	const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
-	const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
-
-
-	if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
-	  for (unsigned int row = 0; row < numElements; ++row) {
-	    for (unsigned int col = 0; col < numElements; ++col) {
-
-	      const T_Data theoreticalResult = static_cast<T_Data>(row)*col*col;
-	      const T_Data diff = result[row + numElements * col] - theoreticalResult;
-	      const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
-	      if (diff > tolerance || diff < -tolerance) {
-		printf("Wrong vectorProd results, row = %u, col = %u, c[row,col] = %f.\n",
-		       row, col, result[row * numElements + col]
-		       );
-	      }
-	    }
-	  }
-	}
-
+        if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
+          for (unsigned int row = 0; row < numElements; ++row) {
+            for (unsigned int col = 0; col < numElements; ++col) {
+              const T_Data theoreticalResult = static_cast<T_Data>(row) * col * col;
+              const T_Data diff = result[row + numElements * col] - theoreticalResult;
+              const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
+              if (diff > tolerance || diff < -tolerance) {
+                printf("Wrong vectorProd results, row = %u, col = %u, c[row,col] = %f.\n",
+                       row,
+                       col,
+                       result[row * numElements + col]);
+              }
+            }
+          }
+        }
       }
     };
-
 
     struct verifyMatrixMul {
       template <typename T_Acc, typename T_Data>
-      ALPAKA_FN_ACC void operator()(
-				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+      ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+        const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+        const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+        const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
 
-	const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
-	const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
-	const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
+        if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
+          const T_Data partialtheoreticalResult =
+              static_cast<T_Data>(numElements - 1) * (numElements - 1) * numElements * numElements / 4;
 
+          for (unsigned int row = 0; row < numElements; ++row) {
+            for (unsigned int col = 0; col < numElements; ++col) {
+              // theoreticalResult = row * col * (col+1) * Sum(k=1 to numElements-1, k^3)
+              const T_Data theoreticalResult = static_cast<T_Data>(row) * col * (col + 1) * partialtheoreticalResult;
+              const T_Data diff = result[row + numElements * col] - theoreticalResult;
+              const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
 
-	if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
-	  const T_Data partialtheoreticalResult = static_cast<T_Data>(numElements-1)*(numElements-1)*numElements*numElements/4;
-	
-	  for (unsigned int row = 0; row < numElements; ++row) {
-	    for (unsigned int col = 0; col < numElements; ++col) {
-
-	      // theoreticalResult = row * col * (col+1) * Sum(k=1 to numElements-1, k^3)
-	      const T_Data theoreticalResult = static_cast<T_Data>(row)*col*(col+1)*partialtheoreticalResult;
-	      const T_Data diff = result[row + numElements * col] - theoreticalResult;
-	      const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
-	      
-	      if (diff > tolerance || diff < -tolerance) {
-		printf("Wrong matrix multiplication results, row = %u, col = %u, c[row,col] = %f, theoreticalResult = %f.\n",
-		       row, col, result[row * numElements + col], theoreticalResult
-		       );
-	      }
-	    }
-	  }
-	}
-
+              if (diff > tolerance || diff < -tolerance) {
+                printf(
+                    "Wrong matrix multiplication results, row = %u, col = %u, c[row,col] = %f, theoreticalResult = "
+                    "%f.\n",
+                    row,
+                    col,
+                    result[row * numElements + col],
+                    theoreticalResult);
+              }
+            }
+          }
+        }
       }
     };
-
 
     struct verifyMatrixMulVector {
       template <typename T_Acc, typename T_Data>
-      ALPAKA_FN_ACC void operator()(
-				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+      ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+        const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
 
-	const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+        if (threadIdxGlobal == 0) {
+          const unsigned long int N = numElements - 1;
+          const unsigned long int N2 = N * N;
+          const unsigned long int N3 = N2 * N;
+          const unsigned long int N4 = N2 * N2;
+          const unsigned long int N5 = N4 * N;
+          const T_Data partialtheoreticalResult =
+              static_cast<T_Data>(N2) * (N + 1) * (N + 1) / 4 *
+              ((6 * N5 + 15 * N4 + 10 * N3 - N) / 30 + (N + 1) * (N + 1) * N2 / 2 + N * (N + 1) / 2);
 
-	if (threadIdxGlobal == 0) {
-	  const unsigned long int N = numElements - 1;
-	  const unsigned long int N2 = N*N;
-	  const unsigned long int N3 = N2 * N;
-	  const unsigned long int N4 = N2 * N2;
-	  const unsigned long int N5 = N4 * N;
-	  const T_Data partialtheoreticalResult = static_cast<T_Data>(N2)*(N+1)*(N+1)/4 * ((6*N5+15*N4+10*N3-N)/30 + (N+1)*(N+1)*N2/2 + N*(N+1)/2);
+          for (unsigned int i = 0; i < numElements; ++i) {
+            // theoreticalResult = N^2*(N+1)^2/4 * i * Sum(k=1 to N, k^2*(k+1)^2)
+            const T_Data theoreticalResult = i * partialtheoreticalResult;
+            const T_Data diff = result[i] - theoreticalResult;
+            const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
 
-
-	  for (unsigned int i = 0; i < numElements; ++i) {
-
-	    // theoreticalResult = N^2*(N+1)^2/4 * i * Sum(k=1 to N, k^2*(k+1)^2)
-	    const T_Data theoreticalResult = i * partialtheoreticalResult;
-	    const T_Data diff = result[i] - theoreticalResult;
-	    const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
-
-	    if (diff > tolerance || diff < -tolerance) {
-	      printf("Wrong matrix-vector multiplication results, i = %u, c[i] = %f, theoreticalResult = %f.\n",
-		     i, result[i], theoreticalResult
-		     );
-	    
-	    }
-	  }
-	}
-
+            if (diff > tolerance || diff < -tolerance) {
+              printf("Wrong matrix-vector multiplication results, i = %u, c[i] = %f, theoreticalResult = %f.\n",
+                     i,
+                     result[i],
+                     theoreticalResult);
+            }
+          }
+        }
       }
     };
 
-  } // namespace debug
+  }  // namespace debug
 
-
-} // namespace
-
-
+}  // namespace
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   void alpakaAlgo1() {
-
     const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
     const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
     const Vec size(NUM_VALUES);
     Queue queue(device);
 
-   
     // Host data
     auto h_a_buf = alpaka::mem::buf::alloc<float, Idx>(host, size);
     auto h_b_buf = alpaka::mem::buf::alloc<float, Idx>(host, size);
@@ -289,7 +258,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       h_b[i] = i * i;
     }
 
-
     // Device data
     auto d_a_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
     auto d_b_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
@@ -297,19 +265,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     alpaka::mem::view::copy(queue, d_b_buf, h_b_buf, size);
     auto d_c_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
 
-
     // Prepare 1D workDiv
     Vec elementsPerThread(Vec::all(1));
     Vec threadsPerBlock(Vec::all(32));
     const Vec blocksPerGrid(Vec::all((NUM_VALUES + 32 - 1) / 32));
 #if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || \
-  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
     // on the GPU, run with 32 threads in parallel per block, each looking at a single element
     // on the CPU, run serially with a single thread per block, over 32 elements
     std::swap(threadsPerBlock, elementsPerThread);
 #endif
     const WorkDiv workDiv(blocksPerGrid, threadsPerBlock, elementsPerThread);
-
 
     // VECTOR ADDITION
     alpaka::queue::enqueue(queue,
@@ -325,7 +291,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const unsigned int threadsPerBlockSide = (NUM_VALUES < 32 ? NUM_VALUES : 32u);
     Vec2 threadsPerBlock2(threadsPerBlockSide, threadsPerBlockSide);
 #if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || \
-  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
     // on the GPU, run with 32 threads in parallel per block, each looking at a single element
     // on the CPU, run serially with a single thread per block, over 32 elements
     std::swap(threadsPerBlock2, elementsPerThread2);
@@ -334,49 +300,47 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const Vec2 blocksPerGrid2(blocksPerGridSide, blocksPerGridSide);
     const WorkDiv2 workDiv2(blocksPerGrid2, threadsPerBlock2, elementsPerThread2);
 
-
     // Device data
     const Vec2 sizeSquare(NUM_VALUES, NUM_VALUES);
     auto d_ma_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
     auto d_mb_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
     auto d_mc_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
 
-
     // VECTOR MULTIPLICATION
     alpaka::queue::enqueue(queue,
-			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
-								  vectorProd(),
-								  alpaka::mem::view::getPtrNative(d_a_buf),
-								  alpaka::mem::view::getPtrNative(d_b_buf),
-								  alpaka::mem::view::getPtrNative(d_ma_buf),
-								  NUM_VALUES));
+                           alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+                                                                  vectorProd(),
+                                                                  alpaka::mem::view::getPtrNative(d_a_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_b_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_ma_buf),
+                                                                  NUM_VALUES));
 
     alpaka::queue::enqueue(queue,
-			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
-								  vectorProd(),
-								  alpaka::mem::view::getPtrNative(d_a_buf),
-								  alpaka::mem::view::getPtrNative(d_c_buf),
-								  alpaka::mem::view::getPtrNative(d_mb_buf),
-								  NUM_VALUES));
+                           alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+                                                                  vectorProd(),
+                                                                  alpaka::mem::view::getPtrNative(d_a_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_c_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_mb_buf),
+                                                                  NUM_VALUES));
 
     // MATRIX MULTIPLICATION
     alpaka::queue::enqueue(queue,
-			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
-								  matrixMul(),
-								  alpaka::mem::view::getPtrNative(d_ma_buf),
-								  alpaka::mem::view::getPtrNative(d_mb_buf),
-								  alpaka::mem::view::getPtrNative(d_mc_buf),
-								  NUM_VALUES));
+                           alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+                                                                  matrixMul(),
+                                                                  alpaka::mem::view::getPtrNative(d_ma_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_mb_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_mc_buf),
+                                                                  NUM_VALUES));
 
     // MATRIX - VECTOR MULTIPLICATION
     alpaka::queue::enqueue(queue,
-			   alpaka::kernel::createTaskKernel<Acc>(workDiv,
-								 matrixMulVector(),
-								 alpaka::mem::view::getPtrNative(d_mc_buf),
-								 alpaka::mem::view::getPtrNative(d_b_buf),
-								 alpaka::mem::view::getPtrNative(d_c_buf),
-								 NUM_VALUES));
+                           alpaka::kernel::createTaskKernel<Acc>(workDiv,
+                                                                 matrixMulVector(),
+                                                                 alpaka::mem::view::getPtrNative(d_mc_buf),
+                                                                 alpaka::mem::view::getPtrNative(d_b_buf),
+                                                                 alpaka::mem::view::getPtrNative(d_c_buf),
+                                                                 NUM_VALUES));
 
-    alpaka::wait::wait(queue);    
+    alpaka::wait::wait(queue);
   }
-} // namespace ALPAKA_ACCELERATOR_NAMESPACE
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
@@ -3,101 +3,315 @@
 namespace {
   constexpr unsigned int NUM_VALUES = 1000;
 
+
   struct vectorAdd {
     template <typename T_Acc, typename T_Data>
     ALPAKA_FN_ACC void operator()(
-        T_Acc const &acc, T_Data const *a, T_Data const *b, T_Data *c, unsigned int numElements) const {
-      //uint32_t const gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
-      uint32_t const blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u]);
-      uint32_t const gridBlockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
-      uint32_t const blockThreadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
-      uint32_t const elemDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
 
-      uint32_t i = (blockThreadIdx + gridBlockIdx * blockDimension) * elemDimension;
-      if (i < numElements) {
-        c[i] = a[i] + b[i];
+      // Global thread index in grid
+      const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+      const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+
+      // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+      const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
+      const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
+      const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
+
+
+      for (uint32_t i = firstElementIdxGlobal; i < endElementIdxGlobal; ++i) {
+	c[i] = a[i] + b[i];
       }
+
     }
   };
 
-#ifdef TODO
-  template <typename T>
-  __global__ void vectorProd(const T *a, const T *b, T *c, int numElements) {
-    int row = blockIdx.y * blockDim.y + threadIdx.y;
-    int col = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if (row < numElements && col < numElements) {
-      c[row * numElements + col] = a[row] * b[col];
-    }
-  }
+  struct vectorProd {
+    template <typename T_Acc, typename T_Data>
+    ALPAKA_FN_ACC void operator()(
+				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
 
-  template <typename T>
-  __global__ void matrixMul(const T *a, const T *b, T *c, int numElements) {
-    int row = blockIdx.y * blockDim.y + threadIdx.y;
-    int col = blockIdx.x * blockDim.x + threadIdx.x;
+      // Global thread index in Dim2 grid
+      const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+      const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+      const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
 
-    if (row < numElements && col < numElements) {
-      T tmp = 0;
-      for (int i = 0; i < numElements; ++i) {
-        tmp += a[row * numElements + i] * b[i * numElements + col];
+      // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+      const auto& threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc));
+      const uint32_t threadDimensionX(threadDimension[0u]);
+      const uint32_t firstElementIdxGlobalX = threadIdxGlobalX * threadDimensionX;
+      const uint32_t endElementIdxGlobalXUncut = firstElementIdxGlobalX + threadDimensionX;
+      const uint32_t endElementIdxGlobalX = std::min(endElementIdxGlobalXUncut, numElements);
+
+      const uint32_t threadDimensionY(threadDimension[1u]);
+      const uint32_t firstElementIdxGlobalY = threadIdxGlobalY * threadDimensionY;
+      const uint32_t endElementIdxGlobalYUncut = firstElementIdxGlobalY + threadDimensionY;
+      const uint32_t endElementIdxGlobalY = std::min(endElementIdxGlobalYUncut, numElements);
+
+
+      for (uint32_t col = firstElementIdxGlobalX; col < endElementIdxGlobalX; ++col) {
+	for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {
+
+	  c[row + numElements * col] = a[row] * b[col];
+	}
       }
-      c[row * numElements + col] = tmp;
+
     }
-  }
+  };
 
-  template <typename T>
-  __global__ void matrixMulVector(const T *a, const T *b, T *c, int numElements) {
-    int row = blockIdx.y * blockDim.y + threadIdx.y;
 
-    if (row < numElements) {
-      T tmp = 0;
-      for (int i = 0; i < numElements; ++i) {
-        tmp += a[row * numElements + i] * b[i];
+  struct matrixMul {
+    template <typename T_Acc, typename T_Data>
+    ALPAKA_FN_ACC void operator()(
+				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
+
+      // Global thread index in Dim2 grid
+      const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+      const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+      const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
+
+      // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+      const auto& threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc));
+      const uint32_t threadDimensionX(threadDimension[0u]);
+      const uint32_t firstElementIdxGlobalX = threadIdxGlobalX * threadDimensionX;
+      const uint32_t endElementIdxGlobalXUncut = firstElementIdxGlobalX + threadDimensionX;
+      const uint32_t endElementIdxGlobalX = std::min(endElementIdxGlobalXUncut, numElements);
+
+      const uint32_t threadDimensionY(threadDimension[1u]);
+      const uint32_t firstElementIdxGlobalY = threadIdxGlobalY * threadDimensionY;
+      const uint32_t endElementIdxGlobalYUncut = firstElementIdxGlobalY + threadDimensionY;
+      const uint32_t endElementIdxGlobalY = std::min(endElementIdxGlobalYUncut, numElements);
+
+
+      for (uint32_t col = firstElementIdxGlobalX; col < endElementIdxGlobalX; ++col) {
+	for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {	
+
+	  T_Data tmp = 0;
+	  for (unsigned int i = 0; i < numElements; ++i) {
+	    tmp += a[row + numElements * i] * b[i + numElements * col];
+	  }
+	  c[row + numElements * col] = tmp;
+	}
       }
-      c[row] = tmp;
+
     }
-  }
-#endif
-}  // namespace
+  };
+
+
+  struct matrixMulVector {
+    template <typename T_Acc, typename T_Data>
+    ALPAKA_FN_ACC void operator()(
+				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
+
+      // Global thread index in grid
+      const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+      const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+
+      // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+      const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
+      const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
+      const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
+
+
+      for (uint32_t row = firstElementIdxGlobal; row < endElementIdxGlobal; ++row) {
+	T_Data tmp = 0;
+	for (unsigned int i = 0; i < numElements; ++i) {
+	  tmp += a[row * numElements + i] * b[i];
+	}
+	c[row] = tmp;
+      }
+
+    }
+  };
+
+
+
+  /* 
+     DEBUG ONLY
+     Obviously not optimized (and contains printf anyway), incorporated to verify results.
+  */
+  namespace debug {
+    constexpr float TOLERANCE_RATIO = 0.01;
+
+
+    struct verifyVectorAdd {
+      template <typename T_Acc, typename T_Data>
+      ALPAKA_FN_ACC void operator()(
+				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+
+	// Global thread index in grid
+	const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+	const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+
+	// Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+	const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
+	const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
+	const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
+
+
+	for (uint32_t i = firstElementIdxGlobal; i < endElementIdxGlobal; ++i) {
+
+	  // theoreticalResult = i+i^2 = i*(i+1)
+	  if (result[i] != i*(i+1)) { 
+	    printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n",
+		   i, result[i]
+		   );
+	  }
+	}
+	
+      }
+    };
+
+
+    struct verifyVectorProd {
+      template <typename T_Acc, typename T_Data>
+      ALPAKA_FN_ACC void operator()(
+				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+
+	const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+	const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+	const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
+
+
+	if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
+	  for (unsigned int row = 0; row < numElements; ++row) {
+	    for (unsigned int col = 0; col < numElements; ++col) {
+
+	      const T_Data theoreticalResult = static_cast<T_Data>(row)*col*col;
+	      const T_Data diff = result[row + numElements * col] - theoreticalResult;
+	      const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
+	      if (diff > tolerance || diff < -tolerance) {
+		printf("Wrong vectorProd results, row = %u, col = %u, c[row,col] = %f.\n",
+		       row, col, result[row * numElements + col]
+		       );
+	      }
+	    }
+	  }
+	}
+
+      }
+    };
+
+
+    struct verifyMatrixMul {
+      template <typename T_Acc, typename T_Data>
+      ALPAKA_FN_ACC void operator()(
+				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+
+	const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+	const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+	const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
+
+
+	if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
+	  const T_Data partialtheoreticalResult = static_cast<T_Data>(numElements-1)*(numElements-1)*numElements*numElements/4;
+	
+	  for (unsigned int row = 0; row < numElements; ++row) {
+	    for (unsigned int col = 0; col < numElements; ++col) {
+
+	      // theoreticalResult = row * col * (col+1) * Sum(k=1 to numElements-1, k^3)
+	      const T_Data theoreticalResult = static_cast<T_Data>(row)*col*(col+1)*partialtheoreticalResult;
+	      const T_Data diff = result[row + numElements * col] - theoreticalResult;
+	      const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
+	      
+	      if (diff > tolerance || diff < -tolerance) {
+		printf("Wrong matrix multiplication results, row = %u, col = %u, c[row,col] = %f, theoreticalResult = %f.\n",
+		       row, col, result[row * numElements + col], theoreticalResult
+		       );
+	      }
+	    }
+	  }
+	}
+
+      }
+    };
+
+
+    struct verifyMatrixMulVector {
+      template <typename T_Acc, typename T_Data>
+      ALPAKA_FN_ACC void operator()(
+				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+
+	const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+
+	if (threadIdxGlobal == 0) {
+	  const unsigned long int N = numElements - 1;
+	  const unsigned long int N2 = N*N;
+	  const unsigned long int N3 = N2 * N;
+	  const unsigned long int N4 = N2 * N2;
+	  const unsigned long int N5 = N4 * N;
+	  const T_Data partialtheoreticalResult = static_cast<T_Data>(N2)*(N+1)*(N+1)/4 * ((6*N5+15*N4+10*N3-N)/30 + (N+1)*(N+1)*N2/2 + N*(N+1)/2);
+
+
+	  for (unsigned int i = 0; i < numElements; ++i) {
+
+	    // theoreticalResult = N^2*(N+1)^2/4 * i * Sum(k=1 to N, k^2*(k+1)^2)
+	    const T_Data theoreticalResult = i * partialtheoreticalResult;
+	    const T_Data diff = result[i] - theoreticalResult;
+	    const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
+
+	    if (diff > tolerance || diff < -tolerance) {
+	      printf("Wrong matrix-vector multiplication results, i = %u, c[i] = %f, theoreticalResult = %f.\n",
+		     i, result[i], theoreticalResult
+		     );
+	    
+	    }
+	  }
+	}
+
+      }
+    };
+
+  } // namespace debug
+
+
+} // namespace
+
+
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   void alpakaAlgo2() {
-    const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
-    const DevAcc device(alpaka::pltf::getDevByIdx<PltfAcc>(0u));
-    const Vec size(NUM_VALUES);
 
+    const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
+    const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
+    const Vec size(NUM_VALUES);
     Queue queue(device);
 
+   
+    // Host data
     auto h_a_buf = alpaka::mem::buf::alloc<float, Idx>(host, size);
     auto h_b_buf = alpaka::mem::buf::alloc<float, Idx>(host, size);
     auto h_a = alpaka::mem::view::getPtrNative(h_a_buf);
     auto h_b = alpaka::mem::view::getPtrNative(h_b_buf);
-
     for (auto i = 0U; i < NUM_VALUES; i++) {
       h_a[i] = i;
       h_b[i] = i * i;
     }
 
+
+    // Device data
     auto d_a_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
     auto d_b_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
-
     alpaka::mem::view::copy(queue, d_a_buf, h_a_buf, size);
     alpaka::mem::view::copy(queue, d_b_buf, h_b_buf, size);
+    auto d_c_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
 
+
+    // Prepare 1D workDiv
     Vec elementsPerThread(Vec::all(1));
     Vec threadsPerBlock(Vec::all(32));
-    Vec blocksPerGrid(Vec::all((NUM_VALUES + 32 - 1) / 32));
+    const Vec blocksPerGrid(Vec::all((NUM_VALUES + 32 - 1) / 32));
 #if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || \
-    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
     // on the GPU, run with 32 threads in parallel per block, each looking at a single element
     // on the CPU, run serially with a single thread per block, over 32 elements
     std::swap(threadsPerBlock, elementsPerThread);
 #endif
-
     const WorkDiv workDiv(blocksPerGrid, threadsPerBlock, elementsPerThread);
 
-    auto d_c_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
 
+    // VECTOR ADDITION
     alpaka::queue::enqueue(queue,
                            alpaka::kernel::createTaskKernel<Acc>(workDiv,
                                                                  vectorAdd(),
@@ -106,29 +320,63 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                  alpaka::mem::view::getPtrNative(d_c_buf),
                                                                  NUM_VALUES));
 
-#ifdef TODO
-    vectorAdd<<<blocksPerGrid, threadsPerBlock, 0, stream>>>(d_a.get(), d_b.get(), d_c.get(), NUM_VALUES);
-
-    auto d_ma = cms::cuda::make_device_unique<float[]>(NUM_VALUES * NUM_VALUES, stream);
-    auto d_mb = cms::cuda::make_device_unique<float[]>(NUM_VALUES * NUM_VALUES, stream);
-    auto d_mc = cms::cuda::make_device_unique<float[]>(NUM_VALUES * NUM_VALUES, stream);
-    dim3 threadsPerBlock3{NUM_VALUES, NUM_VALUES};
-    dim3 blocksPerGrid3{1, 1};
-    if (NUM_VALUES * NUM_VALUES > 32) {
-      threadsPerBlock3.x = 32;
-      threadsPerBlock3.y = 32;
-      blocksPerGrid3.x = ceil(double(NUM_VALUES) / double(threadsPerBlock3.x));
-      blocksPerGrid3.y = ceil(double(NUM_VALUES) / double(threadsPerBlock3.y));
-    }
-    vectorProd<<<blocksPerGrid3, threadsPerBlock3, 0, stream>>>(d_a.get(), d_b.get(), d_ma.get(), NUM_VALUES);
-    vectorProd<<<blocksPerGrid3, threadsPerBlock3, 0, stream>>>(d_a.get(), d_c.get(), d_mb.get(), NUM_VALUES);
-    matrixMul<<<blocksPerGrid3, threadsPerBlock3, 0, stream>>>(d_ma.get(), d_mb.get(), d_mc.get(), NUM_VALUES);
-
-    matrixMulVector<<<blocksPerGrid, threadsPerBlock, 0, stream>>>(d_mc.get(), d_b.get(), d_c.get(), NUM_VALUES);
-
-    return d_a;
+    // Prepare 2D workDiv
+    Vec2 elementsPerThread2(1u, 1u);
+    const unsigned int threadsPerBlockSide = (NUM_VALUES < 32 ? NUM_VALUES : 32u);
+    Vec2 threadsPerBlock2(threadsPerBlockSide, threadsPerBlockSide);
+#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || \
+  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+    // on the GPU, run with 32 threads in parallel per block, each looking at a single element
+    // on the CPU, run serially with a single thread per block, over 32 elements
+    std::swap(threadsPerBlock2, elementsPerThread2);
 #endif
+    const unsigned int blocksPerGridSide = (NUM_VALUES <= 32 ? 1 : std::ceil(NUM_VALUES / 32.));
+    const Vec2 blocksPerGrid2(blocksPerGridSide, blocksPerGridSide);
+    const WorkDiv2 workDiv2(blocksPerGrid2, threadsPerBlock2, elementsPerThread2);
 
-    alpaka::wait::wait(queue);
+
+    // Device data
+    const Vec2 sizeSquare(NUM_VALUES, NUM_VALUES);
+    auto d_ma_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
+    auto d_mb_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
+    auto d_mc_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
+
+
+    // VECTOR MULTIPLICATION
+    alpaka::queue::enqueue(queue,
+			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+								  vectorProd(),
+								  alpaka::mem::view::getPtrNative(d_a_buf),
+								  alpaka::mem::view::getPtrNative(d_b_buf),
+								  alpaka::mem::view::getPtrNative(d_ma_buf),
+								  NUM_VALUES));
+
+    alpaka::queue::enqueue(queue,
+			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+								  vectorProd(),
+								  alpaka::mem::view::getPtrNative(d_a_buf),
+								  alpaka::mem::view::getPtrNative(d_c_buf),
+								  alpaka::mem::view::getPtrNative(d_mb_buf),
+								  NUM_VALUES));
+
+    // MATRIX MULTIPLICATION
+    alpaka::queue::enqueue(queue,
+			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+								  matrixMul(),
+								  alpaka::mem::view::getPtrNative(d_ma_buf),
+								  alpaka::mem::view::getPtrNative(d_mb_buf),
+								  alpaka::mem::view::getPtrNative(d_mc_buf),
+								  NUM_VALUES));
+
+    // MATRIX - VECTOR MULTIPLICATION
+    alpaka::queue::enqueue(queue,
+			   alpaka::kernel::createTaskKernel<Acc>(workDiv,
+								 matrixMulVector(),
+								 alpaka::mem::view::getPtrNative(d_mc_buf),
+								 alpaka::mem::view::getPtrNative(d_b_buf),
+								 alpaka::mem::view::getPtrNative(d_c_buf),
+								 NUM_VALUES));
+
+    alpaka::wait::wait(queue);    
   }
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+} // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
@@ -3,12 +3,13 @@
 namespace {
   constexpr unsigned int NUM_VALUES = 1000;
 
-
   struct vectorAdd {
     template <typename T_Acc, typename T_Data>
-    ALPAKA_FN_ACC void operator()(
-				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
-
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc,
+                                  const T_Data* __restrict__ a,
+                                  const T_Data* __restrict__ b,
+                                  T_Data* __restrict__ c,
+                                  unsigned int numElements) const {
       // Global thread index in grid
       const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
       const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
@@ -18,20 +19,19 @@ namespace {
       const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
       const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
 
-
       for (uint32_t i = firstElementIdxGlobal; i < endElementIdxGlobal; ++i) {
-	c[i] = a[i] + b[i];
+        c[i] = a[i] + b[i];
       }
-
     }
   };
-
 
   struct vectorProd {
     template <typename T_Acc, typename T_Data>
-    ALPAKA_FN_ACC void operator()(
-				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
-
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc,
+                                  const T_Data* __restrict__ a,
+                                  const T_Data* __restrict__ b,
+                                  T_Data* __restrict__ c,
+                                  unsigned int numElements) const {
       // Global thread index in Dim2 grid
       const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
       const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
@@ -49,23 +49,21 @@ namespace {
       const uint32_t endElementIdxGlobalYUncut = firstElementIdxGlobalY + threadDimensionY;
       const uint32_t endElementIdxGlobalY = std::min(endElementIdxGlobalYUncut, numElements);
 
-
       for (uint32_t col = firstElementIdxGlobalX; col < endElementIdxGlobalX; ++col) {
-	for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {
-
-	  c[row + numElements * col] = a[row] * b[col];
-	}
+        for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {
+          c[row + numElements * col] = a[row] * b[col];
+        }
       }
-
     }
   };
-
 
   struct matrixMul {
     template <typename T_Acc, typename T_Data>
-    ALPAKA_FN_ACC void operator()(
-				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
-
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc,
+                                  const T_Data* __restrict__ a,
+                                  const T_Data* __restrict__ b,
+                                  T_Data* __restrict__ c,
+                                  unsigned int numElements) const {
       // Global thread index in Dim2 grid
       const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
       const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
@@ -83,27 +81,25 @@ namespace {
       const uint32_t endElementIdxGlobalYUncut = firstElementIdxGlobalY + threadDimensionY;
       const uint32_t endElementIdxGlobalY = std::min(endElementIdxGlobalYUncut, numElements);
 
-
       for (uint32_t col = firstElementIdxGlobalX; col < endElementIdxGlobalX; ++col) {
-	for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {	
-
-	  T_Data tmp = 0;
-	  for (unsigned int i = 0; i < numElements; ++i) {
-	    tmp += a[row + numElements * i] * b[i + numElements * col];
-	  }
-	  c[row + numElements * col] = tmp;
-	}
+        for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {
+          T_Data tmp = 0;
+          for (unsigned int i = 0; i < numElements; ++i) {
+            tmp += a[row + numElements * i] * b[i + numElements * col];
+          }
+          c[row + numElements * col] = tmp;
+        }
       }
-
     }
   };
 
-
   struct matrixMulVector {
     template <typename T_Acc, typename T_Data>
-    ALPAKA_FN_ACC void operator()(
-				  T_Acc const& acc, const T_Data* __restrict__ a, const T_Data* __restrict__ b, T_Data* __restrict__ c, unsigned int numElements) const {
-
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc,
+                                  const T_Data* __restrict__ a,
+                                  const T_Data* __restrict__ b,
+                                  T_Data* __restrict__ c,
+                                  unsigned int numElements) const {
       // Global thread index in grid
       const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
       const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
@@ -113,19 +109,15 @@ namespace {
       const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
       const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
 
-
       for (uint32_t row = firstElementIdxGlobal; row < endElementIdxGlobal; ++row) {
-	T_Data tmp = 0;
-	for (unsigned int i = 0; i < numElements; ++i) {
-	  tmp += a[row * numElements + i] * b[i];
-	}
-	c[row] = tmp;
+        T_Data tmp = 0;
+        for (unsigned int i = 0; i < numElements; ++i) {
+          tmp += a[row * numElements + i] * b[i];
+        }
+        c[row] = tmp;
       }
-
     }
   };
-
-
 
   /* 
      DEBUG ONLY
@@ -134,151 +126,128 @@ namespace {
   namespace debug {
     constexpr float TOLERANCE_RATIO = 0.01;
 
-
     struct verifyVectorAdd {
       template <typename T_Acc, typename T_Data>
-      ALPAKA_FN_ACC void operator()(
-				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+      ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+        // Global thread index in grid
+        const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+        const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
 
-	// Global thread index in grid
-	const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
-	const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+        // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+        const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
+        const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
+        const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
 
-	// Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
-	const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
-	const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
-	const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, numElements);
-
-
-	for (uint32_t i = firstElementIdxGlobal; i < endElementIdxGlobal; ++i) {
-
-	  // theoreticalResult = i+i^2 = i*(i+1)
-	  if (result[i] != i*(i+1)) { 
-	    printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n",
-		   i, result[i]
-		   );
-	  }
-	}
-	
+        for (uint32_t i = firstElementIdxGlobal; i < endElementIdxGlobal; ++i) {
+          // theoreticalResult = i+i^2 = i*(i+1)
+          if (result[i] != i * (i + 1)) {
+            printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);
+          }
+        }
       }
     };
-
 
     struct verifyVectorProd {
       template <typename T_Acc, typename T_Data>
-      ALPAKA_FN_ACC void operator()(
-				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+      ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+        const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+        const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+        const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
 
-	const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
-	const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
-	const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
-
-
-	if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
-	  for (unsigned int row = 0; row < numElements; ++row) {
-	    for (unsigned int col = 0; col < numElements; ++col) {
-
-	      const T_Data theoreticalResult = static_cast<T_Data>(row)*col*col;
-	      const T_Data diff = result[row + numElements * col] - theoreticalResult;
-	      const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
-	      if (diff > tolerance || diff < -tolerance) {
-		printf("Wrong vectorProd results, row = %u, col = %u, c[row,col] = %f.\n",
-		       row, col, result[row * numElements + col]
-		       );
-	      }
-	    }
-	  }
-	}
-
+        if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
+          for (unsigned int row = 0; row < numElements; ++row) {
+            for (unsigned int col = 0; col < numElements; ++col) {
+              const T_Data theoreticalResult = static_cast<T_Data>(row) * col * col;
+              const T_Data diff = result[row + numElements * col] - theoreticalResult;
+              const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
+              if (diff > tolerance || diff < -tolerance) {
+                printf("Wrong vectorProd results, row = %u, col = %u, c[row,col] = %f.\n",
+                       row,
+                       col,
+                       result[row * numElements + col]);
+              }
+            }
+          }
+        }
       }
     };
-
 
     struct verifyMatrixMul {
       template <typename T_Acc, typename T_Data>
-      ALPAKA_FN_ACC void operator()(
-				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+      ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+        const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+        const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+        const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
 
-	const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
-	const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
-	const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
+        if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
+          const T_Data partialtheoreticalResult =
+              static_cast<T_Data>(numElements - 1) * (numElements - 1) * numElements * numElements / 4;
 
+          for (unsigned int row = 0; row < numElements; ++row) {
+            for (unsigned int col = 0; col < numElements; ++col) {
+              // theoreticalResult = row * col * (col+1) * Sum(k=1 to numElements-1, k^3)
+              const T_Data theoreticalResult = static_cast<T_Data>(row) * col * (col + 1) * partialtheoreticalResult;
+              const T_Data diff = result[row + numElements * col] - theoreticalResult;
+              const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
 
-	if (threadIdxGlobalX == 0 && threadIdxGlobalY == 0) {
-	  const T_Data partialtheoreticalResult = static_cast<T_Data>(numElements-1)*(numElements-1)*numElements*numElements/4;
-	
-	  for (unsigned int row = 0; row < numElements; ++row) {
-	    for (unsigned int col = 0; col < numElements; ++col) {
-
-	      // theoreticalResult = row * col * (col+1) * Sum(k=1 to numElements-1, k^3)
-	      const T_Data theoreticalResult = static_cast<T_Data>(row)*col*(col+1)*partialtheoreticalResult;
-	      const T_Data diff = result[row + numElements * col] - theoreticalResult;
-	      const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
-	      
-	      if (diff > tolerance || diff < -tolerance) {
-		printf("Wrong matrix multiplication results, row = %u, col = %u, c[row,col] = %f, theoreticalResult = %f.\n",
-		       row, col, result[row * numElements + col], theoreticalResult
-		       );
-	      }
-	    }
-	  }
-	}
-
+              if (diff > tolerance || diff < -tolerance) {
+                printf(
+                    "Wrong matrix multiplication results, row = %u, col = %u, c[row,col] = %f, theoreticalResult = "
+                    "%f.\n",
+                    row,
+                    col,
+                    result[row * numElements + col],
+                    theoreticalResult);
+              }
+            }
+          }
+        }
       }
     };
-
 
     struct verifyMatrixMulVector {
       template <typename T_Acc, typename T_Data>
-      ALPAKA_FN_ACC void operator()(
-				    const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+      ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
+        const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
 
-	const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+        if (threadIdxGlobal == 0) {
+          const unsigned long int N = numElements - 1;
+          const unsigned long int N2 = N * N;
+          const unsigned long int N3 = N2 * N;
+          const unsigned long int N4 = N2 * N2;
+          const unsigned long int N5 = N4 * N;
+          const T_Data partialtheoreticalResult =
+              static_cast<T_Data>(N2) * (N + 1) * (N + 1) / 4 *
+              ((6 * N5 + 15 * N4 + 10 * N3 - N) / 30 + (N + 1) * (N + 1) * N2 / 2 + N * (N + 1) / 2);
 
-	if (threadIdxGlobal == 0) {
-	  const unsigned long int N = numElements - 1;
-	  const unsigned long int N2 = N*N;
-	  const unsigned long int N3 = N2 * N;
-	  const unsigned long int N4 = N2 * N2;
-	  const unsigned long int N5 = N4 * N;
-	  const T_Data partialtheoreticalResult = static_cast<T_Data>(N2)*(N+1)*(N+1)/4 * ((6*N5+15*N4+10*N3-N)/30 + (N+1)*(N+1)*N2/2 + N*(N+1)/2);
+          for (unsigned int i = 0; i < numElements; ++i) {
+            // theoreticalResult = N^2*(N+1)^2/4 * i * Sum(k=1 to N, k^2*(k+1)^2)
+            const T_Data theoreticalResult = i * partialtheoreticalResult;
+            const T_Data diff = result[i] - theoreticalResult;
+            const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
 
-
-	  for (unsigned int i = 0; i < numElements; ++i) {
-
-	    // theoreticalResult = N^2*(N+1)^2/4 * i * Sum(k=1 to N, k^2*(k+1)^2)
-	    const T_Data theoreticalResult = i * partialtheoreticalResult;
-	    const T_Data diff = result[i] - theoreticalResult;
-	    const T_Data tolerance = theoreticalResult * TOLERANCE_RATIO;
-
-	    if (diff > tolerance || diff < -tolerance) {
-	      printf("Wrong matrix-vector multiplication results, i = %u, c[i] = %f, theoreticalResult = %f.\n",
-		     i, result[i], theoreticalResult
-		     );
-	    
-	    }
-	  }
-	}
-
+            if (diff > tolerance || diff < -tolerance) {
+              printf("Wrong matrix-vector multiplication results, i = %u, c[i] = %f, theoreticalResult = %f.\n",
+                     i,
+                     result[i],
+                     theoreticalResult);
+            }
+          }
+        }
       }
     };
 
-  } // namespace debug
+  }  // namespace debug
 
-
-} // namespace
-
-
+}  // namespace
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   void alpakaAlgo2() {
-
     const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
     const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
     const Vec size(NUM_VALUES);
     Queue queue(device);
 
-   
     // Host data
     auto h_a_buf = alpaka::mem::buf::alloc<float, Idx>(host, size);
     auto h_b_buf = alpaka::mem::buf::alloc<float, Idx>(host, size);
@@ -289,7 +258,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       h_b[i] = i * i;
     }
 
-
     // Device data
     auto d_a_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
     auto d_b_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
@@ -297,19 +265,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     alpaka::mem::view::copy(queue, d_b_buf, h_b_buf, size);
     auto d_c_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
 
-
     // Prepare 1D workDiv
     Vec elementsPerThread(Vec::all(1));
     Vec threadsPerBlock(Vec::all(32));
     const Vec blocksPerGrid(Vec::all((NUM_VALUES + 32 - 1) / 32));
 #if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || \
-  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
     // on the GPU, run with 32 threads in parallel per block, each looking at a single element
     // on the CPU, run serially with a single thread per block, over 32 elements
     std::swap(threadsPerBlock, elementsPerThread);
 #endif
     const WorkDiv workDiv(blocksPerGrid, threadsPerBlock, elementsPerThread);
-
 
     // VECTOR ADDITION
     alpaka::queue::enqueue(queue,
@@ -325,7 +291,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const unsigned int threadsPerBlockSide = (NUM_VALUES < 32 ? NUM_VALUES : 32u);
     Vec2 threadsPerBlock2(threadsPerBlockSide, threadsPerBlockSide);
 #if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || \
-  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
     // on the GPU, run with 32 threads in parallel per block, each looking at a single element
     // on the CPU, run serially with a single thread per block, over 32 elements
     std::swap(threadsPerBlock2, elementsPerThread2);
@@ -334,49 +300,47 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const Vec2 blocksPerGrid2(blocksPerGridSide, blocksPerGridSide);
     const WorkDiv2 workDiv2(blocksPerGrid2, threadsPerBlock2, elementsPerThread2);
 
-
     // Device data
     const Vec2 sizeSquare(NUM_VALUES, NUM_VALUES);
     auto d_ma_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
     auto d_mb_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
     auto d_mc_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
 
-
     // VECTOR MULTIPLICATION
     alpaka::queue::enqueue(queue,
-			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
-								  vectorProd(),
-								  alpaka::mem::view::getPtrNative(d_a_buf),
-								  alpaka::mem::view::getPtrNative(d_b_buf),
-								  alpaka::mem::view::getPtrNative(d_ma_buf),
-								  NUM_VALUES));
+                           alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+                                                                  vectorProd(),
+                                                                  alpaka::mem::view::getPtrNative(d_a_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_b_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_ma_buf),
+                                                                  NUM_VALUES));
 
     alpaka::queue::enqueue(queue,
-			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
-								  vectorProd(),
-								  alpaka::mem::view::getPtrNative(d_a_buf),
-								  alpaka::mem::view::getPtrNative(d_c_buf),
-								  alpaka::mem::view::getPtrNative(d_mb_buf),
-								  NUM_VALUES));
+                           alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+                                                                  vectorProd(),
+                                                                  alpaka::mem::view::getPtrNative(d_a_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_c_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_mb_buf),
+                                                                  NUM_VALUES));
 
     // MATRIX MULTIPLICATION
     alpaka::queue::enqueue(queue,
-			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
-								  matrixMul(),
-								  alpaka::mem::view::getPtrNative(d_ma_buf),
-								  alpaka::mem::view::getPtrNative(d_mb_buf),
-								  alpaka::mem::view::getPtrNative(d_mc_buf),
-								  NUM_VALUES));
+                           alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+                                                                  matrixMul(),
+                                                                  alpaka::mem::view::getPtrNative(d_ma_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_mb_buf),
+                                                                  alpaka::mem::view::getPtrNative(d_mc_buf),
+                                                                  NUM_VALUES));
 
     // MATRIX - VECTOR MULTIPLICATION
     alpaka::queue::enqueue(queue,
-			   alpaka::kernel::createTaskKernel<Acc>(workDiv,
-								 matrixMulVector(),
-								 alpaka::mem::view::getPtrNative(d_mc_buf),
-								 alpaka::mem::view::getPtrNative(d_b_buf),
-								 alpaka::mem::view::getPtrNative(d_c_buf),
-								 NUM_VALUES));
+                           alpaka::kernel::createTaskKernel<Acc>(workDiv,
+                                                                 matrixMulVector(),
+                                                                 alpaka::mem::view::getPtrNative(d_mc_buf),
+                                                                 alpaka::mem::view::getPtrNative(d_b_buf),
+                                                                 alpaka::mem::view::getPtrNative(d_c_buf),
+                                                                 NUM_VALUES));
 
-    alpaka::wait::wait(queue);    
+    alpaka::wait::wait(queue);
   }
-} // namespace ALPAKA_ACCELERATOR_NAMESPACE
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE


### PR DESCRIPTION
Add simple vectorProd, matrixMul, matrixVectorMul tests to alpakatest.
Compiles and runs smoothy with serial, tbb and GPU cases.

Calling the 3 Producers, on 1000 events, with size N=1000, I get similar throughput comparing Alpaka(CUDA) with native CUDA style kernels (GPU Quadro M1200):
- cudatest: ~17.8 events/s
- alpakatest --cuda: ~16.6 events/s
Hence potentially a small overhead with Alpaka(CUDA), which I presume is expected (consistent with the 6% overhead found in the literature).


NB 1: I was getting wrong results with vectorAdd in the serial and tbb cases.  
Indeed, there was no loop on the elements. Hence, only one value every 32 was calculated, in the serial and tbb cases. 
vectorAdd is now fixed in this PR (all results have been cross-checked). Was this expected?

NB 2: Following throughput are obtained calling the same 3 Producers, on 1000 events, with size N=1000, in the serial and TBB cases (Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz):
- alpakatest --serial: ~0.75 event/s
- alpakatest --tbb: ~1.1 event/s
Though these do not make much sense, as no effort was done for optimization anyway.