### PR TITLE
[alpakatest] Add return types to alpakatest algos

### DIFF
--- a/src/alpaka/Makefile
+++ b/src/alpaka/Makefile
@@ -8,7 +8,8 @@ $(TARGET):
 test_cpu: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
-	$(TARGET) --maxEvents 2 --serial --tbb
+	$(TARGET) --maxEvents 2 --serial
+	$(TARGET) --maxEvents 2 --tbb
 	@echo "Succeeded"
 test_nvidiagpu: $(TARGET)
 	@echo

--- a/src/alpakatest/AlpakaCore/alpakaConfig.h
+++ b/src/alpakatest/AlpakaCore/alpakaConfig.h
@@ -26,6 +26,10 @@ namespace alpaka_cuda_async {
   using DevAcc2 = alpaka::dev::Dev<Acc2>;
   using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
   using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+
+  template <class T_Data>
+    using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+
   using Queue = alpaka::queue::QueueCudaRtNonBlocking;
 }  // namespace alpaka_cuda_async
 
@@ -46,6 +50,10 @@ namespace alpaka_serial_sync {
   using DevAcc2 = alpaka::dev::Dev<Acc2>;
   using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
   using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+
+  template <class T_Data>
+    using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+
   using Queue = alpaka::queue::QueueCpuBlocking;
 }  // namespace alpaka_serial_sync
 
@@ -66,6 +74,10 @@ namespace alpaka_tbb_async {
   using DevAcc2 = alpaka::dev::Dev<Acc2>;
   using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
   using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+
+  template <class T_Data>
+    using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+
   using Queue = alpaka::queue::QueueCpuNonBlocking;
 }  // namespace alpaka_tbb_async
 
@@ -86,6 +98,10 @@ namespace alpaka_omp2_async {
   using DevAcc2 = alpaka::dev::Dev<Acc2>;
   using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
   using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+
+  template <class T_Data>
+    using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+
   using Queue = alpaka::queue::QueueCpuNonBlocking;
 }  // namespace alpaka_omp2_async
 
@@ -106,6 +122,10 @@ namespace alpaka_omp4_async {
   using DevAcc2 = alpaka::dev::Dev<Acc2>;
   using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
   using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+
+  template <class T_Data>
+    using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+
   using Queue = alpaka::queue::QueueCpuNonBlocking;
 }  // namespace alpaka_omp4_async
 

--- a/src/alpakatest/AlpakaCore/alpakaConfig.h
+++ b/src/alpakatest/AlpakaCore/alpakaConfig.h
@@ -28,7 +28,7 @@ namespace alpaka_cuda_async {
   using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
 
   template <class T_Data>
-    using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
 
   using Queue = alpaka::queue::QueueCudaRtNonBlocking;
 }  // namespace alpaka_cuda_async
@@ -52,7 +52,7 @@ namespace alpaka_serial_sync {
   using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
 
   template <class T_Data>
-    using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
 
   using Queue = alpaka::queue::QueueCpuBlocking;
 }  // namespace alpaka_serial_sync
@@ -76,7 +76,7 @@ namespace alpaka_tbb_async {
   using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
 
   template <class T_Data>
-    using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
 
   using Queue = alpaka::queue::QueueCpuNonBlocking;
 }  // namespace alpaka_tbb_async
@@ -100,7 +100,7 @@ namespace alpaka_omp2_async {
   using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
 
   template <class T_Data>
-    using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
 
   using Queue = alpaka::queue::QueueCpuNonBlocking;
 }  // namespace alpaka_omp2_async
@@ -124,7 +124,7 @@ namespace alpaka_omp4_async {
   using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
 
   template <class T_Data>
-    using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
 
   using Queue = alpaka::queue::QueueCpuNonBlocking;
 }  // namespace alpaka_omp4_async

--- a/src/alpakatest/Makefile
+++ b/src/alpakatest/Makefile
@@ -8,7 +8,8 @@ $(TARGET):
 test_cpu: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
