### PR TITLE
[kokkos] Rewrite Hist::finalize() with Teamscan

### DIFF
--- a/src/kokkos/KokkosCore/HistoContainer.h
+++ b/src/kokkos/KokkosCore/HistoContainer.h
@@ -165,14 +165,11 @@ namespace cms {
 
     // iteratate over bins containing all values in window wmin, wmax
     template <typename Histo, typename V, typename Func, typename ExecSpace>
-    KOKKOS_INLINE_FUNCTION void forEachInWindow(Kokkos::View<Histo[1], ExecSpace> hist,
-                                                V wmin,
-                                                V wmax,
-                                                Func const& func) {
+    KOKKOS_INLINE_FUNCTION void forEachInWindow(Kokkos::View<Histo*, ExecSpace> hist, V wmin, V wmax, Func const& func) {
       auto bs = Histo::bin(wmin);
       auto be = Histo::bin(wmax);
       assert(be >= bs);
-      for (auto pj = hist().begin(bs); pj < hist().end(be); ++pj) {
+      for (auto pj = hist(0).begin(bs); pj < hist(0).end(be); ++pj) {
         func(*pj);
       }
     }

--- a/src/kokkos/plugin-PixelVertexFinding/kokkos/gpuClusterFillHist.h
+++ b/src/kokkos/plugin-PixelVertexFinding/kokkos/gpuClusterFillHist.h
@@ -64,7 +64,9 @@ namespace KOKKOS_NAMESPACE {
         iv[i] = i;
         nn[i] = 0;
       });
+
       team_member.team_barrier();
+      Histo::finalize(vhist, Histo::totbins(), team_member);
     }
   }  // namespace gpuVertexFinder
 }  // namespace KOKKOS_NAMESPACE

--- a/src/kokkos/plugin-PixelVertexFinding/kokkos/gpuClusterTracksByDensity.h
+++ b/src/kokkos/plugin-PixelVertexFinding/kokkos/gpuClusterTracksByDensity.h
@@ -224,8 +224,6 @@ namespace KOKKOS_NAMESPACE {
             clusterFillHist(vdata, vws, vhist, minT, eps, errmax, chi2max, team_member);
           });
 
