### PR TITLE
Use the correct version of Eigen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,7 @@ external_eigen: $(EIGEN_BASE)
 
 $(EIGEN_BASE):
 	git clone https://github.com/cms-externals/eigen-git-mirror $@
-	cd $@ && git checkout -b cms_branch d812f411c3f9
+	cd $@ && git checkout -b cms_branch b20a61c3a0dc9a79790cd258130a99b574662272
 
 # Boost
 .PHONY: external_boost


### PR DESCRIPTION
This new one is the one used in CMSSW_11_2_0_pre8_Patatrack (and earlier), the one used before is the commit used as the base of patches applied by CMS.

Resolves #147.

Update needs either `make distclean` or `rm -fR external/eigen`.