-	$(TARGET) --maxEvents 2 --serial --tbb
+	$(TARGET) --maxEvents 2 --serial
+	$(TARGET) --maxEvents 2 --tbb
 	@echo "Succeeded"
 test_nvidiagpu: $(TARGET)
 	@echo

--- a/src/alpakatest/plugin-Test1/alpaka/TestProducer.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/TestProducer.cc
@@ -23,10 +23,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   };
 
   TestProducer::TestProducer(edm::ProductRegistry& reg)
-    : rawGetToken_(reg.consumes<FEDRawDataCollection>()),
-      putToken_(reg.produces<AlpakaAccBuf2<float>>())
-  {
-  }
+      : rawGetToken_(reg.consumes<FEDRawDataCollection>()), putToken_(reg.produces<AlpakaAccBuf2<float>>()) {}
 
   void TestProducer::produce(edm::Event& event, edm::EventSetup const& eventSetup) {
     auto const value = event.get(rawGetToken_).FEDData(1200).size();

--- a/src/alpakatest/plugin-Test1/alpaka/TestProducer.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/TestProducer.cc
@@ -21,20 +21,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void produce(edm::Event& event, edm::EventSetup const& eventSetup) override;
 
     edm::EDGetTokenT<FEDRawDataCollection> rawGetToken_;
-    /*#ifdef TODO
-    edm::EDPutTokenT<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>> putToken_;
-    #endif*/
-    edm::EDPutTokenT<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>> putToken_;
-    //edm::EDPutTokenT<float*> putToken_;
+    edm::EDPutTokenT<AlpakaAccBuf2<float>> putToken_;
   };
 
     TestProducer::TestProducer(edm::ProductRegistry& reg)
       : rawGetToken_(reg.consumes<FEDRawDataCollection>()),
-	/*#ifdef TODO
-	  putToken_(reg.produces<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>>())
-	  #endif*/
-        putToken_(reg.produces<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>>())
-	//putToken_(reg.produces<float*>())
+        putToken_(reg.produces<AlpakaAccBuf2<float>>())
   {
   }
 
@@ -43,15 +35,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     std::cout << "TestProducer  Event " << event.eventID() << " stream " << event.streamID() << " ES int "
               << eventSetup.get<int>() << " FED 1200 size " << value << std::endl;
 
-    /*#ifdef TODO
-      cms::cuda::ScopedContextProduce ctx(event.streamID());
-
-      ctx.emplace(event, putToken_, gpuAlgo1(ctx.stream()));
-      #endif*/
-    //alpakaAlgo1();
-
-    //alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx> result = alpakaAlgo1();
-    //std::cout << alpaka::mem::view::getPtrNative(result) << std::endl;
+#ifdef SCOPEDCONTEXT
+    cms::cuda::ScopedContextProduce ctx(event.streamID());
+    ctx.emplace(event, putToken_, gpuAlgo1(ctx.stream()));
+#endif
 
     event.emplace(putToken_, alpakaAlgo1());
 

--- a/src/alpakatest/plugin-Test1/alpaka/TestProducer.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/TestProducer.cc
@@ -10,6 +10,8 @@
 
 #include "alpakaAlgo1.h"
 
+
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestProducer : public edm::EDProducer {
   public:
@@ -19,17 +21,20 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void produce(edm::Event& event, edm::EventSetup const& eventSetup) override;
 
     edm::EDGetTokenT<FEDRawDataCollection> rawGetToken_;
-#ifdef TODO
+    /*#ifdef TODO
     edm::EDPutTokenT<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>> putToken_;
-#endif
+    #endif*/
+    edm::EDPutTokenT<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>> putToken_;
+    //edm::EDPutTokenT<float*> putToken_;
   };
 
