### PR TITLE
[cuda] Add compile macros to disable caching allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ This program is frozen to correspond to CMSSW_11_2_0_pre8_Patatrack.
 
 The location of CUDA 11 libraries can be set with `CUDA_BASE` variable.
 
+The use of caching allocator can be disabled at compile time with
+```
+make cuda ... USER_CXXFLAGS="-DCUDA_DISABLE_CACHING_ALLOCATOR"
+```
+
 #### `cudadev`
 
 This program is currently equivalent to `cuda`.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ make cuda ... USER_CXXFLAGS="-DCUDA_DISABLE_CACHING_ALLOCATOR"
 
 This program is currently equivalent to `cuda`.
 
+The use of caching allocator can be disabled at compile time with
+```
+make cudadev ... USER_CXXFLAGS="-DCUDADEV_DISABLE_CACHING_ALLOCATOR"
+```
+
 #### `cudauvm`
 
 The purpose of this program is to test the performance of the CUDA

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ make cudauvm ... USER_CXXFLAGS="-DCUDAUVM_DISABLE_ADVISE"
 |----------------------------------------|-------------------------------------------------------|
 | `-DCUDAUVM_DISABLE_ADVISE`             | Disable `cudaMemAdvise(cudaMemAdviseSetReadMostly)`   |
 | `-DCUDAUVM_DISABLE_PREFETCH`           | Disable `cudaMemPrefetchAsync`                        |
+| `-DCUDAUVM_DISABLE_CACHING_ALLOCATOR`  | Disable caching allocator                             |
 | `-DCUDAUVM_MANAGED_TEMPORARY`          | Use managed memory also for temporary data structures |
 | `-DCUDAUVM_DISABLE_MANAGED_BEAMSPOT`   | Disable managed memory in `BeamSpotToCUDA`            |
 | `-DCUDAUVM_DISABLE_MANAGED_CLUSTERING` | Disable managed memory in `SiPixelRawToClusterCUDA`   |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   * [Additional make targets](#additional-make-targets)
   * [Test program specific notes (if any)](#test-program-specific-notes-if-any)
     * [`fwtest`](#fwtest)
+    * [`cudatest`](#cudatest)
     * [`cuda`](#cuda)
     * [`cudadev`](#cudadev)
     * [`cudauvm`](#cudauvm)
@@ -164,6 +165,13 @@ are filtered based on the availability of compilers/toolchains. Essentially
 #### `fwtest`
 
 The printouts can be disabled with `-DFWTEST_SILENT` build flag (e.g. `make ... USER_CXXFLAGS="-DFWTEST_SILENT"`).
+
+#### `cudatest`
+
+The use of caching allocator can be disabled at compile time with
+```
+make cudatest ... USER_CXXFLAGS="-DCUDATEST_DISABLE_CACHING_ALLOCATOR"
+```
 
 #### `cuda`
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,10 @@ are filtered based on the availability of compilers/toolchains. Essentially
 
 #### `fwtest`
 
-The printouts can be disabled with `-DFWTEST_SILENT` build flag (e.g. `make ... USER_CXXFLAGS="-DFWTEST_SILENT"`).
+The printouts can be disabled at compile with with
+```
+make fwtest ... USER_CXXFLAGS="-DFWTEST_SILENT"
+```
 
 #### `cudatest`
 

--- a/src/cuda/CUDACore/getCachingDeviceAllocator.h
+++ b/src/cuda/CUDACore/getCachingDeviceAllocator.h
@@ -10,7 +10,11 @@
 
 namespace cms::cuda::allocator {
   // Use caching or not
+#ifdef CUDA_DISABLE_CACHING_ALLOCATOR
+  constexpr bool useCaching = false;
+#else
   constexpr bool useCaching = true;
+#endif
   // Growth factor (bin_growth in cub::CachingDeviceAllocator
   constexpr unsigned int binGrowth = 2;
   // Smallest bin, corresponds to binGrowth^minBin bytes (min_bin in cub::CacingDeviceAllocator

--- a/src/cudadev/CUDACore/getCachingDeviceAllocator.h
+++ b/src/cudadev/CUDACore/getCachingDeviceAllocator.h
@@ -10,7 +10,11 @@
 
 namespace cms::cuda::allocator {
   // Use caching or not
+#ifdef CUDADEV_DISABLE_CACHING_ALLOCATOR
+  constexpr bool useCaching = false;
+#else
   constexpr bool useCaching = true;
+#endif
   // Growth factor (bin_growth in cub::CachingDeviceAllocator
   constexpr unsigned int binGrowth = 2;
   // Smallest bin, corresponds to binGrowth^minBin bytes (min_bin in cub::CacingDeviceAllocator

--- a/src/cudatest/CUDACore/getCachingDeviceAllocator.h
+++ b/src/cudatest/CUDACore/getCachingDeviceAllocator.h
@@ -10,7 +10,11 @@
 
 namespace cms::cuda::allocator {
   // Use caching or not
+#ifdef CUDATEST_DISABLE_CACHING_ALLOCATOR
+  constexpr bool useCaching = false;
+#else
   constexpr bool useCaching = true;
+#endif
   // Growth factor (bin_growth in cub::CachingDeviceAllocator
   constexpr unsigned int binGrowth = 2;
   // Smallest bin, corresponds to binGrowth^minBin bytes (min_bin in cub::CacingDeviceAllocator

--- a/src/cudauvm/CUDACore/getCachingDeviceAllocator.h
+++ b/src/cudauvm/CUDACore/getCachingDeviceAllocator.h
@@ -10,7 +10,11 @@
 
 namespace cms::cuda::allocator {
   // Use caching or not
+#ifdef CUDAUVM_DISABLE_CACHING_ALLOCATOR
+  constexpr bool useCaching = false;
+#else
   constexpr bool useCaching = true;
+#endif
   // Growth factor (bin_growth in cub::CachingDeviceAllocator
   constexpr unsigned int binGrowth = 2;
   // Smallest bin, corresponds to binGrowth^minBin bytes (min_bin in cub::CacingDeviceAllocator


### PR DESCRIPTION
For all four CUDA programs with separate macros. Intended only to test the impact of disabling the caching allocator (that is significant).