-      Hist::finalize(vhist, leagueSize, execSpace);
-
       Kokkos::parallel_for(
           "clusterTracksByDensity", hintLightWeight(policy), KOKKOS_LAMBDA(const member_type& team_member) {
             clusterTracksByDensity(vdata, vws, vhist, minT, eps, errmax, chi2max, team_member);

--- a/src/kokkos/plugin-PixelVertexFinding/kokkos/gpuClusterTracksDBSCAN.h
+++ b/src/kokkos/plugin-PixelVertexFinding/kokkos/gpuClusterTracksDBSCAN.h
@@ -231,8 +231,6 @@ namespace KOKKOS_NAMESPACE {
             clusterFillHist(vdata, vws, vhist, minT, eps, errmax, chi2max, team_member);
           });
 
-      Hist::finalize(vhist, leagueSize, execSpace);
-
       Kokkos::parallel_for(
           "clusterTracksDBSCAN", hintLightWeight(policy), KOKKOS_LAMBDA(const member_type& team_member) {
             clusterTracksDBSCAN(vdata, vws, vhist, minT, eps, errmax, chi2max, team_member);

--- a/src/kokkos/plugin-PixelVertexFinding/kokkos/gpuClusterTracksIterative.h
+++ b/src/kokkos/plugin-PixelVertexFinding/kokkos/gpuClusterTracksIterative.h
@@ -205,8 +205,6 @@ namespace KOKKOS_NAMESPACE {
             clusterFillHist(vdata, vws, vhist, minT, eps, errmax, chi2max, team_member);
           });
 
-      Hist::finalize(vhist, leagueSize, execSpace);
-
       Kokkos::parallel_for(
           "clusterTracksIterative", hintLightWeight(policy), KOKKOS_LAMBDA(const member_type& team_member) {
             clusterTracksIterative(vdata, vws, vhist, minT, eps, errmax, chi2max, team_member);

--- a/src/kokkos/plugin-PixelVertexFinding/kokkos/gpuVertexFinder.cc
+++ b/src/kokkos/plugin-PixelVertexFinding/kokkos/gpuVertexFinder.cc
@@ -132,11 +132,7 @@ namespace KOKKOS_NAMESPACE {
           hintLightWeight(Kokkos::RangePolicy<KokkosExecSpace>(execSpace, 0, TkSoA::stride())),
           KOKKOS_LAMBDA(const size_t i) { loadTracks(tksoa, vertices_d, workspace_d, ptMin, i); });
 
-#if defined KOKKOS_BACKEND_SERIAL || defined KOKKOS_BACKEND_PTHREAD
       auto policy = TeamPolicy(execSpace, 1, Kokkos::AUTO()).set_scratch_size(0, Kokkos::PerTeam(8192 * 4));
-#else
-      auto policy = TeamPolicy(execSpace, 1, 1024 - 256).set_scratch_size(0, Kokkos::PerTeam(8192 * 4));
-#endif
 
       if (oneKernel_) {
         // implemented only for density clustesrs

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClustering.h
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClustering.h
@@ -117,9 +117,11 @@ namespace gpuClustering {
               continue;
             d_hist(teamMember.league_rank()).count(y(i));
           }
+
+          teamMember.team_barrier();
+          Hist::finalize(d_hist, loop_count, teamMember);
         });
 
-    Hist::finalize(d_hist, teamPolicy.league_size(), execSpace);
     int shared_view_level = 0;
     Kokkos::parallel_for(
         "findClus_msize",

--- a/src/kokkos/test/kokkos/OneHistoContainer_t.cc
+++ b/src/kokkos/test/kokkos/OneHistoContainer_t.cc
@@ -61,7 +61,6 @@ void go() {
 
     Kokkos::parallel_for(
         "count",
-
 // XXX Team prefix scan used in Hist::finalize() requires power-of-two blockDim
 // Kokkos::AUTO() in CUDA backend will somehow use blockDim = 96 thus fail the execution
 #ifdef KOKKOS_BACKEND_CUDA

--- a/src/kokkos/test/kokkos/OneHistoContainer_t.cc
+++ b/src/kokkos/test/kokkos/OneHistoContainer_t.cc
@@ -46,60 +46,60 @@ void go() {
 
     using TeamHist = cms::kokkos::HistoContainer<T, NBINS, N, S, uint16_t>;
 
-    Kokkos::View<TeamHist[1], KokkosExecSpace> histo_d("histo_d");
+    Kokkos::View<TeamHist*, KokkosExecSpace> histo_d("histo_d", 1);
     auto histo_h = Kokkos::create_mirror_view(histo_d);
 
     Kokkos::parallel_for(
         "set_zero",
         Kokkos::RangePolicy<KokkosExecSpace>(KokkosExecSpace(), 0, TeamHist::totbins()),
-        KOKKOS_LAMBDA(const int& i) { histo_d().off[i] = 0; });
+        KOKKOS_LAMBDA(const int& i) { histo_d(0).off[i] = 0; });
 
     Kokkos::parallel_for(
         "set_zero_bin",
         Kokkos::RangePolicy<KokkosExecSpace>(KokkosExecSpace(), 0, TeamHist::capacity()),
-        KOKKOS_LAMBDA(const int& i) { histo_d().bins[i] = 0; });
+        KOKKOS_LAMBDA(const int& i) { histo_d(0).bins[i] = 0; });
 
     Kokkos::parallel_for(
         "count",
 // XXX Team prefix scan used in Hist::finalize() requires power-of-two blockDim
 // Kokkos::AUTO() in CUDA backend will somehow use blockDim = 96 thus fail the execution
-#ifdef KOKKOS_BACKEND_CUDA
+#if defined KOKKOS_BACKEND_CUDA || defined KOKKOS_BACKEND_HIP
         team_policy(KokkosExecSpace(), 1, 64),
 #else
         team_policy(KokkosExecSpace(), 1, Kokkos::AUTO()),
 #endif
         KOKKOS_LAMBDA(const member_type& teamMember) {
           for (uint32_t i = teamMember.team_rank(); i < N; i += teamMember.team_size())
-            histo_d().count(v_d(i));
+            histo_d(0).count(v_d(i));
           teamMember.team_barrier();
 
-          assert(0 == histo_d().size());
+          assert(0 == histo_d(0).size());
           teamMember.team_barrier();
 
           TeamHist::finalize(histo_d, TeamHist::totbins(), teamMember);
           teamMember.team_barrier();
 
-          assert(N == histo_d().size());
+          assert(N == histo_d(0).size());
         });
 
     Kokkos::parallel_for(
         "assert_check",
         Kokkos::RangePolicy<KokkosExecSpace>(KokkosExecSpace(), 0, TeamHist::totbins() - 1),
-        KOKKOS_LAMBDA(const int& i) { assert(histo_d().off[i] <= histo_d().off[i + 1]); });
+        KOKKOS_LAMBDA(const int& i) { assert(histo_d(0).off[i] <= histo_d(0).off[i + 1]); });
 
     Kokkos::parallel_for(
         "fill", Kokkos::RangePolicy<KokkosExecSpace>(KokkosExecSpace(), 0, N), KOKKOS_LAMBDA(const int& i) {
-          histo_d().fill(v_d(i), i);
+          histo_d(0).fill(v_d(i), i);
         });
 
     Kokkos::deep_copy(KokkosExecSpace(), histo_h, histo_d);
 
-    assert(0 == histo_h().off[0]);
-    assert(N == histo_h().size());
+    assert(0 == histo_h(0).off[0]);
+    assert(N == histo_h(0).size());
 
     Kokkos::parallel_for(
         "bin", Kokkos::RangePolicy<KokkosExecSpace>(KokkosExecSpace(), 0, N - 1), KOKKOS_LAMBDA(const int& i) {
-          auto p = histo_d().begin() + i;
+          auto p = histo_d(0).begin() + i;
           assert((*p) < N);
           auto k1 = TeamHist::bin(v_d(*p));
           auto k2 = TeamHist::bin(v_d(*(p + 1)));
@@ -108,7 +108,7 @@ void go() {
 
     Kokkos::parallel_for(
         "forEachInWindow", Kokkos::RangePolicy<KokkosExecSpace>(KokkosExecSpace(), 0, N), KOKKOS_LAMBDA(const int& i) {
-          auto p = histo_d().begin() + i;
+          auto p = histo_d(0).begin() + i;
           auto j = *p;
           auto b0 = TeamHist::bin(v_d(j));
           int tot = 0;
@@ -117,7 +117,7 @@ void go() {
             ++tot;
           };
           forEachInWindow(histo_d, v_d(j), v_d(j), ftest);
-          int rtot = histo_d().size(b0);
+          int rtot = histo_d(0).size(b0);
 
           assert(tot == rtot);
           tot = 0;
@@ -132,7 +132,7 @@ void go() {
           forEachInWindow(histo_d, vm, vp, ftest);
           int bp = TeamHist::bin(vp);
           int bm = TeamHist::bin(vm);
-          rtot = histo_d().end(bp) - histo_d().begin(bm);
+          rtot = histo_d(0).end(bp) - histo_d(0).begin(bm);
           assert(tot == rtot);
         });
   }


### PR DESCRIPTION
I tried to fuse multiple kernels into one since `finalize()` is now a device function but got a sequence of different errors. Will do it next week.