-  TestProducer::TestProducer(edm::ProductRegistry& reg)
-      : rawGetToken_(reg.consumes<FEDRawDataCollection>())
-#ifdef TODO
-        ,
-        putToken_(reg.produces<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>>())
-#endif
+    TestProducer::TestProducer(edm::ProductRegistry& reg)
+      : rawGetToken_(reg.consumes<FEDRawDataCollection>()),
+	/*#ifdef TODO
+	  putToken_(reg.produces<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>>())
+	  #endif*/
+        putToken_(reg.produces<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>>())
+	//putToken_(reg.produces<float*>())
   {
   }
 
@@ -38,12 +43,18 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     std::cout << "TestProducer  Event " << event.eventID() << " stream " << event.streamID() << " ES int "
               << eventSetup.get<int>() << " FED 1200 size " << value << std::endl;
 
-    alpakaAlgo1();
-#ifdef TODO
-    cms::cuda::ScopedContextProduce ctx(event.streamID());
+    /*#ifdef TODO
+      cms::cuda::ScopedContextProduce ctx(event.streamID());
 
-    ctx.emplace(event, putToken_, gpuAlgo1(ctx.stream()));
-#endif
+      ctx.emplace(event, putToken_, gpuAlgo1(ctx.stream()));
+      #endif*/
+    //alpakaAlgo1();
+
+    //alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx> result = alpakaAlgo1();
+    //std::cout << alpaka::mem::view::getPtrNative(result) << std::endl;
+
+    event.emplace(putToken_, alpakaAlgo1());
+
   }
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 

--- a/src/alpakatest/plugin-Test1/alpaka/TestProducer.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/TestProducer.cc
@@ -10,8 +10,6 @@
 
 #include "alpakaAlgo1.h"
 
-
-
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestProducer : public edm::EDProducer {
   public:
@@ -24,9 +22,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     edm::EDPutTokenT<AlpakaAccBuf2<float>> putToken_;
   };
 
-    TestProducer::TestProducer(edm::ProductRegistry& reg)
-      : rawGetToken_(reg.consumes<FEDRawDataCollection>()),
-        putToken_(reg.produces<AlpakaAccBuf2<float>>())
+  TestProducer::TestProducer(edm::ProductRegistry& reg)
+    : rawGetToken_(reg.consumes<FEDRawDataCollection>()),
+      putToken_(reg.produces<AlpakaAccBuf2<float>>())
   {
   }
 
@@ -41,7 +39,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif
 
     event.emplace(putToken_, alpakaAlgo1());
-
   }
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
@@ -243,7 +243,6 @@ namespace {
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   AlpakaAccBuf2<float> alpakaAlgo1() {
-    //float* alpakaAlgo1() {
     const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
     const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
     const Vec size(NUM_VALUES);

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
@@ -242,7 +242,7 @@ namespace {
 }  // namespace
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx> alpakaAlgo1() {
+  AlpakaAccBuf2<float> alpakaAlgo1() {
     //float* alpakaAlgo1() {
     const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
     const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
@@ -342,12 +342,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                  alpaka::mem::view::getPtrNative(d_c_buf),
                                                                  NUM_VALUES));
 
-    
-
-    //alpaka::mem::view::copy(queue, blockRetVals, blockRetValsAcc, resultElemCount);
-
     alpaka::wait::wait(queue);
     return d_mc_buf;
-    //return alpaka::mem::view::getPtrNative(d_mc_buf);
   }
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
@@ -242,7 +242,8 @@ namespace {
 }  // namespace
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  void alpakaAlgo1() {
+  alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx> alpakaAlgo1() {
+    //float* alpakaAlgo1() {
     const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
     const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
     const Vec size(NUM_VALUES);
@@ -341,6 +342,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                  alpaka::mem::view::getPtrNative(d_c_buf),
                                                                  NUM_VALUES));
 
+    
+
+    //alpaka::mem::view::copy(queue, blockRetVals, blockRetValsAcc, resultElemCount);
+
     alpaka::wait::wait(queue);
+    return d_mc_buf;
+    //return alpaka::mem::view::getPtrNative(d_mc_buf);
   }
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.h
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.h
@@ -9,10 +9,7 @@
 // of build rules for files to be compiled by accelerator, and
 // different set for files to be compiled by architecture?
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  //alpaka::mem::buf::Buf<Acc2, float, std::integral_constant<long unsigned int, 1>, unsigned int> alpakaAlgo1();
-  alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx> alpakaAlgo1();
-  //float* alpakaAlgo1();
-
+  AlpakaAccBuf2<float> alpakaAlgo1();
 }
 
 #endif

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.h
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.h
@@ -9,7 +9,10 @@
 // of build rules for files to be compiled by accelerator, and
 // different set for files to be compiled by architecture?
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  void alpakaAlgo1();
+  //alpaka::mem::buf::Buf<Acc2, float, std::integral_constant<long unsigned int, 1>, unsigned int> alpakaAlgo1();
+  alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx> alpakaAlgo1();
+  //float* alpakaAlgo1();
+
 }
 
 #endif

