### PR TITLE
Add a doneWaiting overload without the exception argument

### DIFF
--- a/src/fwtest/Framework/WaitingTaskWithArenaHolder.h
+++ b/src/fwtest/Framework/WaitingTaskWithArenaHolder.h
@@ -52,6 +52,12 @@ namespace edm {
     // into the correct arena of threads. Use of the arena allows doneWaiting
     // to be called from a thread outside the arena of threads that will manage
     // the task. doneWaiting can be called from a non-TBB thread.
+    void doneWaiting();
+
+    // This spawns the task. The arena is needed to get the task spawned
+    // into the correct arena of threads. Use of the arena allows doneWaiting
+    // to be called from a thread outside the arena of threads that will manage
+    // the task. doneWaiting can be called from a non-TBB thread.
     void doneWaiting(std::exception_ptr iExcept);
 
     // This next function is useful if you know from the context that

--- a/src/fwtest/bin/StreamSchedule.cc
+++ b/src/fwtest/bin/StreamSchedule.cc
@@ -82,7 +82,7 @@ namespace edm {
         (*iWorker)->doWorkAsync(*eventPtr, *eventSetup_, nextEventTask);
       }
     } else {
-      h.doneWaiting(std::exception_ptr{});
+      h.doneWaiting();
     }
   }
 

--- a/src/fwtest/plugin-Test2/TestProducer2.cc
+++ b/src/fwtest/plugin-Test2/TestProducer2.cc
@@ -39,7 +39,7 @@ void TestProducer2::acquire(edm::Event const& event,
   future_ = std::async([holder = std::move(holder)]() mutable {
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(1s);
-    holder.doneWaiting(std::exception_ptr());
+    holder.doneWaiting();
     return 42;
   });
 


### PR DESCRIPTION
Simplifies a bit the interface and usage of `doneWaiting()`, avoiding the need to create a null `std::exception_ptr`.