### PR TITLE
Remove duplicate targets in case they could be enabled by many toolchains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,8 @@ endif
 ifdef SYCL_BASE
 TARGETS += $(TARGETS_SYCL)
 endif
+# remove possible duplicates
+TARGETS := $(sort $(TARGETS))
 all: $(TARGETS)
 
 # Define test targets for each architecture


### PR DESCRIPTION
Currently can come up if both CUDA and ROCm toolchains are detected.