--- a/src/alpakatest/plugin-Test2/alpaka/TestProducer2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/TestProducer2.cc
@@ -46,7 +46,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif
     alpakaAlgo2();
 
-
     std::cout << "TestProducer2::acquire Event " << event.eventID() << " stream " << event.streamID()
 #ifdef SCOPEDCONTEXT
               << " array " << array.get()
@@ -55,9 +54,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   }
 
   void TestProducer2::produce(edm::Event& event, edm::EventSetup const& eventSetup) {
-  std::cout << "TestProducer2::produce Event " << event.eventID() << " stream " << event.streamID() << std::endl;
-  ++nevents;
-}
+    std::cout << "TestProducer2::produce Event " << event.eventID() << " stream " << event.streamID() << std::endl;
+    ++nevents;
+  }
 
   void TestProducer2::endJob() {
     std::cout << "TestProducer2::endJob processed " << nevents.load() << " events" << std::endl;

--- a/src/alpakatest/plugin-Test2/alpaka/TestProducer2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/TestProducer2.cc
@@ -26,18 +26,24 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void produce(edm::Event& event, edm::EventSetup const& eventSetup) override;
     void endJob() override;
 
-#ifdef TODO
-    edm::EDGetTokenT<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>> getToken_;
-#endif
+    /*
+      #ifdef TODO
+      edm::EDGetTokenT<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>> getToken_;
+      #endif
+    */
+    //edm::EDPutTokenT<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>> putToken_;
   };
 
-  TestProducer2::TestProducer2(edm::ProductRegistry& reg)
-#ifdef TODO
-      : getToken_(reg.consumes<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>>())
-#endif
+  TestProducer2::TestProducer2(edm::ProductRegistry& reg) 
+  //:
+    /*
+      #ifdef TODO
+      getToken_(reg.consumes<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>>())
+      #endif*/
+    //putToken_(reg.produces<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>>())
   {
-    nevents = 0;
-  }
+  nevents = 0;
+}
 
   void TestProducer2::acquire(edm::Event const& event,
                               edm::EventSetup const& eventSetup,
@@ -49,7 +55,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     auto const& array = ctx.get(tmp);
 #endif
-    alpakaAlgo2();
+  //alpakaAlgo2()
+
 
     std::cout << "TestProducer2::acquire Event " << event.eventID() << " stream " << event.streamID()
 #ifdef TODO
@@ -59,9 +66,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   }
 
   void TestProducer2::produce(edm::Event& event, edm::EventSetup const& eventSetup) {
-    std::cout << "TestProducer2::produce Event " << event.eventID() << " stream " << event.streamID() << std::endl;
-    ++nevents;
-  }
+  std::cout << "TestProducer2::produce Event " << event.eventID() << " stream " << event.streamID() << std::endl;
+  //event.emplace(putToken_, alpakaAlgo2());
+  ++nevents;
+}
 
   void TestProducer2::endJob() {
     std::cout << "TestProducer2::endJob processed " << nevents.load() << " events" << std::endl;

--- a/src/alpakatest/plugin-Test2/alpaka/TestProducer2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/TestProducer2.cc
@@ -29,16 +29,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     edm::EDGetTokenT<AlpakaAccBuf2<float>> getToken_;
   };
 
