### PR TITLE
Code format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export SO_LDFLAGS_NVCC := --linker-options '-z,defs'
 
 GCC_TOOLCHAIN := $(abspath $(dir $(shell which $(CXX)))/..)
 
-CLANG_FORMAT := clang-format-8
+CLANG_FORMAT := clang-format-10
 CMAKE := cmake
 
 # Source code

--- a/README.md
+++ b/README.md
@@ -301,3 +301,5 @@ tests (`make test`). Programs to have build errors should primarily be
 filtered out from `$(TARGETS)`, and failing tests should primarily be
 removed from the set of tests run by default. Breakages can, however,
 be accepted for short periods of time with a good justification.
+
+The code is formatted with `clang-format` version 10.

--- a/src/kokkostest/KokkosCore/ProductBase.h
+++ b/src/kokkostest/KokkosCore/ProductBase.h
@@ -113,8 +113,7 @@ namespace cms {
       impl::ExecSpaceSpecific<ExecSpace> const& execSpaceSpecific() const {
         auto const& sp = *execSpaceSpecific_;
         if (typeid(sp) != typeid(impl::ExecSpaceSpecific<ExecSpace>)) {
-          throw std::runtime_error(std::string("Incompatible Execution space: has ") +
-                                   typeid(sp).name() + ", but " +
+          throw std::runtime_error(std::string("Incompatible Execution space: has ") + typeid(sp).name() + ", but " +
                                    typeid(impl::ExecSpaceSpecific<ExecSpace>).name() + " was asked for");
         }
         return static_cast<impl::ExecSpaceSpecific<ExecSpace> const&>(sp);


### PR DESCRIPTION
One change has gotten past manual code formatting. Also update the default `clang-format` to version 10 (to reflect reality), and mention that in the README.