### PR TITLE
[kokkos] Remove -- numberOfInnerThreads command line argument

### DIFF
--- a/src/kokkostest/bin/main.cc
+++ b/src/kokkostest/bin/main.cc
@@ -30,9 +30,6 @@ namespace {
         << " [--hip]"
 #endif
         << " [--numberOfThreads NT] [--numberOfStreams NS]"
-#ifdef KOKKOS_ENABLE_THREADS
-        << " [--numberOfInnerThreads NIT]"
-#endif
         << "[--maxEvents ME] [--data PATH] [--transfer] [--validation]\n\n"
         << "Options\n"
         << " --serial                Use CPU Serial backend\n"
@@ -47,9 +44,6 @@ namespace {
 #endif
         << " --numberOfThreads       Number of threads to use (default 1)\n"
         << " --numberOfStreams       Number of concurrent events (default 0=numberOfThreads)\n"
-#ifdef KOKKOS_ENABLE_THREADS
-        << " --numberOfInnerThreads  Number of inner (intra-event) threads to use (for pthread backend, default 1)\n"
-#endif
         << " --maxEvents             Number of events to process (default -1 for all events in the input file)\n"
         << " --data                  Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer              Transfer results from GPU to CPU (default is to leave them on GPU)\n"
@@ -65,7 +59,6 @@ int main(int argc, char** argv) {
   std::vector<Backend> backends;
   int numberOfThreads = 1;
   int numberOfStreams = 0;
-  int numberOfInnerThreads = 1;
   int maxEvents = -1;
   std::filesystem::path datadir;
   bool transfer = false;
@@ -94,11 +87,6 @@ int main(int argc, char** argv) {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
-#ifdef KOKKOS_ENABLE_THREADS
-    } else if (*i == "--numberOfInnerThreads") {
-      ++i;
-      numberOfInnerThreads = std::stoi(*i);
-#endif
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -128,7 +116,11 @@ int main(int argc, char** argv) {
   }
 
   // Initialize Kokkos
-  kokkos_common::InitializeScopeGuard kokkosGuard(backends, numberOfInnerThreads);
+#ifdef KOKKOS_ENABLE_THREADS
+  kokkos_common::InitializeScopeGuard kokkosGuard(backends, numberOfThreads);
+#else
+  kokkos_common::InitializeScopeGuard kokkosGuard(backends, 1);
+#endif
 
   // Initialize EventProcessor
   std::vector<std::string> edmodules;


### PR DESCRIPTION
The option turned out to be rather confusing in the end (given that the pthread backend turned out to require all Kokkos calls to originate from one specific thread). This PR removes the `--numberOfInnerThreads` option and uses the `--numberOfThreads` option instead. 