-  TestProducer2::TestProducer2(edm::ProductRegistry& reg) :
-    getToken_(reg.consumes<AlpakaAccBuf2<float>>())
-  {
+  TestProducer2::TestProducer2(edm::ProductRegistry& reg) : getToken_(reg.consumes<AlpakaAccBuf2<float>>()) {
     nevents = 0;
   }
 
   void TestProducer2::acquire(edm::Event const& event,
                               edm::EventSetup const& eventSetup,
                               edm::WaitingTaskWithArenaHolder holder) {
-
 #ifdef SCOPEDCONTEXT
     auto const& tmp = event.get(getToken_);
     cms::cuda::ScopedContextAcquire ctx(tmp, std::move(holder));

--- a/src/alpakatest/plugin-Test2/alpaka/TestProducer2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/TestProducer2.cc
@@ -26,40 +26,29 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void produce(edm::Event& event, edm::EventSetup const& eventSetup) override;
     void endJob() override;
 
-    /*
-      #ifdef TODO
-      edm::EDGetTokenT<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>> getToken_;
-      #endif
-    */
-    //edm::EDPutTokenT<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>> putToken_;
+    edm::EDGetTokenT<AlpakaAccBuf2<float>> getToken_;
   };
 
-  TestProducer2::TestProducer2(edm::ProductRegistry& reg) 
-  //:
-    /*
-      #ifdef TODO
-      getToken_(reg.consumes<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>>())
-      #endif*/
-    //putToken_(reg.produces<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>>())
+  TestProducer2::TestProducer2(edm::ProductRegistry& reg) :
+    getToken_(reg.consumes<AlpakaAccBuf2<float>>())
   {
-  nevents = 0;
-}
+    nevents = 0;
+  }
 
   void TestProducer2::acquire(edm::Event const& event,
                               edm::EventSetup const& eventSetup,
                               edm::WaitingTaskWithArenaHolder holder) {
-#ifdef TODO
+
+#ifdef SCOPEDCONTEXT
     auto const& tmp = event.get(getToken_);
-
     cms::cuda::ScopedContextAcquire ctx(tmp, std::move(holder));
-
     auto const& array = ctx.get(tmp);
 #endif
-  //alpakaAlgo2()
+    alpakaAlgo2();
 
 
     std::cout << "TestProducer2::acquire Event " << event.eventID() << " stream " << event.streamID()
-#ifdef TODO
+#ifdef SCOPEDCONTEXT
               << " array " << array.get()
 #endif
               << std::endl;
@@ -67,7 +56,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   void TestProducer2::produce(edm::Event& event, edm::EventSetup const& eventSetup) {
   std::cout << "TestProducer2::produce Event " << event.eventID() << " stream " << event.streamID() << std::endl;
-  //event.emplace(putToken_, alpakaAlgo2());
   ++nevents;
 }
 

--- a/src/alpakatest/plugin-Test2/alpaka/TestProducer3.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/TestProducer3.cc
@@ -19,10 +19,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     edm::EDGetTokenT<AlpakaAccBuf2<float>> getToken_;
   };
 
