### PR TITLE
Add warmup option to run the command once before starting the profiling

### DIFF
--- a/run-scan.py
+++ b/run-scan.py
@@ -123,7 +123,7 @@ def main(opts):
 
         if opts.warmup:
           printMessage("Warming up")
-          run(nev, nstr, cores_main, opts, "warmup.txt")
+          run(nev, nstr, cores_main, opts, opts.output+"_warmup.txt")
           print()
           opts.warmup = False
 

--- a/run-scan.py
+++ b/run-scan.py
@@ -120,6 +120,13 @@ def main(opts):
         else:
             nev = nev_per_stream*nstr
         (cores_main, cores_bkg) = partition_cores(cores, nth)
+
+        if opts.warmup:
+          printMessage("Warming up")
+          run(nev, nstr, cores_main, opts, "warmup.txt")
+          print()
+          opts.warmup = False
+
         msg = "Number of streams %d threads %d events %d" % (nstr, nth, nev)
         if opts.taskset:
             msg += ", running on cores %s" % ",".join(cores_main)
@@ -195,6 +202,8 @@ if __name__ == "__main__":
                         help="Repeat each point this many times (default: 1)")
     parser.add_argument("--tryAgain", type=int, default=1,
                         help="In case of failure on a point, try again at most this many times (default: 1)")
+    parser.add_argument("--warmup", action="store_true",
+                        help="Run the command once before starting the profiling")
     parser.add_argument("--dryRun", action="store_true",
                         help="Print out commands, don't actually run anything")
 


### PR DESCRIPTION
Usage:
```
./run-scan.py --numThreads 4 --eventsPerStream 1000 --repeat 4 --overwrite --warmup ./cuda 
20-12-06 10:19:55 Warming up
20-12-06 10:20:01 Processed 4000 events in 5.067138e+00 seconds, throughput 789.4 events/s.

20-12-06 10:20:01 Number of streams 4 threads 4 events 4000
20-12-06 10:20:06 Processed 4000 events in 4.927730e+00 seconds, throughput 811.733 events/s.
20-12-06 10:20:12 Processed 4000 events in 4.954347e+00 seconds, throughput 807.372 events/s.
20-12-06 10:20:17 Processed 4000 events in 4.949005e+00 seconds, throughput 808.243 events/s.
20-12-06 10:20:23 Processed 4000 events in 4.941497e+00 seconds, throughput 809.471 events/s.
20-12-06 10:20:23 Number of streams 4 threads 4, average throughput 809.204750
```

The first measurement is run but its results are discarded.

The log is sent to `warmup.txt`, which can still be useful to debug any problems (*e.g.* missing environment, *etc.*)