-  TestProducer3::TestProducer3(edm::ProductRegistry& reg) :
-    getToken_(reg.consumes<AlpakaAccBuf2<float>>())
-  {
-  }
+  TestProducer3::TestProducer3(edm::ProductRegistry& reg) : getToken_(reg.consumes<AlpakaAccBuf2<float>>()) {}
 
   void TestProducer3::produce(edm::Event& event, edm::EventSetup const& eventSetup) {
     const auto& result = event.get(getToken_);

--- a/src/alpakatest/plugin-Test2/alpaka/TestProducer3.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/TestProducer3.cc
@@ -8,6 +8,47 @@
 
 #include "AlpakaCore/alpakaConfig.h"
 
+
+namespace {
+  constexpr unsigned int NUM_VALUES = 1000;
+
+  struct TestPrint {
+    template <typename T_Acc, typename T_Data>
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc,
+                                  const T_Data* __restrict__ a,
+                                  unsigned int numElements) const {
+      // Global thread index in Dim2 grid
+      const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+      const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
+      const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
+
+      // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
+      const auto& threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc));
+      const uint32_t threadDimensionX(threadDimension[0u]);
+      const uint32_t firstElementIdxGlobalX = threadIdxGlobalX * threadDimensionX;
+      const uint32_t endElementIdxGlobalXUncut = firstElementIdxGlobalX + threadDimensionX;
+      const uint32_t endElementIdxGlobalX = std::min(endElementIdxGlobalXUncut, numElements);
+
+      const uint32_t threadDimensionY(threadDimension[1u]);
+      const uint32_t firstElementIdxGlobalY = threadIdxGlobalY * threadDimensionY;
+      const uint32_t endElementIdxGlobalYUncut = firstElementIdxGlobalY + threadDimensionY;
+      const uint32_t endElementIdxGlobalY = std::min(endElementIdxGlobalYUncut, numElements);
+
+      for (uint32_t col = firstElementIdxGlobalX; col < endElementIdxGlobalX; ++col) {
+        for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {
+          printf("TestPrint, row = %u, col = %u, a[row,col] = %f.\n",
+		 row,
+		 col,
+		 a[row * numElements + col]);
+        }
+      }
+    }
+  };
+
+}
+
+
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestProducer3 : public edm::EDProducer {
   public:
@@ -16,24 +57,68 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   private:
     void produce(edm::Event& event, edm::EventSetup const& eventSetup) override;
 
-#ifdef TODO
+    /*#ifdef TODO
     edm::EDGetTokenT<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>> getToken_;
-#endif
+    #endif*/
+    edm::EDGetTokenT<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>> getToken_;
   };
 
-  TestProducer3::TestProducer3(edm::ProductRegistry& reg)
-#ifdef TODO
-      : getToken_(reg.consumes<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>>())
-#endif
+  TestProducer3::TestProducer3(edm::ProductRegistry& reg) 
+    :
+    /*#ifdef TODO
+      getToken_(reg.consumes<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>>())
+      #endif*/
+    getToken_(reg.consumes<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>>())
   {
   }
 
   void TestProducer3::produce(edm::Event& event, edm::EventSetup const& eventSetup) {
-#ifdef TODO
-    auto const& tmp = event.get(getToken_);
+    /*#ifdef TODO
+    auto const& tmp = event.get(getToken_); 
     cms::cuda::ScopedContextProduce ctx(tmp);
-#endif
+    #endif*/
+
+
+    auto const result = event.get(getToken_);
     std::cout << "TestProducer3 Event " << event.eventID() << " stream " << event.streamID() << std::endl;
+
+
+
+
+
+    const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
+    const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
+    const Vec size(NUM_VALUES);
+    Queue queue(device);
+
+    // Prepare 2D workDiv
+    Vec2 elementsPerThread2(1u, 1u);
+    const unsigned int threadsPerBlockSide = (NUM_VALUES < 32 ? NUM_VALUES : 32u);
+    Vec2 threadsPerBlock2(threadsPerBlockSide, threadsPerBlockSide);
+#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || \
+  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+    // on the GPU, run with 32 threads in parallel per block, each looking at a single element
+    // on the CPU, run serially with a single thread per block, over 32 elements
+    std::swap(threadsPerBlock2, elementsPerThread2);
+#endif
+    const unsigned int blocksPerGridSide = (NUM_VALUES <= 32 ? 1 : std::ceil(NUM_VALUES / 32.));
+    const Vec2 blocksPerGrid2(blocksPerGridSide, blocksPerGridSide);
+    const WorkDiv2 workDiv2(blocksPerGrid2, threadsPerBlock2, elementsPerThread2);
+
+    alpaka::queue::enqueue(queue,
+			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+								  TestPrint(),
+								  alpaka::mem::view::getPtrNative(result),
+								  NUM_VALUES));
+    alpaka::wait::wait(queue);
+
+
+
+
+
+
+
+
   }
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 

--- a/src/alpakatest/plugin-Test2/alpaka/TestProducer3.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/TestProducer3.cc
@@ -9,46 +9,6 @@
 #include "AlpakaCore/alpakaConfig.h"
 
 
-namespace {
-  constexpr unsigned int NUM_VALUES = 1000;
-
-  struct TestPrint {
-    template <typename T_Acc, typename T_Data>
-    ALPAKA_FN_ACC void operator()(T_Acc const& acc,
-                                  const T_Data* __restrict__ a,
-                                  unsigned int numElements) const {
-      // Global thread index in Dim2 grid
-      const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
-      const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
-      const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
-
-      // Global element index (obviously relevant for CPU only, for GPU, i = threadIndexGlobal only)
-      const auto& threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc));
-      const uint32_t threadDimensionX(threadDimension[0u]);
-      const uint32_t firstElementIdxGlobalX = threadIdxGlobalX * threadDimensionX;
-      const uint32_t endElementIdxGlobalXUncut = firstElementIdxGlobalX + threadDimensionX;
-      const uint32_t endElementIdxGlobalX = std::min(endElementIdxGlobalXUncut, numElements);
-
-      const uint32_t threadDimensionY(threadDimension[1u]);
-      const uint32_t firstElementIdxGlobalY = threadIdxGlobalY * threadDimensionY;
-      const uint32_t endElementIdxGlobalYUncut = firstElementIdxGlobalY + threadDimensionY;
-      const uint32_t endElementIdxGlobalY = std::min(endElementIdxGlobalYUncut, numElements);
-
-      for (uint32_t col = firstElementIdxGlobalX; col < endElementIdxGlobalX; ++col) {
-        for (uint32_t row = firstElementIdxGlobalY; row < endElementIdxGlobalY; ++row) {
-          printf("TestPrint, row = %u, col = %u, a[row,col] = %f.\n",
-		 row,
-		 col,
-		 a[row * numElements + col]);
-        }
-      }
-    }
-  };
-
-}
-
-
-
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestProducer3 : public edm::EDProducer {
   public:
@@ -57,69 +17,23 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   private:
     void produce(edm::Event& event, edm::EventSetup const& eventSetup) override;
 
-    /*#ifdef TODO
-    edm::EDGetTokenT<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>> getToken_;
-    #endif*/
-    edm::EDGetTokenT<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>> getToken_;
+    edm::EDGetTokenT<AlpakaAccBuf2<float>> getToken_;
   };
 
-  TestProducer3::TestProducer3(edm::ProductRegistry& reg) 
-    :
-    /*#ifdef TODO
-      getToken_(reg.consumes<cms::cuda::Product<cms::cuda::device::unique_ptr<float[]>>>())
-      #endif*/
-    getToken_(reg.consumes<alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx>>())
+  TestProducer3::TestProducer3(edm::ProductRegistry& reg) :
+    getToken_(reg.consumes<AlpakaAccBuf2<float>>())
   {
   }
 
   void TestProducer3::produce(edm::Event& event, edm::EventSetup const& eventSetup) {
-    /*#ifdef TODO
-    auto const& tmp = event.get(getToken_); 
-    cms::cuda::ScopedContextProduce ctx(tmp);
-    #endif*/
+    const auto& result = event.get(getToken_);
 
-
-    auto const result = event.get(getToken_);
-    std::cout << "TestProducer3 Event " << event.eventID() << " stream " << event.streamID() << std::endl;
-
-
-
-
-
-    const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
-    const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
-    const Vec size(NUM_VALUES);
-    Queue queue(device);
-
-    // Prepare 2D workDiv
-    Vec2 elementsPerThread2(1u, 1u);
-    const unsigned int threadsPerBlockSide = (NUM_VALUES < 32 ? NUM_VALUES : 32u);
-    Vec2 threadsPerBlock2(threadsPerBlockSide, threadsPerBlockSide);
-#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || \
-  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
-    // on the GPU, run with 32 threads in parallel per block, each looking at a single element
-    // on the CPU, run serially with a single thread per block, over 32 elements
-    std::swap(threadsPerBlock2, elementsPerThread2);
+#ifdef SCOPEDCONTEXT
+    cms::cuda::ScopedContextProduce ctx(result);
 #endif
-    const unsigned int blocksPerGridSide = (NUM_VALUES <= 32 ? 1 : std::ceil(NUM_VALUES / 32.));
-    const Vec2 blocksPerGrid2(blocksPerGridSide, blocksPerGridSide);
-    const WorkDiv2 workDiv2(blocksPerGrid2, threadsPerBlock2, elementsPerThread2);
 
-    alpaka::queue::enqueue(queue,
-			   alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
-								  TestPrint(),
-								  alpaka::mem::view::getPtrNative(result),
-								  NUM_VALUES));
-    alpaka::wait::wait(queue);
-
-
-
-
-
-
-
-
+    std::cout << "TestProducer3 Event " << event.eventID() << " stream " << event.streamID() << std::endl;
   }
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+  }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
 DEFINE_FWK_ALPAKA_MODULE(TestProducer3);

--- a/src/alpakatest/plugin-Test2/alpaka/TestProducer3.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/TestProducer3.cc
@@ -8,7 +8,6 @@
 
 #include "AlpakaCore/alpakaConfig.h"
 
-
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestProducer3 : public edm::EDProducer {
   public:
@@ -34,6 +33,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     std::cout << "TestProducer3 Event " << event.eventID() << " stream " << event.streamID() << std::endl;
   }
-  }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
 DEFINE_FWK_ALPAKA_MODULE(TestProducer3);

--- a/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
@@ -242,7 +242,7 @@ namespace {
 }  // namespace
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  void alpakaAlgo2() {
+  alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx> alpakaAlgo2() {
     const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
     const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
     const Vec size(NUM_VALUES);
@@ -342,5 +342,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                  NUM_VALUES));
 
     alpaka::wait::wait(queue);
+    return d_mc_buf;
   }
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
@@ -242,7 +242,7 @@ namespace {
 }  // namespace
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx> alpakaAlgo2() {
+  AlpakaAccBuf2<float> alpakaAlgo2() {
     const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
     const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
     const Vec size(NUM_VALUES);

--- a/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.h
+++ b/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.h
@@ -9,7 +9,7 @@
 // of build rules for files to be compiled by accelerator, and
 // different set for files to be compiled by architecture?
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  void alpakaAlgo2();
+  alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx> alpakaAlgo2();
 }
 
 #endif

--- a/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.h
+++ b/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.h
@@ -9,7 +9,7 @@
 // of build rules for files to be compiled by accelerator, and
 // different set for files to be compiled by architecture?
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  alpaka::mem::buf::Buf<Acc2, float, Dim2, Idx> alpakaAlgo2();
+  AlpakaAccBuf2<float> alpakaAlgo2();
 }
 
 #endif


### PR DESCRIPTION
Event data can now be stored, and accessed with getToken directly from Acc memory, no need to transfer data to CPU.

NB: At a later stage: There should likely be implementations in AlpakaCore of ScopedContext, similar to what is done in KokkosCore; skipped for now.