### PR TITLE
Adjustments in AlpakaCore/prefixScan and its test + Add helper functions to handle workdiv

### DIFF
--- a/src/alpaka/AlpakaCore/HistoContainer.h
+++ b/src/alpaka/AlpakaCore/HistoContainer.h
@@ -17,49 +17,48 @@ namespace cms {
 
     struct countFromVector {
       template <typename T_Acc, typename Histo, typename T>
-	ALPAKA_FN_ACC void operator()(const T_Acc &acc,
-				      Histo *__restrict__ h,
-				      uint32_t nh,
-				      T const *__restrict__ v,
-				      uint32_t const *__restrict__ offsets) const {
+      ALPAKA_FN_ACC void operator()(const T_Acc &acc,
+                                    Histo *__restrict__ h,
+                                    uint32_t nh,
+                                    T const *__restrict__ v,
+                                    uint32_t const *__restrict__ offsets) const {
         const uint32_t nt = offsets[nh];
-	cms::alpakatools::for_each_element_1D_grid_stride(acc, nt, [&](uint32_t i) {
-            auto off = alpaka_std::upper_bound(offsets, offsets + nh + 1, i);
-            assert((*off) > 0);
-            int32_t ih = off - offsets - 1;
-            assert(ih >= 0);
-            assert(ih < int(nh));
-            h->count(acc, v[i], ih);
-          });
+        cms::alpakatools::for_each_element_1D_grid_stride(acc, nt, [&](uint32_t i) {
+          auto off = alpaka_std::upper_bound(offsets, offsets + nh + 1, i);
+          assert((*off) > 0);
+          int32_t ih = off - offsets - 1;
+          assert(ih >= 0);
+          assert(ih < int(nh));
+          h->count(acc, v[i], ih);
+        });
       }
     };
 
     struct fillFromVector {
       template <typename T_Acc, typename Histo, typename T>
-	ALPAKA_FN_ACC void operator()(const T_Acc &acc,
-				      Histo *__restrict__ h,
-				      uint32_t nh,
-				      T const *__restrict__ v,
-				      uint32_t const *__restrict__ offsets) const {
+      ALPAKA_FN_ACC void operator()(const T_Acc &acc,
+                                    Histo *__restrict__ h,
+                                    uint32_t nh,
+                                    T const *__restrict__ v,
+                                    uint32_t const *__restrict__ offsets) const {
         const uint32_t nt = offsets[nh];
-	cms::alpakatools::for_each_element_1D_grid_stride(acc, nt, [&](uint32_t i) {
-	    auto off = alpaka_std::upper_bound(offsets, offsets + nh + 1, i);
-	    assert((*off) > 0);
-	    int32_t ih = off - offsets - 1;
-	    assert(ih >= 0);
-	    assert(ih < int(nh));
-	    h->fill(acc, v[i], i, ih);
-	  });
+        cms::alpakatools::for_each_element_1D_grid_stride(acc, nt, [&](uint32_t i) {
+          auto off = alpaka_std::upper_bound(offsets, offsets + nh + 1, i);
+          assert((*off) > 0);
+          int32_t ih = off - offsets - 1;
+          assert(ih >= 0);
+          assert(ih < int(nh));
+          h->fill(acc, v[i], i, ih);
+        });
       }
     };
 
     struct launchZero {
       template <typename T_Acc, typename Histo>
-	ALPAKA_FN_ACC ALPAKA_FN_INLINE __attribute__((always_inline)) void operator()(const T_Acc &acc,
-										      Histo *__restrict__ h) const {
-	cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, Histo::totbins(), [&](uint32_t i) {
-	    h->off[i] = 0;
-	  });
+      ALPAKA_FN_ACC ALPAKA_FN_INLINE __attribute__((always_inline)) void operator()(const T_Acc &acc,
+                                                                                    Histo *__restrict__ h) const {
+        cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(
+            acc, Histo::totbins(), [&](uint32_t i) { h->off[i] = 0; });
       }
     };
 
@@ -255,9 +254,7 @@ namespace cms {
           return;
         }
 
-	cms::alpakatools::for_each_element_1D_grid_stride(acc, totbins(), m, [&](uint32_t i) {
-            off[i] = n;
-	  });
+        cms::alpakatools::for_each_element_1D_grid_stride(acc, totbins(), m, [&](uint32_t i) { off[i] = n; });
       }
 
       template <typename T_Acc>

--- a/src/alpaka/AlpakaCore/HistoContainer.h
+++ b/src/alpaka/AlpakaCore/HistoContainer.h
@@ -57,7 +57,7 @@ namespace cms {
       template <typename T_Acc, typename Histo>
 	ALPAKA_FN_ACC ALPAKA_FN_INLINE __attribute__((always_inline)) void operator()(const T_Acc &acc,
 										      Histo *__restrict__ h) const {
-	cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, Histo::totbins(), [&](uint32_t i) {
+	cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, Histo::totbins(), [&](uint32_t i) {
 	    h->off[i] = 0;
 	  });
       }

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -156,12 +156,12 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
                                                                     const uint32_t maxNumberOfElements,
                                                                     const uint32_t elementIdxShift,
-                                                                    Func&& func) {
+                                                                    const Func func) {
       const auto& [firstElementIdx, endElementIdx] = cms::alpakatools::element_index_range_in_block_truncated(
           acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIdxShift));
 
       for (uint32_t elementIdx = firstElementIdx[0u]; elementIdx < endElementIdx[0u]; ++elementIdx) {
-        std::forward<Func>(func)(elementIdx);
+        func(elementIdx);
       }
     }
 
@@ -171,10 +171,9 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
                                                                     const uint32_t maxNumberOfElements,
-                                                                    Func&& func) {
+                                                                    const Func func) {
       const uint32_t elementIdxShift = 0;
-      cms::alpakatools::for_each_element_in_thread_1D_index_in_block(
-          acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
     /*
@@ -186,13 +185,13 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
                                                                    const uint32_t maxNumberOfElements,
                                                                    uint32_t elementIdxShift,
-                                                                   Func&& func) {
+                                                                   const Func func) {
       // Take into account the block index in grid to compute the element indices.
       const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
       elementIdxShift += blockIdxInGrid * blockDimension;
 
-      for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
+      for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
     /*
@@ -201,10 +200,9 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
                                                                    const uint32_t maxNumberOfElements,
-                                                                   Func&& func) {
+                                                                   const Func func) {
       const uint32_t elementIdxShift = 0;
-      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(
-          acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
     /******************************************************************************
@@ -221,7 +219,7 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
                                                         const uint32_t maxNumberOfElements,
                                                         const uint32_t elementIdxShift,
-                                                        Func&& func) {
+                                                        const Func func) {
       // Get thread / element indices in block.
       const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
           cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
@@ -235,7 +233,7 @@ namespace cms {
            threadIdx += blockDimension, endElementIdx += blockDimension) {
         // (CPU) Loop on all elements.
         for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
-          std::forward<Func>(func)(i);
+          func(i);
         }
       }
     }
@@ -246,10 +244,9 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
                                                         const uint32_t maxNumberOfElements,
-                                                        Func&& func) {
+                                                        const Func func) {
       const uint32_t elementIdxShift = 0;
-      cms::alpakatools::for_each_element_1D_block_stride(
-          acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
+      cms::alpakatools::for_each_element_1D_block_stride(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
     /*
@@ -262,7 +259,7 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
                                                        const uint32_t maxNumberOfElements,
                                                        const uint32_t elementIdxShift,
-                                                       Func&& func) {
+                                                       const Func func) {
       Vec1 elementIdxShiftVec = Vec1::all(elementIdxShift);
 
       // Get thread / element indices in block.
@@ -278,7 +275,7 @@ namespace cms {
            threadIdx += gridDimension, endElementIdx += gridDimension) {
         // (CPU) Loop on all elements.
         for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
-          std::forward<Func>(func)(i);
+          func(i);
         }
       }
     }
@@ -289,10 +286,9 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
                                                        const uint32_t maxNumberOfElements,
-                                                       Func&& func) {
+                                                       const Func func) {
       const uint32_t elementIdxShift = 0;
-      cms::alpakatools::for_each_element_1D_grid_stride(
-          acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
+      cms::alpakatools::for_each_element_1D_grid_stride(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
   }  // namespace alpakatools

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -153,10 +153,10 @@ namespace cms {
      * Indexes are local to the BLOCK.
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
-                                                                                     const uint32_t maxNumberOfElements,
-                                                                                     const uint32_t elementIdxShift,
-                                                                                     Func&& func) {
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
+                                                                    const uint32_t maxNumberOfElements,
+                                                                    const uint32_t elementIdxShift,
+                                                                    Func&& func) {
       const auto& [firstElementIdx, endElementIdx] = cms::alpakatools::element_index_range_in_block_truncated(
           acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIdxShift));
 
@@ -169,9 +169,9 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
-                                                                                     const uint32_t maxNumberOfElements,
-                                                                                     Func&& func) {
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
+                                                                    const uint32_t maxNumberOfElements,
+                                                                    Func&& func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_in_thread_1D_index_in_block(
           acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
@@ -183,10 +183,10 @@ namespace cms {
      * Indexes are expressed in GRID 'frame-of-reference'.
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
-                                                                                    const uint32_t maxNumberOfElements,
-                                                                                    uint32_t elementIdxShift,
-                                                                                    Func&& func) {
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
+                                                                   const uint32_t maxNumberOfElements,
+                                                                   uint32_t elementIdxShift,
+                                                                   Func&& func) {
       // Take into account the block index in grid to compute the element indices.
       const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
@@ -199,9 +199,9 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
-                                                                                    const uint32_t maxNumberOfElements,
-                                                                                    Func&& func) {
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
+                                                                   const uint32_t maxNumberOfElements,
+                                                                   Func&& func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(
           acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
@@ -218,10 +218,10 @@ namespace cms {
      * Indexes are local to the BLOCK.
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_1D_block_stride(const T_Acc& acc,
-                                                                         const uint32_t maxNumberOfElements,
-                                                                         const uint32_t elementIdxShift,
-                                                                         Func&& func) {
+    ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
+                                                        const uint32_t maxNumberOfElements,
+                                                        const uint32_t elementIdxShift,
+                                                        Func&& func) {
       // Get thread / element indices in block.
       const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
           cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
@@ -244,9 +244,9 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_1D_block_stride(const T_Acc& acc,
-                                                                         const uint32_t maxNumberOfElements,
-                                                                         Func&& func) {
+    ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
+                                                        const uint32_t maxNumberOfElements,
+                                                        Func&& func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_1D_block_stride(
           acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
@@ -259,10 +259,10 @@ namespace cms {
      * Indexes are local to the GRID.
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_1D_grid_stride(const T_Acc& acc,
-                                                                        const uint32_t maxNumberOfElements,
-                                                                        const uint32_t elementIdxShift,
-                                                                        Func&& func) {
+    ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
+                                                       const uint32_t maxNumberOfElements,
+                                                       const uint32_t elementIdxShift,
+                                                       Func&& func) {
       Vec1 elementIdxShiftVec = Vec1::all(elementIdxShift);
 
       // Get thread / element indices in block.
@@ -287,9 +287,9 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_1D_grid_stride(const T_Acc& acc,
-                                                                        const uint32_t maxNumberOfElements,
-                                                                        Func&& func) {
+    ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
+                                                       const uint32_t maxNumberOfElements,
+                                                       Func&& func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_1D_grid_stride(
           acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -33,7 +33,7 @@ namespace cms {
      * (should obviously only be needed for debug / printout).
      */
     template <typename T_Acc>
-      ALPAKA_FN_ACC bool once_per_block_1D(const T_Acc& acc, uint32_t i) {
+    ALPAKA_FN_ACC bool once_per_block_1D(const T_Acc& acc, uint32_t i) {
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
       return (i % blockDimension == 0);
     }
@@ -43,14 +43,14 @@ namespace cms {
      * Warning: the max index is not truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block(const T_Acc& acc, const Vec<T_Dim>& elementIdxShift) {
+    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block(const T_Acc& acc,
+                                                                                 const Vec<T_Dim>& elementIdxShift) {
       Vec<T_Dim> firstElementIdxVec = Vec<T_Dim>::zeros();
       Vec<T_Dim> endElementIdxUncutVec = Vec<T_Dim>::zeros();
 
       // Loop on all grid dimensions.
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-
-	// Take into account the thread index in block.
+        // Take into account the thread index in block.
         const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[dimIndex]);
         const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[dimIndex]);
 
@@ -58,7 +58,7 @@ namespace cms {
         // Obviously relevant for CPU only.
         // For GPU, threadDimension = 1, and elementIdx = firstElementIdx = threadIdx + elementIdxShift.
         const uint32_t firstElementIdxLocal = threadIdxLocal * threadDimension;
-	const uint32_t firstElementIdx = firstElementIdxLocal + elementIdxShift[dimIndex]; // Add the shift!
+        const uint32_t firstElementIdx = firstElementIdxLocal + elementIdxShift[dimIndex];  // Add the shift!
         const uint32_t endElementIdxUncut = firstElementIdx + threadDimension;
 
         firstElementIdxVec[dimIndex] = firstElementIdx;
@@ -69,14 +69,13 @@ namespace cms {
       return {firstElementIdxVec, endElementIdxUncutVec};
     }
 
-
     /*
      * Computes the range of the elements indexes, local to the block.
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, const Vec<T_Dim>& elementIdxShift) {
-
+    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block_truncated(
+        const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, const Vec<T_Dim>& elementIdxShift) {
       // Check dimension
       static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
                     "Accelerator and maxNumberOfElements need to have same dimension.");
@@ -91,23 +90,21 @@ namespace cms {
       return {firstElementIdxLocalVec, endElementIdxLocalVec};
     }
 
-
     /*
      * Computes the range of the elements indexes in grid.
      * Warning: the max index is not truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid(const T_Acc& acc, Vec<T_Dim>& elementIdxShift) {
-
+    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid(const T_Acc& acc,
+                                                                                Vec<T_Dim>& elementIdxShift) {
       // Loop on all grid dimensions.
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-
         // Take into account the block index in grid.
         const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[dimIndex]);
         const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[dimIndex]);
 
-	// Shift to get global indices in grid (instead of local to the block)
-	elementIdxShift[dimIndex] += blockIdxInGrid * blockDimension;
+        // Shift to get global indices in grid (instead of local to the block)
+        elementIdxShift[dimIndex] += blockIdxInGrid * blockDimension;
       }
 
       // Return element indexes, shifted by elementIdxShift.
@@ -119,8 +116,8 @@ namespace cms {
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, Vec<T_Dim>& elementIdxShift) {
-
+    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(
+        const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, Vec<T_Dim>& elementIdxShift) {
       // Check dimension
       static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
                     "Accelerator and maxNumberOfElements need to have same dimension.");
@@ -135,18 +132,16 @@ namespace cms {
       return {firstElementIdxGlobalVec, endElementIdxGlobalVec};
     }
 
-
     /*
      * Computes the range of the element(s) index(es) in grid.
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
-      
+    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(
+        const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
       Vec<T_Dim> elementIdxShift = Vec<T_Dim>::zeros();
       return element_index_range_in_grid_truncated(acc, maxNumberOfElements, elementIdxShift);
     }
-
 
     /*********************************************
      *     1D HELPERS, LOOP ON ALL CPU ELEMENTS
@@ -158,13 +153,15 @@ namespace cms {
      * Indexes are local to the BLOCK.
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
-
-      const auto& [firstElementIdx, endElementIdx] =
-	cms::alpakatools::element_index_range_in_block_truncated(acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIdxShift));
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
+                                                                    const uint32_t maxNumberOfElements,
+                                                                    const uint32_t elementIdxShift,
+                                                                    const Func& func) {
+      const auto& [firstElementIdx, endElementIdx] = cms::alpakatools::element_index_range_in_block_truncated(
+          acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIdxShift));
 
       for (uint32_t elementIdx = firstElementIdx[0u]; elementIdx < endElementIdx[0u]; ++elementIdx) {
-	func(elementIdx);
+        func(elementIdx);
       }
     }
 
@@ -172,8 +169,10 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
-      const uint32_t elementIdxShift = 0; 
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
+                                                                    const uint32_t maxNumberOfElements,
+                                                                    const Func& func) {
+      const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
@@ -183,8 +182,10 @@ namespace cms {
      * Indexes are expressed in GRID 'frame-of-reference'.
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const uint32_t maxNumberOfElements, uint32_t elementIdxShift, const Func& func) {
-
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
+                                                                   const uint32_t maxNumberOfElements,
+                                                                   uint32_t elementIdxShift,
+                                                                   const Func& func) {
       // Take into account the block index in grid to compute the element indices.
       const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
@@ -197,11 +198,12 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
-      const uint32_t elementIdxShift = 0; 
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
+                                                                   const uint32_t maxNumberOfElements,
+                                                                   const Func& func) {
+      const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, maxNumberOfElements, elementIdxShift, func);
     }
-
 
     /******************************************************************************
      *     1D HELPERS, LOOP ON ALL CPU ELEMENTS, AND ELEMENT/THREAD STRIDED ACCESS
@@ -214,37 +216,38 @@ namespace cms {
      * Indexes are local to the BLOCK.
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
-
+    ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
+                                                        const uint32_t maxNumberOfElements,
+                                                        const uint32_t elementIdxShift,
+                                                        const Func& func) {
       // Get thread / element indices in block.
-      const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
-	cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
-      
+      const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
+          cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
+
       // Stride = block size.
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
 
       // Strided access.
       for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-	   threadIdx < maxNumberOfElements;
-	   threadIdx += blockDimension, endElementIdx += blockDimension) {
-	  
-	// (CPU) Loop on all elements.
-	for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
-	  func(i);
-	}
+           threadIdx < maxNumberOfElements;
+           threadIdx += blockDimension, endElementIdx += blockDimension) {
+        // (CPU) Loop on all elements.
+        for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
+          func(i);
+        }
       }
-      
     }
 
     /*
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
-      const uint32_t elementIdxShift = 0;      
+    ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
+                                                        const uint32_t maxNumberOfElements,
+                                                        const Func& func) {
+      const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_1D_block_stride(acc, maxNumberOfElements, elementIdxShift, func);
     }
-    
 
     /*
      * (CPU) Loop on all elements + (CPU/GPU) Strided access.
@@ -253,42 +256,41 @@ namespace cms {
      * Indexes are local to the GRID.
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
-
+    ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
+                                                       const uint32_t maxNumberOfElements,
+                                                       const uint32_t elementIdxShift,
+                                                       const Func& func) {
       Vec1 elementIdxShiftVec = Vec1::all(elementIdxShift);
-      
+
       // Get thread / element indices in block.
-      const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
-	cms::alpakatools::element_index_range_in_grid(acc, elementIdxShiftVec);
-      
+      const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
+          cms::alpakatools::element_index_range_in_grid(acc, elementIdxShiftVec);
+
       // Stride = grid size.
       const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
 
       // Strided access.
       for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-	   threadIdx < maxNumberOfElements;
-	   threadIdx += gridDimension, endElementIdx += gridDimension) {
-	  
-	// (CPU) Loop on all elements.
-	for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
-	  func(i);
-	}
+           threadIdx < maxNumberOfElements;
+           threadIdx += gridDimension, endElementIdx += gridDimension) {
+        // (CPU) Loop on all elements.
+        for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
+          func(i);
+        }
       }
-      
-    }    
-    
+    }
+
     /*
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) { 
-      const uint32_t elementIdxShift = 0; 
+    ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
+                                                       const uint32_t maxNumberOfElements,
+                                                       const Func& func) {
+      const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_1D_grid_stride(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
-    
-
-    
   }  // namespace alpakatools
 }  // namespace cms
 

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -156,7 +156,7 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
                                                                     const uint32_t maxNumberOfElements,
                                                                     const uint32_t elementIdxShift,
-                                                                    const Func& func) {
+                                                                    const Func func) {
       const auto& [firstElementIdx, endElementIdx] = cms::alpakatools::element_index_range_in_block_truncated(
           acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIdxShift));
 
@@ -171,7 +171,7 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
                                                                     const uint32_t maxNumberOfElements,
-                                                                    const Func& func) {
+                                                                    const Func func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
     }
@@ -185,7 +185,7 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
                                                                    const uint32_t maxNumberOfElements,
                                                                    uint32_t elementIdxShift,
-                                                                   const Func& func) {
+                                                                   const Func func) {
       // Take into account the block index in grid to compute the element indices.
       const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
@@ -200,7 +200,7 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
                                                                    const uint32_t maxNumberOfElements,
-                                                                   const Func& func) {
+                                                                   const Func func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, maxNumberOfElements, elementIdxShift, func);
     }
@@ -219,7 +219,7 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
                                                         const uint32_t maxNumberOfElements,
                                                         const uint32_t elementIdxShift,
-                                                        const Func& func) {
+                                                        const Func func) {
       // Get thread / element indices in block.
       const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
           cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
@@ -244,7 +244,7 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
                                                         const uint32_t maxNumberOfElements,
-                                                        const Func& func) {
+                                                        const Func func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_1D_block_stride(acc, maxNumberOfElements, elementIdxShift, func);
     }
@@ -259,7 +259,7 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
                                                        const uint32_t maxNumberOfElements,
                                                        const uint32_t elementIdxShift,
-                                                       const Func& func) {
+                                                       const Func func) {
       Vec1 elementIdxShiftVec = Vec1::all(elementIdxShift);
 
       // Get thread / element indices in block.
@@ -286,7 +286,7 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
                                                        const uint32_t maxNumberOfElements,
-                                                       const Func& func) {
+                                                       const Func func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_1D_grid_stride(acc, maxNumberOfElements, elementIdxShift, func);
     }

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -28,6 +28,7 @@ namespace cms {
 #endif
     }
 
+
     /*
      * Computes the range of the element(s) global index(es) in grid.
      * Warning: the max index is not truncated by the max number of elements of interest.
@@ -44,7 +45,7 @@ namespace cms {
 
         // Global element index in grid (along dimension dimIndex).
         // Obviously relevant for CPU only.
-        // For GPU, threadDimension = 1, and firstElementIdxGlobal = endElementIdxGlobal = threadIndexGlobal.
+        // For GPU, threadDimension = 1, and endElementIdxGlobal = firstElementIdxLocal + 1.
         const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
         const uint32_t endElementIdxUncutGlobal = firstElementIdxGlobal + threadDimension;
 
@@ -60,8 +61,7 @@ namespace cms {
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_global_index_range_truncated(
-        const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_global_index_range_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
       static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
                     "Accelerator and maxNumberOfElements need to have same dimension.");
       auto&& [firstElementIdxGlobalVec, endElementIdxGlobalVec] = element_global_index_range(acc);
@@ -72,6 +72,149 @@ namespace cms {
 
       return {firstElementIdxGlobalVec, endElementIdxGlobalVec};
     }
+
+
+    /*
+     * Computes the range of the element(s) index(es) local to the block.
+     * Warning: the max index is not truncated by the max number of elements of interest.
+     */
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_local_index_range(const T_Acc& acc) {
+      Vec<T_Dim> firstElementIdxLocalVec = Vec<T_Dim>::zeros();
+      Vec<T_Dim> endElementIdxUncutLocalVec = Vec<T_Dim>::zeros();
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+        // Local thread index in block (along dimension dimIndex).
+        const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[dimIndex]);
+        const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[dimIndex]);
+
+        // Local element index in block (along dimension dimIndex).
+        // Obviously relevant for CPU only.
+        // For GPU, threadDimension = 1, and endElementIdxGlobal = firstElementIdxLocal + 1.
+        const uint32_t firstElementIdxLocal = threadIdxLocal * threadDimension;
+        const uint32_t endElementIdxUncutLocal = firstElementIdxLocal + threadDimension;
+
+        firstElementIdxLocalVec[dimIndex] = firstElementIdxLocal;
+        endElementIdxUncutLocalVec[dimIndex] = endElementIdxUncutLocal;
+      }
+
+      return {firstElementIdxLocalVec, endElementIdxUncutLocalVec};
+    }
+
+    /*
+     * Computes the range of the element(s) global index(es) in grid.
+     * Truncated by the max number of elements of interest.
+     */
+    template <typename T_Acc, typename T_Dim>
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_local_index_range_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
+      static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
+                    "Accelerator and maxNumberOfElements need to have same dimension.");
+      auto&& [firstElementIdxLocalVec, endElementIdxLocalVec] = element_local_index_range(acc);
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+        endElementIdxLocalVec[dimIndex] = std::min(endElementIdxLocalVec[dimIndex], maxNumberOfElements[dimIndex]);
+      }
+
+      return {firstElementIdxLocalVec, endElementIdxLocalVec};
+    }
+
+
+    template <typename T_Acc, typename Func, typename T_Dim = alpaka::dim::Dim<T_Acc>>
+      void for_each_element_in_thread_global_index(const T_Acc& acc, Func func, const Vec<T_Dim>& problemSize) {
+
+      const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
+      cms::alpakatools::element_global_index_range_truncated(acc, problemSize);
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+
+	for (uint32_t elementIdx = firstElementIdxGlobal[dimIndex]; elementIdx < endElementIdxGlobal[dimIndex]; ++elementIdx) {
+	  func(elementIdx);
+	}
+      }
+
+    }
+
+    template <typename T_Acc, typename Func, typename T, typename T_Dim = alpaka::dim::Dim<T_Acc>>
+      void for_each_element_in_thread_local_index(const T_Acc& acc, Func func, const Vec<T_Dim>& problemSize) {
+
+      const auto& [firstElementIdxLocal, endElementIdxLocal] =
+      cms::alpakatools::element_local_index_range_truncated(acc, problemSize);
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+
+	for (uint32_t elementIdx = firstElementIdxLocal[dimIndex]; elementIdx < endElementIdxLocal[dimIndex]; ++elementIdx) {
+	  func(elementIdx);
+	}
+      }
+
+    }
+
+
+    template <typename T_Acc, typename Func, typename T_Dim = alpaka::dim::Dim<T_Acc>>
+      void for_each_element_grid_stride(const T_Acc& acc, Func func, const Vec<T_Dim>& problemSize) {
+
+      
+      const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
+      cms::alpakatools::element_global_index_range(acc);
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+	const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[dimIndex]);
+
+	for (uint32_t threadIdx = firstElementIdxNoStride[dimIndex], endElementIdx = endElementIdxNoStride[dimIndex];
+	     threadIdx < problemSize[dimIndex];
+	     threadIdx += gridDimension, endElementIdx += gridDimension) {
+	  
+	  for (uint32_t i = threadIdx; i < std::min(endElementIdx, problemSize[dimIndex]); ++i) {
+	    func(i);
+	  }
+	}
+      }
+      
+    }
+
+    template <typename T_Acc, typename Func, typename T_Dim = alpaka::dim::Dim<T_Acc>>
+      void for_each_element_block_stride(const T_Acc& acc, Func func, const Vec<T_Dim>& problemSize) {
+
+      
+      const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
+      cms::alpakatools::element_local_index_range(acc);
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+	const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[dimIndex]);
+
+	for (uint32_t threadIdx = firstElementIdxNoStride[dimIndex], endElementIdx = endElementIdxNoStride[dimIndex];
+	     threadIdx < problemSize[dimIndex];
+	     threadIdx += blockDimension, endElementIdx += blockDimension) {
+	  
+	  for (uint32_t i = threadIdx; i < std::min(endElementIdx, problemSize[dimIndex]); ++i) {
+	    func(i);
+	  }
+	}
+      }
+      
+    }
+
+
+    template <typename T_Acc, typename Func, typename T>
+      void for_each_element_in_thread_1D_global_index(const T_Acc& acc, Func func, const T problemSize) {     
+      cms::alpakatools::for_each_element_in_thread_global_index(acc, func, Vec1::all(problemSize));
+    }
+
+    template <typename T_Acc, typename Func, typename T>
+      void for_each_element_in_thread_1D_local_index(const T_Acc& acc, Func func, const T problemSize) {     
+      cms::alpakatools::for_each_element_in_thread_local_index(acc, func, Vec1::all(problemSize));
+    }
+
+    template <typename T_Acc, typename Func, typename T>
+      void for_each_element_1D_grid_stride(const T_Acc& acc, Func func, const T problemSize) {     
+      cms::alpakatools::for_each_element_grid_stride(acc, func, Vec1::all(problemSize));
+    }
+
+    template <typename T_Acc, typename Func, typename T>
+      void for_each_element_1D_block_stride(const T_Acc& acc, Func func, const T problemSize) {     
+      cms::alpakatools::for_each_element_block_stride(acc, func, Vec1::all(problemSize));
+    }
+
 
   }  // namespace alpakatools
 }  // namespace cms

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -35,41 +35,79 @@ namespace cms {
     }
 
     /*
-     * Computes the range of the element(s) global index(es) in grid.
+     * Computes the range of the element(s) index(es), local to the block.
      * Warning: the max index is not truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_global_index_range(const T_Acc& acc) {
-      Vec<T_Dim> firstElementIdxGlobalVec = Vec<T_Dim>::zeros();
-      Vec<T_Dim> endElementIdxUncutGlobalVec = Vec<T_Dim>::zeros();
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block(const T_Acc& acc, const Vec<T_Dim>& elementIndexShift) {
+      Vec<T_Dim> firstElementIdxVec = Vec<T_Dim>::zeros();
+      Vec<T_Dim> endElementIdxUncutVec = Vec<T_Dim>::zeros();
 
+      // Loop on all grid dimensions.
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-        // Global thread index in grid (along dimension dimIndex).
-        const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[dimIndex]);
+	// Take into account the thread index in block to compute the element indices.
+        const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[dimIndex]);
         const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[dimIndex]);
 
-        // Global element index in grid (along dimension dimIndex).
+        // Local element index in block (along dimension dimIndex).
         // Obviously relevant for CPU only.
         // For GPU, threadDimension = 1, and endElementIdxGlobal = firstElementIdxLocal + 1.
-        const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
-        const uint32_t endElementIdxUncutGlobal = firstElementIdxGlobal + threadDimension;
+        const uint32_t firstElementIdxLocal = threadIdxLocal * threadDimension;
+	const uint32_t firstElementIdx = firstElementIdxLocal + elementIndexShift[dimIndex]; // Add the shift!
+        const uint32_t endElementIdxUncut = firstElementIdx + threadDimension;
 
-        firstElementIdxGlobalVec[dimIndex] = firstElementIdxGlobal;
-        endElementIdxUncutGlobalVec[dimIndex] = endElementIdxUncutGlobal;
+        firstElementIdxVec[dimIndex] = firstElementIdx;
+        endElementIdxUncutVec[dimIndex] = endElementIdxUncut;
       }
 
-      return {firstElementIdxGlobalVec, endElementIdxUncutGlobalVec};
+      return {firstElementIdxVec, endElementIdxUncutVec};
     }
 
     /*
-     * Computes the range of the element(s) global index(es) in grid.
+     * Computes the range of the element(s) index(es), local to the block.
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_global_index_range_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, const Vec<T_Dim>& elementIndexShift) {
       static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
                     "Accelerator and maxNumberOfElements need to have same dimension.");
-      auto&& [firstElementIdxGlobalVec, endElementIdxGlobalVec] = element_global_index_range(acc);
+      auto&& [firstElementIdxLocalVec, endElementIdxLocalVec] = element_index_range_in_block(acc, elementIndexShift);
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+        endElementIdxLocalVec[dimIndex] = std::min(endElementIdxLocalVec[dimIndex], maxNumberOfElements[dimIndex]);
+      }
+
+      return {firstElementIdxLocalVec, endElementIdxLocalVec};
+    }
+
+
+    /*
+     * Computes the range of the element(s) index(es) in grid.
+     * Warning: the max index is not truncated by the max number of elements of interest.
+     */
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid(const T_Acc& acc, Vec<T_Dim>& elementIndexShift) {
+      // Loop on all grid dimensions.
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+        // Take into account the block index in grid to compute the element indices.
+        const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[dimIndex]);
+        const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[dimIndex]);
+
+	elementIndexShift[dimIndex] += blockIdxInGrid * blockDimension;
+      }
+
+      return element_index_range_in_block(acc, elementIndexShift);
+    }
+
+    /*
+     * Computes the range of the element(s) index(es) in grid.
+     * Truncated by the max number of elements of interest.
+     */
+    template <typename T_Acc, typename T_Dim>
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, Vec<T_Dim>& elementIndexShift) {
+      static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
+                    "Accelerator and maxNumberOfElements need to have same dimension.");
+      auto&& [firstElementIdxGlobalVec, endElementIdxGlobalVec] = element_index_range_in_grid(acc, elementIndexShift);
 
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
         endElementIdxGlobalVec[dimIndex] = std::min(endElementIdxGlobalVec[dimIndex], maxNumberOfElements[dimIndex]);
@@ -80,181 +118,118 @@ namespace cms {
 
 
     /*
-     * Computes the range of the element(s) index(es) local to the block.
-     * Warning: the max index is not truncated by the max number of elements of interest.
-     */
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_local_index_range(const T_Acc& acc) {
-      Vec<T_Dim> firstElementIdxLocalVec = Vec<T_Dim>::zeros();
-      Vec<T_Dim> endElementIdxUncutLocalVec = Vec<T_Dim>::zeros();
-
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-        // Local thread index in block (along dimension dimIndex).
-        const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[dimIndex]);
-        const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[dimIndex]);
-
-        // Local element index in block (along dimension dimIndex).
-        // Obviously relevant for CPU only.
-        // For GPU, threadDimension = 1, and endElementIdxGlobal = firstElementIdxLocal + 1.
-        const uint32_t firstElementIdxLocal = threadIdxLocal * threadDimension;
-        const uint32_t endElementIdxUncutLocal = firstElementIdxLocal + threadDimension;
-
-        firstElementIdxLocalVec[dimIndex] = firstElementIdxLocal;
-        endElementIdxUncutLocalVec[dimIndex] = endElementIdxUncutLocal;
-      }
-
-      return {firstElementIdxLocalVec, endElementIdxUncutLocalVec};
-    }
-
-    /*
-     * Computes the range of the element(s) global index(es) in grid.
+     * Computes the range of the element(s) index(es) in grid.
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_local_index_range_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
-      static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
-                    "Accelerator and maxNumberOfElements need to have same dimension.");
-      auto&& [firstElementIdxLocalVec, endElementIdxLocalVec] = element_local_index_range(acc);
-
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-        endElementIdxLocalVec[dimIndex] = std::min(endElementIdxLocalVec[dimIndex], maxNumberOfElements[dimIndex]);
-      }
-
-      return {firstElementIdxLocalVec, endElementIdxLocalVec};
-    }
-
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_global_index(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
-
-      const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-      cms::alpakatools::element_global_index_range_truncated(acc, problemSize);
-
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-	const uint32_t firstElementIdx = firstElementIdxGlobal[dimIndex] + indexShift[dimIndex];
-	const uint32_t endElementIdx = endElementIdxGlobal[dimIndex] + indexShift[dimIndex];
-
-	for (uint32_t elementIdx = firstElementIdx; elementIdx < endElementIdx; ++elementIdx) {
-	  func(elementIdx);
-	}
-      }
-
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_local_index(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
-
-      const auto& [firstElementIdxLocal, endElementIdxLocal] =
-      cms::alpakatools::element_local_index_range_truncated(acc, problemSize);
-
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-	const uint32_t firstElementIdx = firstElementIdxLocal[dimIndex] + indexShift[dimIndex];
-	const uint32_t endElementIdx = endElementIdxLocal[dimIndex] + indexShift[dimIndex];
-
-	for (uint32_t elementIdx = firstElementIdx; elementIdx < endElementIdx; ++elementIdx) {
-	  func(elementIdx);
-	}
-      }
-
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_grid_stride(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
       
-      const auto &[firstElementIdxNoStrideNoShift, endElementIdxNoStrideNoShift] =
-      cms::alpakatools::element_global_index_range(acc);
-      
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-	const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[dimIndex]);
-	const uint32_t firstElementIdxNoStride = firstElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
-	const uint32_t endElementIdxNoStride = endElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
+      Vec<T_Dim> elementIndexShift = Vec<T_Dim>::zeros();
+      return element_index_range_in_grid_truncated(acc, elementIndexShift, maxNumberOfElements);
+    }
 
-	for (uint32_t threadIdx = firstElementIdxNoStride, endElementIdx = endElementIdxNoStride;
-	     threadIdx < problemSize[dimIndex];
-	     threadIdx += gridDimension, endElementIdx += gridDimension) {
+
+    // 1D HELPERS
+
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIndexShift, const Func& func) {
+
+      const auto& [firstElementIdx, endElementIdx] =
+	cms::alpakatools::element_index_range_in_block_truncated(acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIndexShift));
+
+      for (uint32_t elementIdx = firstElementIdx[0u]; elementIdx < endElementIdx[0u]; ++elementIdx) {
+	func(elementIdx);
+      }
+    }
+
+
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const uint32_t maxNumberOfElements, uint32_t elementIndexShift, const Func& func) {
+
+      // Take into account the block index in grid to compute the element indices.
+      const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+      const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+      elementIndexShift += blockIdxInGrid * blockDimension;
+
+      for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIndexShift, func);
+    }
+
+
+
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIndexShift, const Func& func) {
+
+      const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
+	cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIndexShift));
+      
+      const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+
+      for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
+	   threadIdx < maxNumberOfElements;
+	   threadIdx += blockDimension, endElementIdx += blockDimension) {
 	  
-	  for (uint32_t i = threadIdx; i < std::min(endElementIdx, problemSize[dimIndex]); ++i) {
-	    func(i);
-	  }
+	for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
+	  func(i);
 	}
       }
       
     }
 
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_block_stride(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
+    
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIndexShift, const Func& func) {
 
-      const auto &[firstElementIdxNoStrideNoShift, endElementIdxNoStrideNoShift] =
-      cms::alpakatools::element_local_index_range(acc);
+      Vec1 elementIndexShiftVec = Vec1::all(elementIndexShift);
       
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-	const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[dimIndex]);
-	const uint32_t firstElementIdxNoStride = firstElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
-	const uint32_t endElementIdxNoStride = endElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
+      const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
+	cms::alpakatools::element_index_range_in_grid(acc, elementIndexShiftVec);
+      
+      const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
 
-	for (uint32_t threadIdx = firstElementIdxNoStride, endElementIdx = endElementIdxNoStride;
-	     threadIdx < problemSize[dimIndex];
-	     threadIdx += blockDimension, endElementIdx += blockDimension) {
+      for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
+	   threadIdx < maxNumberOfElements;
+	   threadIdx += gridDimension, endElementIdx += gridDimension) {
 	  
-	  for (uint32_t i = threadIdx; i < std::min(endElementIdx, problemSize[dimIndex]); ++i) {
-	    func(i);
-	  }
+	for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
+	  func(i);
 	}
       }
       
-    }
-
-
-    // 1D HELPERS    
-
-    // LOOP ON ELEMENTS ONLY, GLOBAL INDICES (per grid)
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_global_index(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
-      cms::alpakatools::for_each_element_in_thread_global_index(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_global_index(const T_Acc& acc, const T_Dim problemSize, Func func) {
-      T_Dim indexShift = 0; 
-      cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, problemSize, indexShift, func);
-    }
-
-    // LOOP ON ELEMENTS ONLY, LOCAL INDICES (per block)
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_local_index(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
-      cms::alpakatools::for_each_element_in_thread_local_index(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_local_index(const T_Acc& acc, const T_Dim problemSize, Func func) {
-      T_Dim indexShift = 0; 
-      cms::alpakatools::for_each_element_in_thread_1D_local_index(acc, problemSize, indexShift, func);
     }
 
     
 
-    // HANDLES THREAD AND ELEMENTS INDICES FOR STRIDED ACCESS, GLOBAL INDICES (per grid)
+
+     
+
+    // LOOP ON ELEMENTS ONLY, GLOBAL INDICES (per grid)
+    /*template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const T_Dim maxNumberOfElements, T_Dim elementIndexShift, Func func) {     
+      cms::alpakatools::for_each_element_in_thread_index_in_grid(acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIndexShift), func);
+      }*/
+
     template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
-      cms::alpakatools::for_each_element_grid_stride(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const T_Dim maxNumberOfElements, const Func& func) {
+      T_Dim elementIndexShift = 0; 
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, maxNumberOfElements, elementIndexShift, func);
     }
 
     template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const T_Dim problemSize, Func func) { 
-      T_Dim indexShift = 0; 
-      cms::alpakatools::for_each_element_1D_grid_stride(acc, problemSize, indexShift, func);
-    }
-
-    // HANDLES THREAD AND ELEMENTS INDICES FOR STRIDED ACCESS, LOCAL INDICES (per block)
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
-      cms::alpakatools::for_each_element_block_stride(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const T_Dim maxNumberOfElements, const Func& func) {
+      T_Dim elementIndexShift = 0; 
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIndexShift, func);
     }
 
     template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const T_Dim problemSize, Func func) {
-      T_Dim indexShift = 0;      
-      cms::alpakatools::for_each_element_1D_block_stride(acc, problemSize, indexShift, func);
+      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const T_Dim maxNumberOfElements, const Func& func) { 
+      T_Dim elementIndexShift = 0; 
+      cms::alpakatools::for_each_element_1D_grid_stride(acc, maxNumberOfElements, elementIndexShift, func);
+    }
+
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const T_Dim maxNumberOfElements, const Func& func) {
+      T_Dim elementIndexShift = 0;      
+      cms::alpakatools::for_each_element_1D_block_stride(acc, maxNumberOfElements, elementIndexShift, func);
     }
 
     

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -119,8 +119,8 @@ namespace cms {
     }
 
 
-    template <typename T_Acc, typename Func, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      void for_each_element_in_thread_global_index(const T_Acc& acc, Func func, const Vec<T_Dim>& problemSize) {
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_global_index(const T_Acc& acc, const Vec<T_Dim>& problemSize, Func func) {
 
       const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
       cms::alpakatools::element_global_index_range_truncated(acc, problemSize);
@@ -134,8 +134,8 @@ namespace cms {
 
     }
 
-    template <typename T_Acc, typename Func, typename T, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      void for_each_element_in_thread_local_index(const T_Acc& acc, Func func, const Vec<T_Dim>& problemSize) {
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_local_index(const T_Acc& acc, const Vec<T_Dim>& problemSize, Func func) {
 
       const auto& [firstElementIdxLocal, endElementIdxLocal] =
       cms::alpakatools::element_local_index_range_truncated(acc, problemSize);
@@ -150,8 +150,8 @@ namespace cms {
     }
 
 
-    template <typename T_Acc, typename Func, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      void for_each_element_grid_stride(const T_Acc& acc, Func func, const Vec<T_Dim>& problemSize) {
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_grid_stride(const T_Acc& acc, const Vec<T_Dim>& problemSize, Func func) {
 
       
       const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
@@ -172,8 +172,8 @@ namespace cms {
       
     }
 
-    template <typename T_Acc, typename Func, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      void for_each_element_block_stride(const T_Acc& acc, Func func, const Vec<T_Dim>& problemSize) {
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_block_stride(const T_Acc& acc, const Vec<T_Dim>& problemSize, Func func) {
 
       
       const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
@@ -195,25 +195,34 @@ namespace cms {
     }
 
 
-    template <typename T_Acc, typename Func, typename T>
-      void for_each_element_in_thread_1D_global_index(const T_Acc& acc, Func func, const T problemSize) {     
-      cms::alpakatools::for_each_element_in_thread_global_index(acc, func, Vec1::all(problemSize));
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_global_index(const T_Acc& acc, const T_Dim problemSize, Func func) {     
+      cms::alpakatools::for_each_element_in_thread_global_index(acc, Vec1::all(problemSize), func);
     }
 
-    template <typename T_Acc, typename Func, typename T>
-      void for_each_element_in_thread_1D_local_index(const T_Acc& acc, Func func, const T problemSize) {     
-      cms::alpakatools::for_each_element_in_thread_local_index(acc, func, Vec1::all(problemSize));
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_local_index(const T_Acc& acc, const T_Dim problemSize, Func func) {     
+      cms::alpakatools::for_each_element_in_thread_local_index(acc, Vec1::all(problemSize), func);
     }
 
-    template <typename T_Acc, typename Func, typename T>
-      void for_each_element_1D_grid_stride(const T_Acc& acc, Func func, const T problemSize) {     
-      cms::alpakatools::for_each_element_grid_stride(acc, func, Vec1::all(problemSize));
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const T_Dim problemSize, Func func) {     
+      cms::alpakatools::for_each_element_grid_stride(acc, Vec1::all(problemSize), func);
     }
 
-    template <typename T_Acc, typename Func, typename T>
-      void for_each_element_1D_block_stride(const T_Acc& acc, Func func, const T problemSize) {     
-      cms::alpakatools::for_each_element_block_stride(acc, func, Vec1::all(problemSize));
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const T_Dim problemSize, Func func) {     
+      cms::alpakatools::for_each_element_block_stride(acc, Vec1::all(problemSize), func);
     }
+
+
+    template <typename T_Acc>
+      ALPAKA_FN_ACC bool once_per_block_1D(const T_Acc& acc, uint32_t i) {
+      const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+      return (i % blockDimension == 0);
+    }
+
+    
 
 
   }  // namespace alpakatools

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -156,12 +156,12 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
                                                                     const uint32_t maxNumberOfElements,
                                                                     const uint32_t elementIdxShift,
-                                                                    const Func func) {
+                                                                    Func&& func) {
       const auto& [firstElementIdx, endElementIdx] = cms::alpakatools::element_index_range_in_block_truncated(
           acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIdxShift));
 
       for (uint32_t elementIdx = firstElementIdx[0u]; elementIdx < endElementIdx[0u]; ++elementIdx) {
-        func(elementIdx);
+        std::forward<Func>(func)(elementIdx);
       }
     }
 
@@ -171,9 +171,10 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
                                                                     const uint32_t maxNumberOfElements,
-                                                                    const Func func) {
+                                                                    Func&& func) {
       const uint32_t elementIdxShift = 0;
-      cms::alpakatools::for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_block(
+          acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
     }
 
     /*
@@ -185,13 +186,13 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
                                                                    const uint32_t maxNumberOfElements,
                                                                    uint32_t elementIdxShift,
-                                                                   const Func func) {
+                                                                   Func&& func) {
       // Take into account the block index in grid to compute the element indices.
       const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
       elementIdxShift += blockIdxInGrid * blockDimension;
 
-      for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
+      for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
     }
 
     /*
@@ -200,9 +201,10 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
                                                                    const uint32_t maxNumberOfElements,
-                                                                   const Func func) {
+                                                                   Func&& func) {
       const uint32_t elementIdxShift = 0;
-      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, maxNumberOfElements, elementIdxShift, func);
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(
+          acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
     }
 
     /******************************************************************************
@@ -219,7 +221,7 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
                                                         const uint32_t maxNumberOfElements,
                                                         const uint32_t elementIdxShift,
-                                                        const Func func) {
+                                                        Func&& func) {
       // Get thread / element indices in block.
       const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
           cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
@@ -233,7 +235,7 @@ namespace cms {
            threadIdx += blockDimension, endElementIdx += blockDimension) {
         // (CPU) Loop on all elements.
         for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
-          func(i);
+          std::forward<Func>(func)(i);
         }
       }
     }
@@ -244,9 +246,10 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
                                                         const uint32_t maxNumberOfElements,
-                                                        const Func func) {
+                                                        Func&& func) {
       const uint32_t elementIdxShift = 0;
-      cms::alpakatools::for_each_element_1D_block_stride(acc, maxNumberOfElements, elementIdxShift, func);
+      cms::alpakatools::for_each_element_1D_block_stride(
+          acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
     }
 
     /*
@@ -259,7 +262,7 @@ namespace cms {
     ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
                                                        const uint32_t maxNumberOfElements,
                                                        const uint32_t elementIdxShift,
-                                                       const Func func) {
+                                                       Func&& func) {
       Vec1 elementIdxShiftVec = Vec1::all(elementIdxShift);
 
       // Get thread / element indices in block.
@@ -275,7 +278,7 @@ namespace cms {
            threadIdx += gridDimension, endElementIdx += gridDimension) {
         // (CPU) Loop on all elements.
         for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
-          func(i);
+          std::forward<Func>(func)(i);
         }
       }
     }
@@ -286,9 +289,10 @@ namespace cms {
     template <typename T_Acc, typename Func>
     ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
                                                        const uint32_t maxNumberOfElements,
-                                                       const Func func) {
+                                                       Func&& func) {
       const uint32_t elementIdxShift = 0;
-      cms::alpakatools::for_each_element_1D_grid_stride(acc, maxNumberOfElements, elementIdxShift, func);
+      cms::alpakatools::for_each_element_1D_grid_stride(
+          acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
     }
 
   }  // namespace alpakatools

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -153,10 +153,10 @@ namespace cms {
      * Indexes are local to the BLOCK.
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
-                                                                    const uint32_t maxNumberOfElements,
-                                                                    const uint32_t elementIdxShift,
-                                                                    Func&& func) {
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
+                                                                                     const uint32_t maxNumberOfElements,
+                                                                                     const uint32_t elementIdxShift,
+                                                                                     Func&& func) {
       const auto& [firstElementIdx, endElementIdx] = cms::alpakatools::element_index_range_in_block_truncated(
           acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIdxShift));
 
@@ -169,9 +169,9 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
-                                                                    const uint32_t maxNumberOfElements,
-                                                                    Func&& func) {
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
+                                                                                     const uint32_t maxNumberOfElements,
+                                                                                     Func&& func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_in_thread_1D_index_in_block(
           acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
@@ -183,10 +183,10 @@ namespace cms {
      * Indexes are expressed in GRID 'frame-of-reference'.
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
-                                                                   const uint32_t maxNumberOfElements,
-                                                                   uint32_t elementIdxShift,
-                                                                   Func&& func) {
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
+                                                                                    const uint32_t maxNumberOfElements,
+                                                                                    uint32_t elementIdxShift,
+                                                                                    Func&& func) {
       // Take into account the block index in grid to compute the element indices.
       const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
@@ -199,9 +199,9 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
-                                                                   const uint32_t maxNumberOfElements,
-                                                                   Func&& func) {
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
+                                                                                    const uint32_t maxNumberOfElements,
+                                                                                    Func&& func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(
           acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
@@ -218,10 +218,10 @@ namespace cms {
      * Indexes are local to the BLOCK.
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
-                                                        const uint32_t maxNumberOfElements,
-                                                        const uint32_t elementIdxShift,
-                                                        Func&& func) {
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_1D_block_stride(const T_Acc& acc,
+                                                                         const uint32_t maxNumberOfElements,
+                                                                         const uint32_t elementIdxShift,
+                                                                         Func&& func) {
       // Get thread / element indices in block.
       const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
           cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
@@ -244,9 +244,9 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
-                                                        const uint32_t maxNumberOfElements,
-                                                        Func&& func) {
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_1D_block_stride(const T_Acc& acc,
+                                                                         const uint32_t maxNumberOfElements,
+                                                                         Func&& func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_1D_block_stride(
           acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));
@@ -259,10 +259,10 @@ namespace cms {
      * Indexes are local to the GRID.
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
-                                                       const uint32_t maxNumberOfElements,
-                                                       const uint32_t elementIdxShift,
-                                                       Func&& func) {
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_1D_grid_stride(const T_Acc& acc,
+                                                                        const uint32_t maxNumberOfElements,
+                                                                        const uint32_t elementIdxShift,
+                                                                        Func&& func) {
       Vec1 elementIdxShiftVec = Vec1::all(elementIdxShift);
 
       // Get thread / element indices in block.
@@ -287,9 +287,9 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-    ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
-                                                       const uint32_t maxNumberOfElements,
-                                                       Func&& func) {
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void for_each_element_1D_grid_stride(const T_Acc& acc,
+                                                                        const uint32_t maxNumberOfElements,
+                                                                        Func&& func) {
       const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_1D_grid_stride(
           acc, maxNumberOfElements, elementIdxShift, std::forward<Func>(func));

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -28,6 +28,10 @@ namespace cms {
 #endif
     }
 
+    /*
+     * 1D helper to only access 1 element per block 
+     * (should obviously only be needed for debug / printout).
+     */
     template <typename T_Acc>
       ALPAKA_FN_ACC bool once_per_block_1D(const T_Acc& acc, uint32_t i) {
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
@@ -35,84 +39,99 @@ namespace cms {
     }
 
     /*
-     * Computes the range of the element(s) index(es), local to the block.
+     * Computes the range of the elements indexes, local to the block.
      * Warning: the max index is not truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block(const T_Acc& acc, const Vec<T_Dim>& elementIndexShift) {
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block(const T_Acc& acc, const Vec<T_Dim>& elementIdxShift) {
       Vec<T_Dim> firstElementIdxVec = Vec<T_Dim>::zeros();
       Vec<T_Dim> endElementIdxUncutVec = Vec<T_Dim>::zeros();
 
       // Loop on all grid dimensions.
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-	// Take into account the thread index in block to compute the element indices.
+
+	// Take into account the thread index in block.
         const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[dimIndex]);
         const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[dimIndex]);
 
-        // Local element index in block (along dimension dimIndex).
+        // Compute the elements indexes in block.
         // Obviously relevant for CPU only.
-        // For GPU, threadDimension = 1, and endElementIdxGlobal = firstElementIdxLocal + 1.
+        // For GPU, threadDimension = 1, and elementIdx = firstElementIdx = threadIdx + elementIdxShift.
         const uint32_t firstElementIdxLocal = threadIdxLocal * threadDimension;
-	const uint32_t firstElementIdx = firstElementIdxLocal + elementIndexShift[dimIndex]; // Add the shift!
+	const uint32_t firstElementIdx = firstElementIdxLocal + elementIdxShift[dimIndex]; // Add the shift!
         const uint32_t endElementIdxUncut = firstElementIdx + threadDimension;
 
         firstElementIdxVec[dimIndex] = firstElementIdx;
         endElementIdxUncutVec[dimIndex] = endElementIdxUncut;
       }
 
+      // Return element indexes, shifted by elementIdxShift.
       return {firstElementIdxVec, endElementIdxUncutVec};
     }
 
+
     /*
-     * Computes the range of the element(s) index(es), local to the block.
+     * Computes the range of the elements indexes, local to the block.
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, const Vec<T_Dim>& elementIndexShift) {
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, const Vec<T_Dim>& elementIdxShift) {
+
+      // Check dimension
       static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
                     "Accelerator and maxNumberOfElements need to have same dimension.");
-      auto&& [firstElementIdxLocalVec, endElementIdxLocalVec] = element_index_range_in_block(acc, elementIndexShift);
+      auto&& [firstElementIdxLocalVec, endElementIdxLocalVec] = element_index_range_in_block(acc, elementIdxShift);
 
+      // Truncate
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
         endElementIdxLocalVec[dimIndex] = std::min(endElementIdxLocalVec[dimIndex], maxNumberOfElements[dimIndex]);
       }
 
+      // Return element indexes, shifted by elementIdxShift, and truncated by maxNumberOfElements.
       return {firstElementIdxLocalVec, endElementIdxLocalVec};
     }
 
 
     /*
-     * Computes the range of the element(s) index(es) in grid.
+     * Computes the range of the elements indexes in grid.
      * Warning: the max index is not truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid(const T_Acc& acc, Vec<T_Dim>& elementIndexShift) {
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid(const T_Acc& acc, Vec<T_Dim>& elementIdxShift) {
+
       // Loop on all grid dimensions.
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-        // Take into account the block index in grid to compute the element indices.
+
+        // Take into account the block index in grid.
         const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[dimIndex]);
         const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[dimIndex]);
 
-	elementIndexShift[dimIndex] += blockIdxInGrid * blockDimension;
+	// Shift to get global indices in grid (instead of local to the block)
+	elementIdxShift[dimIndex] += blockIdxInGrid * blockDimension;
       }
 
-      return element_index_range_in_block(acc, elementIndexShift);
+      // Return element indexes, shifted by elementIdxShift.
+      return element_index_range_in_block(acc, elementIdxShift);
     }
 
     /*
-     * Computes the range of the element(s) index(es) in grid.
+     * Computes the range of the elements indexes in grid.
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, Vec<T_Dim>& elementIndexShift) {
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, Vec<T_Dim>& elementIdxShift) {
+
+      // Check dimension
       static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
                     "Accelerator and maxNumberOfElements need to have same dimension.");
-      auto&& [firstElementIdxGlobalVec, endElementIdxGlobalVec] = element_index_range_in_grid(acc, elementIndexShift);
+      auto&& [firstElementIdxGlobalVec, endElementIdxGlobalVec] = element_index_range_in_grid(acc, elementIdxShift);
 
+      // Truncate
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
         endElementIdxGlobalVec[dimIndex] = std::min(endElementIdxGlobalVec[dimIndex], maxNumberOfElements[dimIndex]);
       }
 
+      // Return element indexes, shifted by elementIdxShift, and truncated by maxNumberOfElements.
       return {firstElementIdxGlobalVec, endElementIdxGlobalVec};
     }
 
@@ -124,50 +143,92 @@ namespace cms {
     template <typename T_Acc, typename T_Dim>
       ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
       
-      Vec<T_Dim> elementIndexShift = Vec<T_Dim>::zeros();
-      return element_index_range_in_grid_truncated(acc, elementIndexShift, maxNumberOfElements);
+      Vec<T_Dim> elementIdxShift = Vec<T_Dim>::zeros();
+      return element_index_range_in_grid_truncated(acc, elementIdxShift, maxNumberOfElements);
     }
 
 
-    // 1D HELPERS
+    /*********************************************
+     *     1D HELPERS, LOOP ON ALL CPU ELEMENTS
+     ********************************************/
 
+    /*
+     * Loop on all (CPU) elements.
+     * Elements loop makes sense in CPU case only. In GPU case, elementIdx = firstElementIdx = threadIdx + shift.
+     * Indexes are local to the BLOCK.
+     */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIndexShift, const Func& func) {
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
 
       const auto& [firstElementIdx, endElementIdx] =
-	cms::alpakatools::element_index_range_in_block_truncated(acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIndexShift));
+	cms::alpakatools::element_index_range_in_block_truncated(acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIdxShift));
 
       for (uint32_t elementIdx = firstElementIdx[0u]; elementIdx < endElementIdx[0u]; ++elementIdx) {
 	func(elementIdx);
       }
     }
 
-
+    /*
+     * Overload for elementIdxShift = 0
+     */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const uint32_t maxNumberOfElements, uint32_t elementIndexShift, const Func& func) {
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
+      const uint32_t elementIdxShift = 0; 
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
+    }
+
+    /*
+     * Loop on all (CPU) elements.
+     * Elements loop makes sense in CPU case only. In GPU case, elementIdx = firstElementIdx = threadIdx + shift.
+     * Indexes are expressed in GRID 'frame-of-reference'.
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const uint32_t maxNumberOfElements, uint32_t elementIdxShift, const Func& func) {
 
       // Take into account the block index in grid to compute the element indices.
       const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
-      elementIndexShift += blockIdxInGrid * blockDimension;
+      elementIdxShift += blockIdxInGrid * blockDimension;
 
-      for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIndexShift, func);
+      for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
+    }
+
+    /*
+     * Overload for elementIdxShift = 0
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
+      const uint32_t elementIdxShift = 0; 
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
 
+    /******************************************************************************
+     *     1D HELPERS, LOOP ON ALL CPU ELEMENTS, AND ELEMENT/THREAD STRIDED ACCESS
+     ******************************************************************************/
 
+    /*
+     * (CPU) Loop on all elements + (CPU/GPU) Strided access.
+     * Elements loop makes sense in CPU case only. In GPU case, elementIdx = firstElementIdx = threadIdx + shift.
+     * Stride to full problem size, by BLOCK size.
+     * Indexes are local to the BLOCK.
+     */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIndexShift, const Func& func) {
+      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
 
+      // Get thread / element indices in block.
       const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
-	cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIndexShift));
+	cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
       
+      // Stride = block size.
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
 
+      // Strided access.
       for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
 	   threadIdx < maxNumberOfElements;
 	   threadIdx += blockDimension, endElementIdx += blockDimension) {
 	  
+	// (CPU) Loop on all elements.
 	for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
 	  func(i);
 	}
@@ -175,62 +236,57 @@ namespace cms {
       
     }
 
-    
+    /*
+     * Overload for elementIdxShift = 0
+     */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIndexShift, const Func& func) {
+      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
+      const uint32_t elementIdxShift = 0;      
+      cms::alpakatools::for_each_element_1D_block_stride(acc, maxNumberOfElements, elementIdxShift, func);
+    }
+    
 
-      Vec1 elementIndexShiftVec = Vec1::all(elementIndexShift);
+    /*
+     * (CPU) Loop on all elements + (CPU/GPU) Strided access.
+     * Elements loop makes sense in CPU case only. In GPU case, elementIdx = firstElementIdx = threadIdx + shift.
+     * Stride to full problem size, by GRID size.
+     * Indexes are local to the GRID.
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
+
+      Vec1 elementIdxShiftVec = Vec1::all(elementIdxShift);
       
+      // Get thread / element indices in block.
       const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
-	cms::alpakatools::element_index_range_in_grid(acc, elementIndexShiftVec);
+	cms::alpakatools::element_index_range_in_grid(acc, elementIdxShiftVec);
       
+      // Stride = grid size.
       const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
 
+      // Strided access.
       for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
 	   threadIdx < maxNumberOfElements;
 	   threadIdx += gridDimension, endElementIdx += gridDimension) {
 	  
+	// (CPU) Loop on all elements.
 	for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
 	  func(i);
 	}
       }
       
+    }    
+    
+    /*
+     * Overload for elementIdxShift = 0
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) { 
+      const uint32_t elementIdxShift = 0; 
+      cms::alpakatools::for_each_element_1D_grid_stride(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
     
-
-
-     
-
-    // LOOP ON ELEMENTS ONLY, GLOBAL INDICES (per grid)
-    /*template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const T_Dim maxNumberOfElements, T_Dim elementIndexShift, Func func) {     
-      cms::alpakatools::for_each_element_in_thread_index_in_grid(acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIndexShift), func);
-      }*/
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const T_Dim maxNumberOfElements, const Func& func) {
-      T_Dim elementIndexShift = 0; 
-      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, maxNumberOfElements, elementIndexShift, func);
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const T_Dim maxNumberOfElements, const Func& func) {
-      T_Dim elementIndexShift = 0; 
-      cms::alpakatools::for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIndexShift, func);
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const T_Dim maxNumberOfElements, const Func& func) { 
-      T_Dim elementIndexShift = 0; 
-      cms::alpakatools::for_each_element_1D_grid_stride(acc, maxNumberOfElements, elementIndexShift, func);
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const T_Dim maxNumberOfElements, const Func& func) {
-      T_Dim elementIndexShift = 0;      
-      cms::alpakatools::for_each_element_1D_block_stride(acc, maxNumberOfElements, elementIndexShift, func);
-    }
 
     
   }  // namespace alpakatools

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -144,7 +144,7 @@ namespace cms {
       ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
       
       Vec<T_Dim> elementIdxShift = Vec<T_Dim>::zeros();
-      return element_index_range_in_grid_truncated(acc, elementIdxShift, maxNumberOfElements);
+      return element_index_range_in_grid_truncated(acc, maxNumberOfElements, elementIdxShift);
     }
 
 

--- a/src/alpaka/AlpakaCore/prefixScan.h
+++ b/src/alpaka/AlpakaCore/prefixScan.h
@@ -8,10 +8,9 @@
 
 template <typename T>
 ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(
-    uint32_t laneId, T const* __restrict__ ci, T* __restrict__ co, uint32_t i, uint32_t mask) {
+    uint32_t laneId, T const* ci, T* co, uint32_t i, uint32_t mask) {
   // ci and co may be the same
   auto x = ci[i];
-#pragma unroll
   for (int offset = 1; offset < 32; offset <<= 1) {
     auto y = __shfl_up_sync(mask, x, offset);
     if (laneId >= offset)
@@ -23,7 +22,6 @@ ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(
 template <typename T>
 ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(uint32_t laneId, T* c, uint32_t i, uint32_t mask) {
   auto x = c[i];
-#pragma unroll
   for (int offset = 1; offset < 32; offset <<= 1) {
     auto y = __shfl_up_sync(mask, x, offset);
     if (laneId >= offset)
@@ -39,8 +37,8 @@ namespace cms {
     // limited to 32*32 elements....
     template <typename T_Acc, typename T>
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void blockPrefixScan(const T_Acc& acc,
-                                                             T const* __restrict__ ci,
-                                                             T* __restrict__ co,
+                                                             T const* ci,
+                                                             T* co,
                                                              uint32_t size,
                                                              T* ws
 #ifndef ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -142,7 +140,6 @@ namespace cms {
         uint32_t const threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
 
         uint32_t const blockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
-        uint32_t const threadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
 
         auto&& ws = alpaka::block::shared::st::allocVar<T[32], __COUNTER__>(acc);
         // first each block does a scan of size 1024; (better be enough blocks....)
@@ -161,7 +158,6 @@ namespace cms {
         uint32_t const blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u]);
         uint32_t const threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
 
-        uint32_t const blockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
         uint32_t const threadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
 
         auto* const psum(alpaka::block::shared::dyn::getMem<T>(acc));

--- a/src/alpaka/AlpakaCore/prefixScan.h
+++ b/src/alpaka/AlpakaCore/prefixScan.h
@@ -2,6 +2,7 @@
 #define HeterogeneousCore_AlpakaUtilities_interface_prefixScan_h
 
 #include <cstdint>
+#include "CUDACore/CMSUnrollLoop.h"
 #include "AlpakaCore/alpakaConfig.h"
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -10,6 +11,7 @@ template <typename T>
 ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(uint32_t laneId, T const* ci, T* co, uint32_t i, uint32_t mask) {
   // ci and co may be the same
   auto x = ci[i];
+CMS_UNROLL_LOOP
   for (int offset = 1; offset < 32; offset <<= 1) {
     auto y = __shfl_up_sync(mask, x, offset);
     if (laneId >= offset)
@@ -21,6 +23,7 @@ ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(uint32_t laneId, T const
 template <typename T>
 ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(uint32_t laneId, T* c, uint32_t i, uint32_t mask) {
   auto x = c[i];
+CMS_UNROLL_LOOP
   for (int offset = 1; offset < 32; offset <<= 1) {
     auto y = __shfl_up_sync(mask, x, offset);
     if (laneId >= offset)

--- a/src/alpaka/AlpakaCore/prefixScan.h
+++ b/src/alpaka/AlpakaCore/prefixScan.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include "AlpakaCore/alpakaConfig.h"
 
+
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 template <typename T>
@@ -32,6 +33,7 @@ ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(uint32_t laneId, T* c, u
 
 #endif
 
+
 namespace cms {
   namespace alpakatools {
     // limited to 32*32 elements....
@@ -46,7 +48,6 @@ namespace cms {
 #endif
     ) {
 #if defined ALPAKA_ACC_GPU_CUDA_ENABLED and __CUDA_ARCH__
-
       uint32_t const blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u]);
       uint32_t const gridBlockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       uint32_t const blockThreadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
@@ -77,6 +78,7 @@ namespace cms {
         co[i] += ws[warpId - 1];
       }
       alpaka::block::sync::syncBlockThreads(acc);
+
 #else
       co[0] = ci[0];
       for (uint32_t i = 1; i < size; ++i)

--- a/src/alpaka/AlpakaCore/prefixScan.h
+++ b/src/alpaka/AlpakaCore/prefixScan.h
@@ -11,7 +11,7 @@ template <typename T>
 ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(uint32_t laneId, T const* ci, T* co, uint32_t i, uint32_t mask) {
   // ci and co may be the same
   auto x = ci[i];
-CMS_UNROLL_LOOP
+  CMS_UNROLL_LOOP
   for (int offset = 1; offset < 32; offset <<= 1) {
     auto y = __shfl_up_sync(mask, x, offset);
     if (laneId >= offset)
@@ -23,7 +23,7 @@ CMS_UNROLL_LOOP
 template <typename T>
 ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(uint32_t laneId, T* c, uint32_t i, uint32_t mask) {
   auto x = c[i];
-CMS_UNROLL_LOOP
+  CMS_UNROLL_LOOP
   for (int offset = 1; offset < 32; offset <<= 1) {
     auto y = __shfl_up_sync(mask, x, offset);
     if (laneId >= offset)

--- a/src/alpaka/AlpakaCore/prefixScan.h
+++ b/src/alpaka/AlpakaCore/prefixScan.h
@@ -4,12 +4,10 @@
 #include <cstdint>
 #include "AlpakaCore/alpakaConfig.h"
 
-
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 template <typename T>
-ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(
-    uint32_t laneId, T const* ci, T* co, uint32_t i, uint32_t mask) {
+ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(uint32_t laneId, T const* ci, T* co, uint32_t i, uint32_t mask) {
   // ci and co may be the same
   auto x = ci[i];
   for (int offset = 1; offset < 32; offset <<= 1) {
@@ -32,7 +30,6 @@ ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void warpPrefixScan(uint32_t laneId, T* c, u
 }
 
 #endif
-
 
 namespace cms {
   namespace alpakatools {

--- a/src/alpaka/CUDACore/CMSUnrollLoop.h
+++ b/src/alpaka/CUDACore/CMSUnrollLoop.h
@@ -1,0 +1,51 @@
+#ifndef FWCore_Utilities_interface_CMSUnrollLoop_h
+#define FWCore_Utilities_interface_CMSUnrollLoop_h
+
+// convert the macro argument to a null-terminated quoted string
+#define STRINGIFY_(ARG) #ARG
+#define STRINGIFY(ARG) STRINGIFY_(ARG)
+
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+// CUDA or HIP device compiler
+
+#define CMS_UNROLL_LOOP _Pragma(STRINGIFY(unroll))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(unroll N))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(unroll 1))
+
+#define CMS_DEVICE_UNROLL_LOOP _Pragma(STRINGIFY(unroll))
+#define CMS_DEVICE_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(unroll N))
+#define CMS_DEVICE_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(unroll 1))
+
+#else  // defined (__CUDA_ARCH__) || defined (__HIP_DEVICE_COMPILE__)
+
+// any host compiler
+#define CMS_DEVICE_UNROLL_LOOP
+#define CMS_DEVICE_UNROLL_LOOP_COUNT(N)
+#define CMS_DEVICE_UNROLL_LOOP_DISABLE
+
+#if defined(__clang__)
+// clang host compiler
+
+#define CMS_UNROLL_LOOP _Pragma(STRINGIFY(clang loop unroll(enable)))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(clang loop unroll_count(N)))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(clang loop unroll(disable)))
+
+#elif defined(__GNUC__)
+// GCC host compiler
+
+#define CMS_UNROLL_LOOP _Pragma(STRINGIFY(GCC ivdep))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(GCC unroll N)) _Pragma(STRINGIFY(GCC ivdep))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(GCC unroll 1))
+
+#else
+// unsupported or unknown compiler
+
+#define CMS_UNROLL_LOOP
+#define CMS_UNROLL_LOOP_COUNT(N)
+#define CMS_UNROLL_LOOP_DISABLE
+
+#endif  // defined(__clang__) || defined(__GNUC__) || ...
+
+#endif  // defined (__CUDA_ARCH__) || defined (__HIP_DEVICE_COMPILE__)
+
+#endif  // FWCore_Utilities_interface_CMSUnrollLoop_h

--- a/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
+++ b/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
@@ -10,7 +10,7 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 struct update {
   template <typename T_Acc>
   ALPAKA_FN_ACC void operator()(const T_Acc &acc, cms::alpakatools::AtomicPairCounter *dc, uint32_t *ind, uint32_t *cont, uint32_t n) const {
-    cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, n, [&](uint32_t i) {
+    cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, n, [&](uint32_t i) {
 	auto m = i % 11;
 	m = m % 6 + 1;  // max 6, no 0
 	auto c = dc->add(acc, m);
@@ -41,7 +41,7 @@ struct verify {
                                 uint32_t const *ind,
                                 uint32_t const *cont,
                                 uint32_t n) const {
-    cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, n, [&](uint32_t i) {
+    cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, n, [&](uint32_t i) {
 	assert(0 == ind[0]);
 	assert(dc->get().m == n);
 	assert(ind[n] == dc->get().n);

--- a/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
+++ b/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
@@ -9,16 +9,17 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 struct update {
   template <typename T_Acc>
-  ALPAKA_FN_ACC void operator()(const T_Acc &acc, cms::alpakatools::AtomicPairCounter *dc, uint32_t *ind, uint32_t *cont, uint32_t n) const {
+  ALPAKA_FN_ACC void operator()(
+      const T_Acc &acc, cms::alpakatools::AtomicPairCounter *dc, uint32_t *ind, uint32_t *cont, uint32_t n) const {
     cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, n, [&](uint32_t i) {
-	auto m = i % 11;
-	m = m % 6 + 1;  // max 6, no 0
-	auto c = dc->add(acc, m);
-	assert(c.m < n);
-	ind[c.m] = c.n;
-	for (uint32_t j = c.n; j < c.n + m; ++j)
-	  cont[j] = i;
-      });
+      auto m = i % 11;
+      m = m % 6 + 1;  // max 6, no 0
+      auto c = dc->add(acc, m);
+      assert(c.m < n);
+      ind[c.m] = c.n;
+      for (uint32_t j = c.n; j < c.n + m; ++j)
+        cont[j] = i;
+    });
   }
 };
 
@@ -42,16 +43,16 @@ struct verify {
                                 uint32_t const *cont,
                                 uint32_t n) const {
     cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, n, [&](uint32_t i) {
-	assert(0 == ind[0]);
-	assert(dc->get().m == n);
-	assert(ind[n] == dc->get().n);
-	auto ib = ind[i];
-	auto ie = ind[i + 1];
-	auto k = cont[ib++];
-	assert(k < n);
-	for (; ib < ie; ++ib)
-	  assert(cont[ib] == k);
-      });
+      assert(0 == ind[0]);
+      assert(dc->get().m == n);
+      assert(ind[n] == dc->get().n);
+      auto ib = ind[i];
+      auto ie = ind[i + 1];
+      auto k = cont[ib++];
+      assert(k < n);
+      for (; ib < ie; ++ib)
+        assert(cont[ib] == k);
+    });
   }
 };
 

--- a/src/alpaka/test/alpaka/OneHistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/OneHistoContainer_t.cc
@@ -24,7 +24,7 @@ struct mykernel {
     auto&& ws = alpaka::block::shared::st::allocVar<typename Hist::Counter[32], __COUNTER__>(acc);
 
     const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
-    const auto& [firstElementIdxNoStride, endElementIdxNoStride] = cms::alpakatools::element_global_index_range(acc);
+    const auto& [firstElementIdxNoStride, endElementIdxNoStride] = cms::alpakatools::element_local_index_range(acc);
 
     // set off zero
     for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];

--- a/src/alpaka/test/alpaka/OneHistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/OneHistoContainer_t.cc
@@ -23,36 +23,22 @@ struct mykernel {
     auto&& hist = alpaka::block::shared::st::allocVar<Hist, __COUNTER__>(acc);
     auto&& ws = alpaka::block::shared::st::allocVar<typename Hist::Counter[32], __COUNTER__>(acc);
 
-    const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
-    const auto& [firstElementIdxNoStride, endElementIdxNoStride] = cms::alpakatools::element_local_index_range(acc);
-
     // set off zero
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-         threadIdx < Hist::totbins();
-         threadIdx += blockDimension, endElementIdx += blockDimension) {
-      for (uint32_t j = threadIdx; j < std::min(endElementIdx, Hist::totbins()); ++j) {
+    cms::alpakatools::for_each_element_1D_block_stride(acc, Hist::totbins(), [&](uint32_t j) {
         hist.off[j] = 0;
-      }
-    }
+      });
     alpaka::block::sync::syncBlockThreads(acc);
 
     // set bins zero
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-         threadIdx < Hist::capacity();
-         threadIdx += blockDimension, endElementIdx += blockDimension) {
-      for (uint32_t j = threadIdx; j < std::min(endElementIdx, Hist::totbins()); ++j) {
+    cms::alpakatools::for_each_element_1D_block_stride(acc, Hist::totbins(), [&](uint32_t j) {
         hist.bins[j] = 0;
-      }
-    }
+      });
     alpaka::block::sync::syncBlockThreads(acc);
 
     // count
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u]; threadIdx < N;
-         threadIdx += blockDimension, endElementIdx += blockDimension) {
-      for (uint32_t j = threadIdx; j < std::min(endElementIdx, N); ++j) {
+    cms::alpakatools::for_each_element_1D_block_stride(acc, N, [&](uint32_t j) {
         hist.count(acc, v[j]);
-      }
-    }
+      });
     alpaka::block::sync::syncBlockThreads(acc);
 
     assert(0 == hist.size());
@@ -62,56 +48,39 @@ struct mykernel {
     hist.finalize(acc, ws);
     alpaka::block::sync::syncBlockThreads(acc);
 
-    if (threadIdxLocal == 0) {
-      printf("hist.size() = %u.\n", hist.size());
-    }
     assert(N == hist.size());
 
     // verify
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-         threadIdx < Hist::nbins();
-         threadIdx += blockDimension, endElementIdx += blockDimension) {
-      for (uint32_t j = threadIdx; j < std::min(endElementIdx, Hist::nbins()); ++j) {
+    cms::alpakatools::for_each_element_1D_block_stride(acc, Hist::nbins(), [&](uint32_t j) {
         assert(hist.off[j] <= hist.off[j + 1]);
-      }
-    }
+      });
     alpaka::block::sync::syncBlockThreads(acc);
 
-    if (threadIdxLocal < 32) {
-      ws[threadIdxLocal] = 0;  // used by prefix scan...
-    }
+    cms::alpakatools::for_each_element_in_thread_1D_local_index(acc, 32, [&](uint32_t i) {
+	ws[i] = 0;  // used by prefix scan...
+      });
     alpaka::block::sync::syncBlockThreads(acc);
 
     // fill
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u]; threadIdx < N;
-         threadIdx += blockDimension, endElementIdx += blockDimension) {
-      for (uint32_t j = threadIdx; j < std::min(endElementIdx, N); ++j) {
+    cms::alpakatools::for_each_element_1D_block_stride(acc, N, [&](uint32_t j) {
         hist.fill(acc, v[j], j);
-      }
-    }
+      });
     alpaka::block::sync::syncBlockThreads(acc);
 
     assert(0 == hist.off[0]);
     assert(N == hist.size());
 
     // bin
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-         threadIdx < hist.size() - 1;
-         threadIdx += blockDimension, endElementIdx += blockDimension) {
-      for (uint32_t j = threadIdx; j < std::min(endElementIdx, hist.size() - 1); ++j) {
+    cms::alpakatools::for_each_element_1D_block_stride(acc, hist.size() - 1, [&](uint32_t j) {
         auto p = hist.begin() + j;
         assert((*p) < N);
         auto k1 = Hist::bin(v[*p]);
         auto k2 = Hist::bin(v[*(p + 1)]);
         assert(k2 >= k1);
-      }
-    }
+      });
 
     // forEachInWindow
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-         threadIdx < hist.size();
-         threadIdx += blockDimension, endElementIdx += blockDimension) {
-      for (uint32_t i = threadIdx; i < std::min(endElementIdx, hist.size()); ++i) {
+    cms::alpakatools::for_each_element_1D_block_stride(acc, hist.size(), [&](uint32_t i) {
         auto p = hist.begin() + i;
         auto j = *p;
         auto b0 = Hist::bin(v[j]);
@@ -137,8 +106,8 @@ struct mykernel {
         int bm = Hist::bin(vm);
         rtot = hist.end(bp) - hist.begin(bm);
         assert(tot == rtot);
-      }
-    }
+      });
+
   }
 };
 

--- a/src/alpaka/test/alpaka/OneHistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/OneHistoContainer_t.cc
@@ -56,7 +56,7 @@ struct mykernel {
       });
     alpaka::block::sync::syncBlockThreads(acc);
 
-    cms::alpakatools::for_each_element_in_thread_1D_local_index(acc, 32, [&](uint32_t i) {
+    cms::alpakatools::for_each_element_in_thread_1D_index_in_block(acc, 32, [&](uint32_t i) {
 	ws[i] = 0;  // used by prefix scan...
       });
     alpaka::block::sync::syncBlockThreads(acc);

--- a/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
+++ b/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
@@ -24,19 +24,19 @@ struct countMultiLocal {
                                 Multiplicity* __restrict__ assoc,
                                 uint32_t n) const {
     cms::alpakatools::for_each_element_1D_grid_stride(acc, n, [&](uint32_t i) {
-        auto&& local = alpaka::block::shared::st::allocVar<Multiplicity::CountersOnly, __COUNTER__>(acc);
-	const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
-	const bool oncePerSharedMemoryAccess = (threadIdxLocal == 0);
-        if (oncePerSharedMemoryAccess) {
-          local.zero();
-        }
-        alpaka::block::sync::syncBlockThreads(acc);
-        local.countDirect(acc, 2 + i % 4);
-        alpaka::block::sync::syncBlockThreads(acc);
-        if (oncePerSharedMemoryAccess) {
-          assoc->add(acc, local);
-        }
-      });
+      auto&& local = alpaka::block::shared::st::allocVar<Multiplicity::CountersOnly, __COUNTER__>(acc);
+      const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+      const bool oncePerSharedMemoryAccess = (threadIdxLocal == 0);
+      if (oncePerSharedMemoryAccess) {
+        local.zero();
+      }
+      alpaka::block::sync::syncBlockThreads(acc);
+      local.countDirect(acc, 2 + i % 4);
+      alpaka::block::sync::syncBlockThreads(acc);
+      if (oncePerSharedMemoryAccess) {
+        assoc->add(acc, local);
+      }
+    });
   }
 };
 
@@ -46,18 +46,15 @@ struct countMulti {
                                 TK const* __restrict__ tk,
                                 Multiplicity* __restrict__ assoc,
                                 uint32_t n) const {
-    cms::alpakatools::for_each_element_1D_grid_stride(acc, n, [&](uint32_t i) {
-	assoc->countDirect(acc, 2 + i % 4);
-      });
+    cms::alpakatools::for_each_element_1D_grid_stride(acc, n, [&](uint32_t i) { assoc->countDirect(acc, 2 + i % 4); });
   }
 };
 
 struct verifyMulti {
   template <typename T_Acc>
   ALPAKA_FN_ACC void operator()(const T_Acc& acc, Multiplicity* __restrict__ m1, Multiplicity* __restrict__ m2) const {
-    cms::alpakatools::for_each_element_1D_grid_stride(acc, Multiplicity::totbins(), [&](uint32_t i) {
-	assert(m1->off[i] == m2->off[i]);
-      });
+    cms::alpakatools::for_each_element_1D_grid_stride(
+        acc, Multiplicity::totbins(), [&](uint32_t i) { assert(m1->off[i] == m2->off[i]); });
   }
 };
 
@@ -67,17 +64,17 @@ struct count {
                                 TK const* __restrict__ tk,
                                 Assoc* __restrict__ assoc,
                                 uint32_t n) const {
-    cms::alpakatools::for_each_element_1D_grid_stride(acc, 4*n, [&](uint32_t i) {
-        auto k = i / 4;
-        auto j = i - 4 * k;
-        assert(j < 4);
-        if (k >= n) {
-          return;
-        }
-        if (tk[k][j] < MaxElem) {
-          assoc->countDirect(acc, tk[k][j]);
-        }
-      });
+    cms::alpakatools::for_each_element_1D_grid_stride(acc, 4 * n, [&](uint32_t i) {
+      auto k = i / 4;
+      auto j = i - 4 * k;
+      assert(j < 4);
+      if (k >= n) {
+        return;
+      }
+      if (tk[k][j] < MaxElem) {
+        assoc->countDirect(acc, tk[k][j]);
+      }
+    });
   }
 };
 
@@ -87,17 +84,17 @@ struct fill {
                                 TK const* __restrict__ tk,
                                 Assoc* __restrict__ assoc,
                                 uint32_t n) const {
-    cms::alpakatools::for_each_element_1D_grid_stride(acc, 4*n, [&](uint32_t i) {
-        auto k = i / 4;
-        auto j = i - 4 * k;
-        assert(j < 4);
-        if (k >= n) {
-          return;
-        }
-        if (tk[k][j] < MaxElem) {
-          assoc->fillDirect(acc, tk[k][j], k);
-        }
-      });
+    cms::alpakatools::for_each_element_1D_grid_stride(acc, 4 * n, [&](uint32_t i) {
+      auto k = i / 4;
+      auto j = i - 4 * k;
+      assert(j < 4);
+      if (k >= n) {
+        return;
+      }
+      if (tk[k][j] < MaxElem) {
+        assoc->fillDirect(acc, tk[k][j], k);
+      }
+    });
   }
 };
 
@@ -116,9 +113,9 @@ struct fillBulk {
                                 Assoc* __restrict__ assoc,
                                 uint32_t n) const {
     cms::alpakatools::for_each_element_1D_grid_stride(acc, n, [&](uint32_t k) {
-        auto m = tk[k][3] < MaxElem ? 4 : 3;
-        assoc->bulkFill(acc, *apc, &tk[k][0], m);
-      });
+      auto m = tk[k][3] < MaxElem ? 4 : 3;
+      assoc->bulkFill(acc, *apc, &tk[k][0], m);
+    });
   }
 };
 

--- a/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
+++ b/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
@@ -23,25 +23,20 @@ struct countMultiLocal {
                                 TK const* __restrict__ tk,
                                 Multiplicity* __restrict__ assoc,
                                 uint32_t n) const {
-    const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
-    const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
-    const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
-        cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(n));
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u]; threadIdx < n;
-         threadIdx += gridDimension, endElementIdx += gridDimension) {
-      for (uint32_t i = threadIdx; i < std::min(endElementIdx, n); ++i) {
+    cms::alpakatools::for_each_element_1D_grid_stride(acc, n, [&](uint32_t i) {
         auto&& local = alpaka::block::shared::st::allocVar<Multiplicity::CountersOnly, __COUNTER__>(acc);
-        if (threadIdxLocal == 0) {
+	const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+	const bool oncePerSharedMemoryAccess = (threadIdxLocal == 0);
+        if (oncePerSharedMemoryAccess) {
           local.zero();
         }
         alpaka::block::sync::syncBlockThreads(acc);
         local.countDirect(acc, 2 + i % 4);
         alpaka::block::sync::syncBlockThreads(acc);
-        if (threadIdxLocal == 0) {
+        if (oncePerSharedMemoryAccess) {
           assoc->add(acc, local);
         }
-      }
-    }
+      });
   }
 };
 
@@ -51,32 +46,18 @@ struct countMulti {
                                 TK const* __restrict__ tk,
                                 Multiplicity* __restrict__ assoc,
                                 uint32_t n) const {
-    const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
-    const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
-        cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(n));
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u]; threadIdx < n;
-         threadIdx += gridDimension, endElementIdx += gridDimension) {
-      for (uint32_t i = threadIdx; i < std::min(endElementIdx, n); ++i) {
-        assoc->countDirect(acc, 2 + i % 4);
-      }
-    }
+    cms::alpakatools::for_each_element_1D_grid_stride(acc, n, [&](uint32_t i) {
+	assoc->countDirect(acc, 2 + i % 4);
+      });
   }
 };
 
 struct verifyMulti {
   template <typename T_Acc>
   ALPAKA_FN_ACC void operator()(const T_Acc& acc, Multiplicity* __restrict__ m1, Multiplicity* __restrict__ m2) const {
-    const uint32_t maxNumberOfElements = Multiplicity::totbins();
-    const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
-    const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
-        cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(maxNumberOfElements));
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-         threadIdx < maxNumberOfElements;
-         threadIdx += gridDimension, endElementIdx += gridDimension) {
-      for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
-        assert(m1->off[i] == m2->off[i]);
-      }
-    }
+    cms::alpakatools::for_each_element_1D_grid_stride(acc, Multiplicity::totbins(), [&](uint32_t i) {
+	assert(m1->off[i] == m2->off[i]);
+      });
   }
 };
 
@@ -86,14 +67,7 @@ struct count {
                                 TK const* __restrict__ tk,
                                 Assoc* __restrict__ assoc,
                                 uint32_t n) const {
-    const uint32_t maxNumberOfElements = 4 * n;
-    const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
-    const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
-        cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(maxNumberOfElements));
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-         threadIdx < maxNumberOfElements;
-         threadIdx += gridDimension, endElementIdx += gridDimension) {
-      for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
+    cms::alpakatools::for_each_element_1D_grid_stride(acc, 4*n, [&](uint32_t i) {
         auto k = i / 4;
         auto j = i - 4 * k;
         assert(j < 4);
@@ -103,8 +77,7 @@ struct count {
         if (tk[k][j] < MaxElem) {
           assoc->countDirect(acc, tk[k][j]);
         }
-      }
-    }
+      });
   }
 };
 
@@ -114,14 +87,7 @@ struct fill {
                                 TK const* __restrict__ tk,
                                 Assoc* __restrict__ assoc,
                                 uint32_t n) const {
-    const uint32_t maxNumberOfElements = 4 * n;
-    const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
-    const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
-        cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(maxNumberOfElements));
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-         threadIdx < maxNumberOfElements;
-         threadIdx += gridDimension, endElementIdx += gridDimension) {
-      for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
+    cms::alpakatools::for_each_element_1D_grid_stride(acc, 4*n, [&](uint32_t i) {
         auto k = i / 4;
         auto j = i - 4 * k;
         assert(j < 4);
@@ -131,8 +97,7 @@ struct fill {
         if (tk[k][j] < MaxElem) {
           assoc->fillDirect(acc, tk[k][j], k);
         }
-      }
-    }
+      });
   }
 };
 
@@ -150,16 +115,10 @@ struct fillBulk {
                                 TK const* __restrict__ tk,
                                 Assoc* __restrict__ assoc,
                                 uint32_t n) const {
-    const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
-    const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
-        cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(n));
-    for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u]; threadIdx < n;
-         threadIdx += gridDimension, endElementIdx += gridDimension) {
-      for (uint32_t k = threadIdx; k < std::min(endElementIdx, n); ++k) {
+    cms::alpakatools::for_each_element_1D_grid_stride(acc, n, [&](uint32_t k) {
         auto m = tk[k][3] < MaxElem ? 4 : 3;
         assoc->bulkFill(acc, *apc, &tk[k][0], m);
-      }
-    }
+      });
   }
 };
 

--- a/src/alpaka/test/alpaka/prefixScan_t.cc
+++ b/src/alpaka/test/alpaka/prefixScan_t.cc
@@ -27,7 +27,7 @@ struct testPrefixScan {
     auto&& co = alpaka::block::shared::st::allocVar<T[1024], __COUNTER__>(acc);
 
     const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
-    const auto& [firstElementIdxNoStride, endElementIdxNoStride] = cms::alpakatools::element_global_index_range(acc);
+    const auto& [firstElementIdxNoStride, endElementIdxNoStride] = cms::alpakatools::element_local_index_range(acc);
 
     for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u]; threadIdx < size;
          threadIdx += blockDimension, endElementIdx += blockDimension) {

--- a/src/alpaka/test/alpaka/prefixScan_t.cc
+++ b/src/alpaka/test/alpaka/prefixScan_t.cc
@@ -116,16 +116,14 @@ int main() {
 
   Queue queue(device);
 
-  const Vec1 threadsPerBlockOrElementsPerThread1(Vec1::all(32));
-  const Vec1 blocksPerGrid1(Vec1::all(1));
-  const WorkDiv1 &workDivWarp = cms::alpakatools::make_workdiv(blocksPerGrid1, threadsPerBlockOrElementsPerThread1);
-  std::cout << "blocks per grid: " << blocksPerGrid1 
-	    << ", threads per block or elements per thread: " << threadsPerBlockOrElementsPerThread1
-            << std::endl;
 
   // WARP PREFIXSCAN (OBVIOUSLY GPU-ONLY)
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
   std::cout << "warp level" << std::endl;
+
+  const Vec1 threadsPerBlockOrElementsPerThread1(Vec1::all(32));
+  const Vec1 blocksPerGrid1(Vec1::all(1));
+  const WorkDiv1 &workDivWarp = cms::alpakatools::make_workdiv(blocksPerGrid1, threadsPerBlockOrElementsPerThread1);
 
   alpaka::queue::enqueue(queue, alpaka::kernel::createTaskKernel<Acc1>(workDivWarp, testWarpPrefixScan<int>(), 32));
   alpaka::wait::wait(queue);
@@ -143,10 +141,15 @@ int main() {
 
   int bs = 1;
   for (bs = 32; bs <= 1024; bs += 32) {
-    std::cout << "bs " << bs << std::endl;
-    const Vec1 threadsPerBlockOrElementsPerThread2(Vec1::all(bs));
-    const Vec1 blocksPerGrid2(Vec1::all(1));
-    const WorkDiv1 &workDivSingleBlock = cms::alpakatools::make_workdiv(blocksPerGrid2, threadsPerBlockOrElementsPerThread2);
+  
+  const Vec1 threadsPerBlockOrElementsPerThread2(Vec1::all(bs));
+  const Vec1 blocksPerGrid2(Vec1::all(1));
+  const WorkDiv1 &workDivSingleBlock = cms::alpakatools::make_workdiv(blocksPerGrid2, threadsPerBlockOrElementsPerThread2);
+
+  std::cout << "blocks per grid: " << blocksPerGrid2 
+	    << ", threads per block or elements per thread: " << threadsPerBlockOrElementsPerThread2
+            << std::endl;
+
     for (int j = 1; j <= 1024; ++j) {
       alpaka::queue::enqueue(queue,
                              alpaka::kernel::createTaskKernel<Acc1>(workDivSingleBlock, testPrefixScan<uint16_t>(), j));

--- a/src/alpaka/test/alpaka/prefixScan_t.cc
+++ b/src/alpaka/test/alpaka/prefixScan_t.cc
@@ -138,13 +138,10 @@ int main() {
   const WorkDiv1 &workDivWarp = cms::alpakatools::make_workdiv(blocksPerGrid1, threadsPerBlockOrElementsPerThread1);
 
   alpaka::queue::enqueue(queue, alpaka::kernel::createTaskKernel<Acc1>(workDivWarp, testWarpPrefixScan<int>(), 32));
-  alpaka::wait::wait(queue);
 
   alpaka::queue::enqueue(queue, alpaka::kernel::createTaskKernel<Acc1>(workDivWarp, testWarpPrefixScan<int>(), 16));
-  alpaka::wait::wait(queue);
 
   alpaka::queue::enqueue(queue, alpaka::kernel::createTaskKernel<Acc1>(workDivWarp, testWarpPrefixScan<int>(), 5));
-  alpaka::wait::wait(queue);
 #endif
 
   // PORTABLE BLOCK PREFIXSCAN
@@ -166,14 +163,11 @@ int main() {
 
   alpaka::queue::enqueue(queue,
     alpaka::kernel::createTaskKernel<Acc1>(workDivSingleBlock, testPrefixScan<uint16_t>(), j));
-  alpaka::wait::wait(queue);
   alpaka::queue::enqueue(queue,
     alpaka::kernel::createTaskKernel<Acc1>(workDivSingleBlock, testPrefixScan<float>(), j));
-  alpaka::wait::wait(queue);
 }
 }
 
-  //alpaka::wait::wait(queue);
 
   // PORTABLE MULTI-BLOCK PREFIXSCAN
   int num_items = 200;
@@ -196,7 +190,6 @@ int main() {
     alpaka::queue::enqueue(
         queue,
         alpaka::kernel::createTaskKernel<Acc1>(workDivMultiBlockInit, init(), input_d, 1, num_items));
-    alpaka::wait::wait(queue);
 
 
     const auto nThreads = 1024;
@@ -213,7 +206,6 @@ int main() {
 								  input_d,
 								  output1_d,
 								  num_items));
-    alpaka::wait::wait(queue);
     
     const Vec1 blocksPerGridSecondStep(Vec1::all(1));
     const WorkDiv1 &workDivMultiBlockSecondStep = cms::alpakatools::make_workdiv(blocksPerGridSecondStep, threadsPerBlockOrElementsPerThread4);
@@ -225,14 +217,14 @@ int main() {
 								  output1_d,
 								  num_items,
 								  nBlocks));
-    alpaka::wait::wait(queue);
+    
 
     alpaka::queue::enqueue(
 			   queue,
 			   alpaka::kernel::createTaskKernel<Acc1>(workDivMultiBlock, 
 								  verify(), output1_d, num_items));
-    alpaka::wait::wait(queue);
 
+    alpaka::wait::wait(queue);  // input_dBuf and output1_dBuf end of scope
   }  // ksize
 
   return 0;

--- a/src/alpaka/test/alpaka/prefixScan_t.cc
+++ b/src/alpaka/test/alpaka/prefixScan_t.cc
@@ -4,7 +4,6 @@
 #include "AlpakaCore/alpakaWorkDivHelper.h"
 #include "AlpakaCore/prefixScan.h"
 
-using namespace cms::alpakatools;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 template <typename T>
@@ -35,8 +34,8 @@ struct testPrefixScan {
       c[i] = 1;
     alpaka::block::sync::syncBlockThreads(acc);
 
-    blockPrefixScan(acc, c, co, size, ws);
-    blockPrefixScan(acc, c, size, ws);
+    cms::alpakatools::blockPrefixScan(acc, c, co, size, ws);
+    cms::alpakatools::blockPrefixScan(acc, c, size, ws);
 
     assert(1 == c[0]);
     assert(1 == co[0]);
@@ -196,7 +195,7 @@ int main() {
     alpaka::queue::enqueue(
 			   queue,
 			   alpaka::kernel::createTaskKernel<Acc1>(workDivMultiBlock,
-								  multiBlockPrefixScanFirstStep<uint32_t>(),
+								  cms::alpakatools::multiBlockPrefixScanFirstStep<uint32_t>(),
 								  input_d,
 								  output1_d,
 								  num_items));
@@ -207,7 +206,7 @@ int main() {
     alpaka::queue::enqueue(
 			   queue,
 			   alpaka::kernel::createTaskKernel<Acc1>(workDivMultiBlockSecondStep,
-								  multiBlockPrefixScanSecondStep<uint32_t>(),
+								  cms::alpakatools::multiBlockPrefixScanSecondStep<uint32_t>(),
 								  input_d,
 								  output1_d,
 								  num_items,

--- a/src/alpaka/test/alpaka/prefixScan_t.cc
+++ b/src/alpaka/test/alpaka/prefixScan_t.cc
@@ -86,7 +86,7 @@ struct init {
   template <typename T_Acc>
   ALPAKA_FN_ACC void operator()(const T_Acc& acc, uint32_t* v, uint32_t val, uint32_t n) const {
 
-    cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, n, [&](uint32_t index) {
+    cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, n, [&](uint32_t index) {
 	v[index] = val;
 
 	if (index == 0)
@@ -99,7 +99,7 @@ struct verify {
   template <typename T_Acc>
   ALPAKA_FN_ACC void operator()(const T_Acc& acc, uint32_t const* v, uint32_t n) const {
 
-    cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, n, [&](uint32_t index) {
+    cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, n, [&](uint32_t index) {
 	assert(v[index] == index + 1);
 
 	if (index == 0)

--- a/src/alpaka/test/alpaka/prefixScan_t.cc
+++ b/src/alpaka/test/alpaka/prefixScan_t.cc
@@ -26,9 +26,7 @@ struct testPrefixScan {
     auto&& c = alpaka::block::shared::st::allocVar<T[1024], __COUNTER__>(acc);
     auto&& co = alpaka::block::shared::st::allocVar<T[1024], __COUNTER__>(acc);
 
-    cms::alpakatools::for_each_element_1D_block_stride(acc, size, [&](uint32_t i) {
-        c[i] = 1;
-      });
+    cms::alpakatools::for_each_element_1D_block_stride(acc, size, [&](uint32_t i) { c[i] = 1; });
 
     alpaka::block::sync::syncBlockThreads(acc);
 
@@ -39,11 +37,10 @@ struct testPrefixScan {
     assert(1 == co[0]);
 
     cms::alpakatools::for_each_element_1D_block_stride(acc, size, 1u, [&](uint32_t i) {
-	assert(c[i] == c[i - 1] + 1);
-	assert(c[i] == i + 1);
-	assert(c[i] = co[i]);
-      });
-
+      assert(c[i] == c[i - 1] + 1);
+      assert(c[i] == i + 1);
+      assert(c[i] = co[i]);
+    });
   }
 };
 
@@ -85,26 +82,24 @@ struct testWarpPrefixScan {
 struct init {
   template <typename T_Acc>
   ALPAKA_FN_ACC void operator()(const T_Acc& acc, uint32_t* v, uint32_t val, uint32_t n) const {
-
     cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, n, [&](uint32_t index) {
-	v[index] = val;
+      v[index] = val;
 
-	if (index == 0)
-	  printf("init\n");
-      });
+      if (index == 0)
+        printf("init\n");
+    });
   }
 };
 
 struct verify {
   template <typename T_Acc>
   ALPAKA_FN_ACC void operator()(const T_Acc& acc, uint32_t const* v, uint32_t n) const {
-
     cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, n, [&](uint32_t index) {
-	assert(v[index] == index + 1);
+      assert(v[index] == index + 1);
 
-	if (index == 0)
-	  printf("verify\n");
-      });
+      if (index == 0)
+        printf("verify\n");
+    });
   }
 };
 

--- a/src/alpakatest/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpakatest/AlpakaCore/alpakaWorkDivHelper.h
@@ -33,7 +33,7 @@ namespace cms {
      * (should obviously only be needed for debug / printout).
      */
     template <typename T_Acc>
-      ALPAKA_FN_ACC bool once_per_block_1D(const T_Acc& acc, uint32_t i) {
+    ALPAKA_FN_ACC bool once_per_block_1D(const T_Acc& acc, uint32_t i) {
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
       return (i % blockDimension == 0);
     }
@@ -43,14 +43,14 @@ namespace cms {
      * Warning: the max index is not truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block(const T_Acc& acc, const Vec<T_Dim>& elementIdxShift) {
+    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block(const T_Acc& acc,
+                                                                                 const Vec<T_Dim>& elementIdxShift) {
       Vec<T_Dim> firstElementIdxVec = Vec<T_Dim>::zeros();
       Vec<T_Dim> endElementIdxUncutVec = Vec<T_Dim>::zeros();
 
       // Loop on all grid dimensions.
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-
-	// Take into account the thread index in block.
+        // Take into account the thread index in block.
         const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[dimIndex]);
         const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[dimIndex]);
 
@@ -58,7 +58,7 @@ namespace cms {
         // Obviously relevant for CPU only.
         // For GPU, threadDimension = 1, and elementIdx = firstElementIdx = threadIdx + elementIdxShift.
         const uint32_t firstElementIdxLocal = threadIdxLocal * threadDimension;
-	const uint32_t firstElementIdx = firstElementIdxLocal + elementIdxShift[dimIndex]; // Add the shift!
+        const uint32_t firstElementIdx = firstElementIdxLocal + elementIdxShift[dimIndex];  // Add the shift!
         const uint32_t endElementIdxUncut = firstElementIdx + threadDimension;
 
         firstElementIdxVec[dimIndex] = firstElementIdx;
@@ -69,14 +69,13 @@ namespace cms {
       return {firstElementIdxVec, endElementIdxUncutVec};
     }
 
-
     /*
      * Computes the range of the elements indexes, local to the block.
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, const Vec<T_Dim>& elementIdxShift) {
-
+    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block_truncated(
+        const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, const Vec<T_Dim>& elementIdxShift) {
       // Check dimension
       static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
                     "Accelerator and maxNumberOfElements need to have same dimension.");
@@ -91,23 +90,21 @@ namespace cms {
       return {firstElementIdxLocalVec, endElementIdxLocalVec};
     }
 
-
     /*
      * Computes the range of the elements indexes in grid.
      * Warning: the max index is not truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid(const T_Acc& acc, Vec<T_Dim>& elementIdxShift) {
-
+    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid(const T_Acc& acc,
+                                                                                Vec<T_Dim>& elementIdxShift) {
       // Loop on all grid dimensions.
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-
         // Take into account the block index in grid.
         const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[dimIndex]);
         const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[dimIndex]);
 
-	// Shift to get global indices in grid (instead of local to the block)
-	elementIdxShift[dimIndex] += blockIdxInGrid * blockDimension;
+        // Shift to get global indices in grid (instead of local to the block)
+        elementIdxShift[dimIndex] += blockIdxInGrid * blockDimension;
       }
 
       // Return element indexes, shifted by elementIdxShift.
@@ -119,8 +116,8 @@ namespace cms {
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, Vec<T_Dim>& elementIdxShift) {
-
+    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(
+        const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, Vec<T_Dim>& elementIdxShift) {
       // Check dimension
       static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
                     "Accelerator and maxNumberOfElements need to have same dimension.");
@@ -135,18 +132,16 @@ namespace cms {
       return {firstElementIdxGlobalVec, endElementIdxGlobalVec};
     }
 
-
     /*
      * Computes the range of the element(s) index(es) in grid.
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
-      
+    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(
+        const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
       Vec<T_Dim> elementIdxShift = Vec<T_Dim>::zeros();
       return element_index_range_in_grid_truncated(acc, maxNumberOfElements, elementIdxShift);
     }
-
 
     /*********************************************
      *     1D HELPERS, LOOP ON ALL CPU ELEMENTS
@@ -158,13 +153,15 @@ namespace cms {
      * Indexes are local to the BLOCK.
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
-
-      const auto& [firstElementIdx, endElementIdx] =
-	cms::alpakatools::element_index_range_in_block_truncated(acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIdxShift));
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
+                                                                    const uint32_t maxNumberOfElements,
+                                                                    const uint32_t elementIdxShift,
+                                                                    const Func& func) {
+      const auto& [firstElementIdx, endElementIdx] = cms::alpakatools::element_index_range_in_block_truncated(
+          acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIdxShift));
 
       for (uint32_t elementIdx = firstElementIdx[0u]; elementIdx < endElementIdx[0u]; ++elementIdx) {
-	func(elementIdx);
+        func(elementIdx);
       }
     }
 
@@ -172,8 +169,10 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
-      const uint32_t elementIdxShift = 0; 
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc,
+                                                                    const uint32_t maxNumberOfElements,
+                                                                    const Func& func) {
+      const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
@@ -183,8 +182,10 @@ namespace cms {
      * Indexes are expressed in GRID 'frame-of-reference'.
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const uint32_t maxNumberOfElements, uint32_t elementIdxShift, const Func& func) {
-
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
+                                                                   const uint32_t maxNumberOfElements,
+                                                                   uint32_t elementIdxShift,
+                                                                   const Func& func) {
       // Take into account the block index in grid to compute the element indices.
       const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
@@ -197,11 +198,12 @@ namespace cms {
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
-      const uint32_t elementIdxShift = 0; 
+    ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc,
+                                                                   const uint32_t maxNumberOfElements,
+                                                                   const Func& func) {
+      const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, maxNumberOfElements, elementIdxShift, func);
     }
-
 
     /******************************************************************************
      *     1D HELPERS, LOOP ON ALL CPU ELEMENTS, AND ELEMENT/THREAD STRIDED ACCESS
@@ -214,37 +216,38 @@ namespace cms {
      * Indexes are local to the BLOCK.
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
-
+    ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
+                                                        const uint32_t maxNumberOfElements,
+                                                        const uint32_t elementIdxShift,
+                                                        const Func& func) {
       // Get thread / element indices in block.
-      const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
-	cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
-      
+      const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
+          cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
+
       // Stride = block size.
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
 
       // Strided access.
       for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-	   threadIdx < maxNumberOfElements;
-	   threadIdx += blockDimension, endElementIdx += blockDimension) {
-	  
-	// (CPU) Loop on all elements.
-	for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
-	  func(i);
-	}
+           threadIdx < maxNumberOfElements;
+           threadIdx += blockDimension, endElementIdx += blockDimension) {
+        // (CPU) Loop on all elements.
+        for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
+          func(i);
+        }
       }
-      
     }
 
     /*
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
-      const uint32_t elementIdxShift = 0;      
+    ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc,
+                                                        const uint32_t maxNumberOfElements,
+                                                        const Func& func) {
+      const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_1D_block_stride(acc, maxNumberOfElements, elementIdxShift, func);
     }
-    
 
     /*
      * (CPU) Loop on all elements + (CPU/GPU) Strided access.
@@ -253,42 +256,41 @@ namespace cms {
      * Indexes are local to the GRID.
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
-
+    ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
+                                                       const uint32_t maxNumberOfElements,
+                                                       const uint32_t elementIdxShift,
+                                                       const Func& func) {
       Vec1 elementIdxShiftVec = Vec1::all(elementIdxShift);
-      
+
       // Get thread / element indices in block.
-      const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
-	cms::alpakatools::element_index_range_in_grid(acc, elementIdxShiftVec);
-      
+      const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
+          cms::alpakatools::element_index_range_in_grid(acc, elementIdxShiftVec);
+
       // Stride = grid size.
       const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
 
       // Strided access.
       for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
-	   threadIdx < maxNumberOfElements;
-	   threadIdx += gridDimension, endElementIdx += gridDimension) {
-	  
-	// (CPU) Loop on all elements.
-	for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
-	  func(i);
-	}
+           threadIdx < maxNumberOfElements;
+           threadIdx += gridDimension, endElementIdx += gridDimension) {
+        // (CPU) Loop on all elements.
+        for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
+          func(i);
+        }
       }
-      
-    }    
-    
+    }
+
     /*
      * Overload for elementIdxShift = 0
      */
     template <typename T_Acc, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) { 
-      const uint32_t elementIdxShift = 0; 
+    ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc,
+                                                       const uint32_t maxNumberOfElements,
+                                                       const Func& func) {
+      const uint32_t elementIdxShift = 0;
       cms::alpakatools::for_each_element_1D_grid_stride(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
-    
-
-    
   }  // namespace alpakatools
 }  // namespace cms
 

--- a/src/alpakatest/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpakatest/AlpakaCore/alpakaWorkDivHelper.h
@@ -28,14 +28,20 @@ namespace cms {
 #endif
     }
 
+    template <typename T_Acc>
+      ALPAKA_FN_ACC bool once_per_block_1D(const T_Acc& acc, uint32_t i) {
+      const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+      return (i % blockDimension == 0);
+    }
+
     /*
      * Computes the range of the element(s) global index(es) in grid.
+     * Warning: the max index is not truncated by the max number of elements of interest.
      */
-    template <typename T_Acc, typename T_Dim>
-    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_global_index_range_truncated(const T_Acc& acc,
-                                                                               const Vec<T_Dim>& maxNumberOfElements) {
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
+    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_global_index_range(const T_Acc& acc) {
       Vec<T_Dim> firstElementIdxGlobalVec = Vec<T_Dim>::zeros();
-      Vec<T_Dim> endElementIdxGlobalVec = Vec<T_Dim>::zeros();
+      Vec<T_Dim> endElementIdxUncutGlobalVec = Vec<T_Dim>::zeros();
 
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
         // Global thread index in grid (along dimension dimIndex).
@@ -44,18 +50,214 @@ namespace cms {
 
         // Global element index in grid (along dimension dimIndex).
         // Obviously relevant for CPU only.
-        // For GPU, threadDimension = 1, and firstElementIdxGlobal = endElementIdxGlobal = threadIndexGlobal.
+        // For GPU, threadDimension = 1, and endElementIdxGlobal = firstElementIdxLocal + 1.
         const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
-        const uint32_t endElementIdxGlobalUncut = firstElementIdxGlobal + threadDimension;
-        const uint32_t endElementIdxGlobal = std::min(endElementIdxGlobalUncut, maxNumberOfElements[dimIndex]);
+        const uint32_t endElementIdxUncutGlobal = firstElementIdxGlobal + threadDimension;
 
         firstElementIdxGlobalVec[dimIndex] = firstElementIdxGlobal;
-        endElementIdxGlobalVec[dimIndex] = endElementIdxGlobal;
+        endElementIdxUncutGlobalVec[dimIndex] = endElementIdxUncutGlobal;
+      }
+
+      return {firstElementIdxGlobalVec, endElementIdxUncutGlobalVec};
+    }
+
+    /*
+     * Computes the range of the element(s) global index(es) in grid.
+     * Truncated by the max number of elements of interest.
+     */
+    template <typename T_Acc, typename T_Dim>
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_global_index_range_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
+      static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
+                    "Accelerator and maxNumberOfElements need to have same dimension.");
+      auto&& [firstElementIdxGlobalVec, endElementIdxGlobalVec] = element_global_index_range(acc);
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+        endElementIdxGlobalVec[dimIndex] = std::min(endElementIdxGlobalVec[dimIndex], maxNumberOfElements[dimIndex]);
       }
 
       return {firstElementIdxGlobalVec, endElementIdxGlobalVec};
     }
 
+
+    /*
+     * Computes the range of the element(s) index(es) local to the block.
+     * Warning: the max index is not truncated by the max number of elements of interest.
+     */
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_local_index_range(const T_Acc& acc) {
+      Vec<T_Dim> firstElementIdxLocalVec = Vec<T_Dim>::zeros();
+      Vec<T_Dim> endElementIdxUncutLocalVec = Vec<T_Dim>::zeros();
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+        // Local thread index in block (along dimension dimIndex).
+        const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[dimIndex]);
+        const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[dimIndex]);
+
+        // Local element index in block (along dimension dimIndex).
+        // Obviously relevant for CPU only.
+        // For GPU, threadDimension = 1, and endElementIdxGlobal = firstElementIdxLocal + 1.
+        const uint32_t firstElementIdxLocal = threadIdxLocal * threadDimension;
+        const uint32_t endElementIdxUncutLocal = firstElementIdxLocal + threadDimension;
+
+        firstElementIdxLocalVec[dimIndex] = firstElementIdxLocal;
+        endElementIdxUncutLocalVec[dimIndex] = endElementIdxUncutLocal;
+      }
+
+      return {firstElementIdxLocalVec, endElementIdxUncutLocalVec};
+    }
+
+    /*
+     * Computes the range of the element(s) global index(es) in grid.
+     * Truncated by the max number of elements of interest.
+     */
+    template <typename T_Acc, typename T_Dim>
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_local_index_range_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
+      static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
+                    "Accelerator and maxNumberOfElements need to have same dimension.");
+      auto&& [firstElementIdxLocalVec, endElementIdxLocalVec] = element_local_index_range(acc);
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+        endElementIdxLocalVec[dimIndex] = std::min(endElementIdxLocalVec[dimIndex], maxNumberOfElements[dimIndex]);
+      }
+
+      return {firstElementIdxLocalVec, endElementIdxLocalVec};
+    }
+
+
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_global_index(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
+
+      const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
+      cms::alpakatools::element_global_index_range_truncated(acc, problemSize);
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+	const uint32_t firstElementIdx = firstElementIdxGlobal[dimIndex] + indexShift[dimIndex];
+	const uint32_t endElementIdx = endElementIdxGlobal[dimIndex] + indexShift[dimIndex];
+
+	for (uint32_t elementIdx = firstElementIdx; elementIdx < endElementIdx; ++elementIdx) {
+	  func(elementIdx);
+	}
+      }
+
+    }
+
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_local_index(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
+
+      const auto& [firstElementIdxLocal, endElementIdxLocal] =
+      cms::alpakatools::element_local_index_range_truncated(acc, problemSize);
+
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+	const uint32_t firstElementIdx = firstElementIdxLocal[dimIndex] + indexShift[dimIndex];
+	const uint32_t endElementIdx = endElementIdxLocal[dimIndex] + indexShift[dimIndex];
+
+	for (uint32_t elementIdx = firstElementIdx; elementIdx < endElementIdx; ++elementIdx) {
+	  func(elementIdx);
+	}
+      }
+
+    }
+
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_grid_stride(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
+      
+      const auto &[firstElementIdxNoStrideNoShift, endElementIdxNoStrideNoShift] =
+      cms::alpakatools::element_global_index_range(acc);
+      
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+	const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[dimIndex]);
+	const uint32_t firstElementIdxNoStride = firstElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
+	const uint32_t endElementIdxNoStride = endElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
+
+	for (uint32_t threadIdx = firstElementIdxNoStride, endElementIdx = endElementIdxNoStride;
+	     threadIdx < problemSize[dimIndex];
+	     threadIdx += gridDimension, endElementIdx += gridDimension) {
+	  
+	  for (uint32_t i = threadIdx; i < std::min(endElementIdx, problemSize[dimIndex]); ++i) {
+	    func(i);
+	  }
+	}
+      }
+      
+    }
+
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_block_stride(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
+
+      const auto &[firstElementIdxNoStrideNoShift, endElementIdxNoStrideNoShift] =
+      cms::alpakatools::element_local_index_range(acc);
+      
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+	const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[dimIndex]);
+	const uint32_t firstElementIdxNoStride = firstElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
+	const uint32_t endElementIdxNoStride = endElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
+
+	for (uint32_t threadIdx = firstElementIdxNoStride, endElementIdx = endElementIdxNoStride;
+	     threadIdx < problemSize[dimIndex];
+	     threadIdx += blockDimension, endElementIdx += blockDimension) {
+	  
+	  for (uint32_t i = threadIdx; i < std::min(endElementIdx, problemSize[dimIndex]); ++i) {
+	    func(i);
+	  }
+	}
+      }
+      
+    }
+
+
+    // 1D HELPERS    
+
+    // LOOP ON ELEMENTS ONLY, GLOBAL INDICES (per grid)
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_global_index(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
+      cms::alpakatools::for_each_element_in_thread_global_index(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
+    }
+
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_global_index(const T_Acc& acc, const T_Dim problemSize, Func func) {
+      T_Dim indexShift = 0; 
+      cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, problemSize, indexShift, func);
+    }
+
+    // LOOP ON ELEMENTS ONLY, LOCAL INDICES (per block)
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_local_index(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
+      cms::alpakatools::for_each_element_in_thread_local_index(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
+    }
+
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_local_index(const T_Acc& acc, const T_Dim problemSize, Func func) {
+      T_Dim indexShift = 0; 
+      cms::alpakatools::for_each_element_in_thread_1D_local_index(acc, problemSize, indexShift, func);
+    }
+
+    
+
+    // HANDLES THREAD AND ELEMENTS INDICES FOR STRIDED ACCESS, GLOBAL INDICES (per grid)
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
+      cms::alpakatools::for_each_element_grid_stride(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
+    }
+
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const T_Dim problemSize, Func func) { 
+      T_Dim indexShift = 0; 
+      cms::alpakatools::for_each_element_1D_grid_stride(acc, problemSize, indexShift, func);
+    }
+
+    // HANDLES THREAD AND ELEMENTS INDICES FOR STRIDED ACCESS, LOCAL INDICES (per block)
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
+      cms::alpakatools::for_each_element_block_stride(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
+    }
+
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const T_Dim problemSize, Func func) {
+      T_Dim indexShift = 0;      
+      cms::alpakatools::for_each_element_1D_block_stride(acc, problemSize, indexShift, func);
+    }
+
+    
   }  // namespace alpakatools
 }  // namespace cms
 

--- a/src/alpakatest/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpakatest/AlpakaCore/alpakaWorkDivHelper.h
@@ -28,6 +28,10 @@ namespace cms {
 #endif
     }
 
+    /*
+     * 1D helper to only access 1 element per block 
+     * (should obviously only be needed for debug / printout).
+     */
     template <typename T_Acc>
       ALPAKA_FN_ACC bool once_per_block_1D(const T_Acc& acc, uint32_t i) {
       const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
@@ -35,227 +39,254 @@ namespace cms {
     }
 
     /*
-     * Computes the range of the element(s) global index(es) in grid.
+     * Computes the range of the elements indexes, local to the block.
      * Warning: the max index is not truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-    ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_global_index_range(const T_Acc& acc) {
-      Vec<T_Dim> firstElementIdxGlobalVec = Vec<T_Dim>::zeros();
-      Vec<T_Dim> endElementIdxUncutGlobalVec = Vec<T_Dim>::zeros();
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block(const T_Acc& acc, const Vec<T_Dim>& elementIdxShift) {
+      Vec<T_Dim> firstElementIdxVec = Vec<T_Dim>::zeros();
+      Vec<T_Dim> endElementIdxUncutVec = Vec<T_Dim>::zeros();
 
+      // Loop on all grid dimensions.
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-        // Global thread index in grid (along dimension dimIndex).
-        const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[dimIndex]);
+
+	// Take into account the thread index in block.
+        const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[dimIndex]);
         const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[dimIndex]);
 
-        // Global element index in grid (along dimension dimIndex).
+        // Compute the elements indexes in block.
         // Obviously relevant for CPU only.
-        // For GPU, threadDimension = 1, and endElementIdxGlobal = firstElementIdxLocal + 1.
-        const uint32_t firstElementIdxGlobal = threadIdxGlobal * threadDimension;
-        const uint32_t endElementIdxUncutGlobal = firstElementIdxGlobal + threadDimension;
+        // For GPU, threadDimension = 1, and elementIdx = firstElementIdx = threadIdx + elementIdxShift.
+        const uint32_t firstElementIdxLocal = threadIdxLocal * threadDimension;
+	const uint32_t firstElementIdx = firstElementIdxLocal + elementIdxShift[dimIndex]; // Add the shift!
+        const uint32_t endElementIdxUncut = firstElementIdx + threadDimension;
 
-        firstElementIdxGlobalVec[dimIndex] = firstElementIdxGlobal;
-        endElementIdxUncutGlobalVec[dimIndex] = endElementIdxUncutGlobal;
+        firstElementIdxVec[dimIndex] = firstElementIdx;
+        endElementIdxUncutVec[dimIndex] = endElementIdxUncut;
       }
 
-      return {firstElementIdxGlobalVec, endElementIdxUncutGlobalVec};
+      // Return element indexes, shifted by elementIdxShift.
+      return {firstElementIdxVec, endElementIdxUncutVec};
     }
 
+
     /*
-     * Computes the range of the element(s) global index(es) in grid.
+     * Computes the range of the elements indexes, local to the block.
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_global_index_range_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, const Vec<T_Dim>& elementIdxShift) {
+
+      // Check dimension
       static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
                     "Accelerator and maxNumberOfElements need to have same dimension.");
-      auto&& [firstElementIdxGlobalVec, endElementIdxGlobalVec] = element_global_index_range(acc);
+      auto&& [firstElementIdxLocalVec, endElementIdxLocalVec] = element_index_range_in_block(acc, elementIdxShift);
 
+      // Truncate
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+        endElementIdxLocalVec[dimIndex] = std::min(endElementIdxLocalVec[dimIndex], maxNumberOfElements[dimIndex]);
+      }
+
+      // Return element indexes, shifted by elementIdxShift, and truncated by maxNumberOfElements.
+      return {firstElementIdxLocalVec, endElementIdxLocalVec};
+    }
+
+
+    /*
+     * Computes the range of the elements indexes in grid.
+     * Warning: the max index is not truncated by the max number of elements of interest.
+     */
+    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid(const T_Acc& acc, Vec<T_Dim>& elementIdxShift) {
+
+      // Loop on all grid dimensions.
+      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
+
+        // Take into account the block index in grid.
+        const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[dimIndex]);
+        const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[dimIndex]);
+
+	// Shift to get global indices in grid (instead of local to the block)
+	elementIdxShift[dimIndex] += blockIdxInGrid * blockDimension;
+      }
+
+      // Return element indexes, shifted by elementIdxShift.
+      return element_index_range_in_block(acc, elementIdxShift);
+    }
+
+    /*
+     * Computes the range of the elements indexes in grid.
+     * Truncated by the max number of elements of interest.
+     */
+    template <typename T_Acc, typename T_Dim>
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, Vec<T_Dim>& elementIdxShift) {
+
+      // Check dimension
+      static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
+                    "Accelerator and maxNumberOfElements need to have same dimension.");
+      auto&& [firstElementIdxGlobalVec, endElementIdxGlobalVec] = element_index_range_in_grid(acc, elementIdxShift);
+
+      // Truncate
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
         endElementIdxGlobalVec[dimIndex] = std::min(endElementIdxGlobalVec[dimIndex], maxNumberOfElements[dimIndex]);
       }
 
+      // Return element indexes, shifted by elementIdxShift, and truncated by maxNumberOfElements.
       return {firstElementIdxGlobalVec, endElementIdxGlobalVec};
     }
 
 
     /*
-     * Computes the range of the element(s) index(es) local to the block.
-     * Warning: the max index is not truncated by the max number of elements of interest.
-     */
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_local_index_range(const T_Acc& acc) {
-      Vec<T_Dim> firstElementIdxLocalVec = Vec<T_Dim>::zeros();
-      Vec<T_Dim> endElementIdxUncutLocalVec = Vec<T_Dim>::zeros();
-
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-        // Local thread index in block (along dimension dimIndex).
-        const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[dimIndex]);
-        const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[dimIndex]);
-
-        // Local element index in block (along dimension dimIndex).
-        // Obviously relevant for CPU only.
-        // For GPU, threadDimension = 1, and endElementIdxGlobal = firstElementIdxLocal + 1.
-        const uint32_t firstElementIdxLocal = threadIdxLocal * threadDimension;
-        const uint32_t endElementIdxUncutLocal = firstElementIdxLocal + threadDimension;
-
-        firstElementIdxLocalVec[dimIndex] = firstElementIdxLocal;
-        endElementIdxUncutLocalVec[dimIndex] = endElementIdxUncutLocal;
-      }
-
-      return {firstElementIdxLocalVec, endElementIdxUncutLocalVec};
-    }
-
-    /*
-     * Computes the range of the element(s) global index(es) in grid.
+     * Computes the range of the element(s) index(es) in grid.
      * Truncated by the max number of elements of interest.
      */
     template <typename T_Acc, typename T_Dim>
-      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_local_index_range_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
-      static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
-                    "Accelerator and maxNumberOfElements need to have same dimension.");
-      auto&& [firstElementIdxLocalVec, endElementIdxLocalVec] = element_local_index_range(acc);
-
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-        endElementIdxLocalVec[dimIndex] = std::min(endElementIdxLocalVec[dimIndex], maxNumberOfElements[dimIndex]);
-      }
-
-      return {firstElementIdxLocalVec, endElementIdxLocalVec};
-    }
-
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_global_index(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
-
-      const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-      cms::alpakatools::element_global_index_range_truncated(acc, problemSize);
-
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-	const uint32_t firstElementIdx = firstElementIdxGlobal[dimIndex] + indexShift[dimIndex];
-	const uint32_t endElementIdx = endElementIdxGlobal[dimIndex] + indexShift[dimIndex];
-
-	for (uint32_t elementIdx = firstElementIdx; elementIdx < endElementIdx; ++elementIdx) {
-	  func(elementIdx);
-	}
-      }
-
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_local_index(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
-
-      const auto& [firstElementIdxLocal, endElementIdxLocal] =
-      cms::alpakatools::element_local_index_range_truncated(acc, problemSize);
-
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-	const uint32_t firstElementIdx = firstElementIdxLocal[dimIndex] + indexShift[dimIndex];
-	const uint32_t endElementIdx = endElementIdxLocal[dimIndex] + indexShift[dimIndex];
-
-	for (uint32_t elementIdx = firstElementIdx; elementIdx < endElementIdx; ++elementIdx) {
-	  func(elementIdx);
-	}
-      }
-
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_grid_stride(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
+      ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements) {
       
-      const auto &[firstElementIdxNoStrideNoShift, endElementIdxNoStrideNoShift] =
-      cms::alpakatools::element_global_index_range(acc);
-      
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-	const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[dimIndex]);
-	const uint32_t firstElementIdxNoStride = firstElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
-	const uint32_t endElementIdxNoStride = endElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
+      Vec<T_Dim> elementIdxShift = Vec<T_Dim>::zeros();
+      return element_index_range_in_grid_truncated(acc, maxNumberOfElements, elementIdxShift);
+    }
 
-	for (uint32_t threadIdx = firstElementIdxNoStride, endElementIdx = endElementIdxNoStride;
-	     threadIdx < problemSize[dimIndex];
-	     threadIdx += gridDimension, endElementIdx += gridDimension) {
+
+    /*********************************************
+     *     1D HELPERS, LOOP ON ALL CPU ELEMENTS
+     ********************************************/
+
+    /*
+     * Loop on all (CPU) elements.
+     * Elements loop makes sense in CPU case only. In GPU case, elementIdx = firstElementIdx = threadIdx + shift.
+     * Indexes are local to the BLOCK.
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
+
+      const auto& [firstElementIdx, endElementIdx] =
+	cms::alpakatools::element_index_range_in_block_truncated(acc, Vec1::all(maxNumberOfElements), Vec1::all(elementIdxShift));
+
+      for (uint32_t elementIdx = firstElementIdx[0u]; elementIdx < endElementIdx[0u]; ++elementIdx) {
+	func(elementIdx);
+      }
+    }
+
+    /*
+     * Overload for elementIdxShift = 0
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_block(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
+      const uint32_t elementIdxShift = 0; 
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
+    }
+
+    /*
+     * Loop on all (CPU) elements.
+     * Elements loop makes sense in CPU case only. In GPU case, elementIdx = firstElementIdx = threadIdx + shift.
+     * Indexes are expressed in GRID 'frame-of-reference'.
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const uint32_t maxNumberOfElements, uint32_t elementIdxShift, const Func& func) {
+
+      // Take into account the block index in grid to compute the element indices.
+      const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+      const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+      elementIdxShift += blockIdxInGrid * blockDimension;
+
+      for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
+    }
+
+    /*
+     * Overload for elementIdxShift = 0
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_in_thread_1D_index_in_grid(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
+      const uint32_t elementIdxShift = 0; 
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, maxNumberOfElements, elementIdxShift, func);
+    }
+
+
+    /******************************************************************************
+     *     1D HELPERS, LOOP ON ALL CPU ELEMENTS, AND ELEMENT/THREAD STRIDED ACCESS
+     ******************************************************************************/
+
+    /*
+     * (CPU) Loop on all elements + (CPU/GPU) Strided access.
+     * Elements loop makes sense in CPU case only. In GPU case, elementIdx = firstElementIdx = threadIdx + shift.
+     * Stride to full problem size, by BLOCK size.
+     * Indexes are local to the BLOCK.
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
+
+      // Get thread / element indices in block.
+      const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
+	cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
+      
+      // Stride = block size.
+      const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+
+      // Strided access.
+      for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
+	   threadIdx < maxNumberOfElements;
+	   threadIdx += blockDimension, endElementIdx += blockDimension) {
 	  
-	  for (uint32_t i = threadIdx; i < std::min(endElementIdx, problemSize[dimIndex]); ++i) {
-	    func(i);
-	  }
+	// (CPU) Loop on all elements.
+	for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
+	  func(i);
 	}
       }
       
     }
 
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_block_stride(const T_Acc& acc, const Vec<T_Dim>& problemSize, const Vec<T_Dim>& indexShift, Func func) {
+    /*
+     * Overload for elementIdxShift = 0
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) {
+      const uint32_t elementIdxShift = 0;      
+      cms::alpakatools::for_each_element_1D_block_stride(acc, maxNumberOfElements, elementIdxShift, func);
+    }
+    
 
-      const auto &[firstElementIdxNoStrideNoShift, endElementIdxNoStrideNoShift] =
-      cms::alpakatools::element_local_index_range(acc);
+    /*
+     * (CPU) Loop on all elements + (CPU/GPU) Strided access.
+     * Elements loop makes sense in CPU case only. In GPU case, elementIdx = firstElementIdx = threadIdx + shift.
+     * Stride to full problem size, by GRID size.
+     * Indexes are local to the GRID.
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const uint32_t elementIdxShift, const Func& func) {
+
+      Vec1 elementIdxShiftVec = Vec1::all(elementIdxShift);
       
-      for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
-	const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[dimIndex]);
-	const uint32_t firstElementIdxNoStride = firstElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
-	const uint32_t endElementIdxNoStride = endElementIdxNoStrideNoShift[dimIndex] + indexShift[dimIndex];
+      // Get thread / element indices in block.
+      const auto &[firstElementIdxNoStride, endElementIdxNoStride] =
+	cms::alpakatools::element_index_range_in_grid(acc, elementIdxShiftVec);
+      
+      // Stride = grid size.
+      const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
 
-	for (uint32_t threadIdx = firstElementIdxNoStride, endElementIdx = endElementIdxNoStride;
-	     threadIdx < problemSize[dimIndex];
-	     threadIdx += blockDimension, endElementIdx += blockDimension) {
+      // Strided access.
+      for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
+	   threadIdx < maxNumberOfElements;
+	   threadIdx += gridDimension, endElementIdx += gridDimension) {
 	  
-	  for (uint32_t i = threadIdx; i < std::min(endElementIdx, problemSize[dimIndex]); ++i) {
-	    func(i);
-	  }
+	// (CPU) Loop on all elements.
+	for (uint32_t i = threadIdx; i < std::min(endElementIdx, maxNumberOfElements); ++i) {
+	  func(i);
 	}
       }
       
-    }
-
-
-    // 1D HELPERS    
-
-    // LOOP ON ELEMENTS ONLY, GLOBAL INDICES (per grid)
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_global_index(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
-      cms::alpakatools::for_each_element_in_thread_global_index(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_global_index(const T_Acc& acc, const T_Dim problemSize, Func func) {
-      T_Dim indexShift = 0; 
-      cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, problemSize, indexShift, func);
-    }
-
-    // LOOP ON ELEMENTS ONLY, LOCAL INDICES (per block)
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_local_index(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
-      cms::alpakatools::for_each_element_in_thread_local_index(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_in_thread_1D_local_index(const T_Acc& acc, const T_Dim problemSize, Func func) {
-      T_Dim indexShift = 0; 
-      cms::alpakatools::for_each_element_in_thread_1D_local_index(acc, problemSize, indexShift, func);
+    }    
+    
+    /*
+     * Overload for elementIdxShift = 0
+     */
+    template <typename T_Acc, typename Func>
+      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const uint32_t maxNumberOfElements, const Func& func) { 
+      const uint32_t elementIdxShift = 0; 
+      cms::alpakatools::for_each_element_1D_grid_stride(acc, maxNumberOfElements, elementIdxShift, func);
     }
 
     
-
-    // HANDLES THREAD AND ELEMENTS INDICES FOR STRIDED ACCESS, GLOBAL INDICES (per grid)
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
-      cms::alpakatools::for_each_element_grid_stride(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_grid_stride(const T_Acc& acc, const T_Dim problemSize, Func func) { 
-      T_Dim indexShift = 0; 
-      cms::alpakatools::for_each_element_1D_grid_stride(acc, problemSize, indexShift, func);
-    }
-
-    // HANDLES THREAD AND ELEMENTS INDICES FOR STRIDED ACCESS, LOCAL INDICES (per block)
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const T_Dim problemSize, T_Dim indexShift, Func func) {     
-      cms::alpakatools::for_each_element_block_stride(acc, Vec1::all(problemSize), Vec1::all(indexShift), func);
-    }
-
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>, typename Func>
-      ALPAKA_FN_ACC void for_each_element_1D_block_stride(const T_Acc& acc, const T_Dim problemSize, Func func) {
-      T_Dim indexShift = 0;      
-      cms::alpakatools::for_each_element_1D_block_stride(acc, problemSize, indexShift, func);
-    }
 
     
   }  // namespace alpakatools

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
@@ -13,9 +13,8 @@ namespace {
                                   unsigned int numElements) const {
       // Global element index in 1D grid.
       // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t i) {
-	  c[i] = a[i] + b[i];
-	});
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(
+          acc, numElements, [&](uint32_t i) { c[i] = a[i] + b[i]; });
     }
   };
 
@@ -29,7 +28,7 @@ namespace {
       // Global element index in 2D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
       const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-	cms::alpakatools::element_index_range_in_grid_truncated(acc, Vec2::all(numElements));
+          cms::alpakatools::element_index_range_in_grid_truncated(acc, Vec2::all(numElements));
 
       for (uint32_t col = firstElementIdxGlobal[0u]; col < endElementIdxGlobal[0u]; ++col) {
         for (uint32_t row = firstElementIdxGlobal[1u]; row < endElementIdxGlobal[1u]; ++row) {
@@ -73,12 +72,12 @@ namespace {
       // Global element index in 1D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
       cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t row) {
-	  T_Data tmp = 0;
-	  for (unsigned int i = 0; i < numElements; ++i) {
-	    tmp += a[row * numElements + i] * b[i];
-	  }
-	  c[row] = tmp;
-	});
+        T_Data tmp = 0;
+        for (unsigned int i = 0; i < numElements; ++i) {
+          tmp += a[row * numElements + i] * b[i];
+        }
+        c[row] = tmp;
+      });
     }
   };
 
@@ -94,12 +93,12 @@ namespace {
       ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
         // Global element index in 1D grid.
         // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-	cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t i) {
-	    // theoreticalResult = i+i^2 = i*(i+1)
-	    if (result[i] != i * (i + 1)) {
-	      printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);
-	    }
-	  });
+        cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t i) {
+          // theoreticalResult = i+i^2 = i*(i+1)
+          if (result[i] != i * (i + 1)) {
+            printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);
+          }
+        });
       }
     };
 

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
@@ -13,7 +13,7 @@ namespace {
                                   unsigned int numElements) const {
       // Global element index in 1D grid.
       // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-      cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t i) {
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t i) {
 	  c[i] = a[i] + b[i];
 	});
     }
@@ -29,7 +29,7 @@ namespace {
       // Global element index in 2D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
       const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-	cms::alpakatools::element_global_index_range_truncated(acc, Vec2::all(numElements));
+	cms::alpakatools::element_index_range_in_grid_truncated(acc, Vec2::all(numElements));
 
       for (uint32_t col = firstElementIdxGlobal[0u]; col < endElementIdxGlobal[0u]; ++col) {
         for (uint32_t row = firstElementIdxGlobal[1u]; row < endElementIdxGlobal[1u]; ++row) {
@@ -49,7 +49,7 @@ namespace {
       // Global element index in 2D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
       const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-          cms::alpakatools::element_global_index_range_truncated(acc, Vec2::all(numElements));
+          cms::alpakatools::element_index_range_in_grid_truncated(acc, Vec2::all(numElements));
 
       for (uint32_t col = firstElementIdxGlobal[0u]; col < endElementIdxGlobal[0u]; ++col) {
         for (uint32_t row = firstElementIdxGlobal[1u]; row < endElementIdxGlobal[1u]; ++row) {
@@ -72,7 +72,7 @@ namespace {
                                   unsigned int numElements) const {
       // Global element index in 1D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-      cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t row) {
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t row) {
 	  T_Data tmp = 0;
 	  for (unsigned int i = 0; i < numElements; ++i) {
 	    tmp += a[row * numElements + i] * b[i];
@@ -94,7 +94,7 @@ namespace {
       ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
         // Global element index in 1D grid.
         // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-	cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t i) {
+	cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t i) {
 	    // theoreticalResult = i+i^2 = i*(i+1)
 	    if (result[i] != i * (i + 1)) {
 	      printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
@@ -13,12 +13,9 @@ namespace {
                                   unsigned int numElements) const {
       // Global element index in 1D grid.
       // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-      const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-          cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(numElements));
-
-      for (uint32_t i = firstElementIdxGlobal[0u]; i < endElementIdxGlobal[0u]; ++i) {
-        c[i] = a[i] + b[i];
-      }
+      cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t i) {
+	  c[i] = a[i] + b[i];
+	});
     }
   };
 
@@ -32,7 +29,7 @@ namespace {
       // Global element index in 2D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
       const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-          cms::alpakatools::element_global_index_range_truncated(acc, Vec2::all(numElements));
+	cms::alpakatools::element_global_index_range_truncated(acc, Vec2::all(numElements));
 
       for (uint32_t col = firstElementIdxGlobal[0u]; col < endElementIdxGlobal[0u]; ++col) {
         for (uint32_t row = firstElementIdxGlobal[1u]; row < endElementIdxGlobal[1u]; ++row) {
@@ -75,16 +72,13 @@ namespace {
                                   unsigned int numElements) const {
       // Global element index in 1D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-      const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-          cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(numElements));
-
-      for (uint32_t row = firstElementIdxGlobal[0u]; row < endElementIdxGlobal[0u]; ++row) {
-        T_Data tmp = 0;
-        for (unsigned int i = 0; i < numElements; ++i) {
-          tmp += a[row * numElements + i] * b[i];
-        }
-        c[row] = tmp;
-      }
+      cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t row) {
+	  T_Data tmp = 0;
+	  for (unsigned int i = 0; i < numElements; ++i) {
+	    tmp += a[row * numElements + i] * b[i];
+	  }
+	  c[row] = tmp;
+	});
     }
   };
 
@@ -100,15 +94,12 @@ namespace {
       ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
         // Global element index in 1D grid.
         // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-        const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-            cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(numElements));
-
-        for (uint32_t i = firstElementIdxGlobal[0u]; i < endElementIdxGlobal[0u]; ++i) {
-          // theoreticalResult = i+i^2 = i*(i+1)
-          if (result[i] != i * (i + 1)) {
-            printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);
-          }
-        }
+	cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t i) {
+	    // theoreticalResult = i+i^2 = i*(i+1)
+	    if (result[i] != i * (i + 1)) {
+	      printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);
+	    }
+	  });
       }
     };
 

--- a/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
@@ -13,9 +13,8 @@ namespace {
                                   unsigned int numElements) const {
       // Global element index in 1D grid.
       // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t i) {
-	  c[i] = a[i] + b[i];
-	});
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(
+          acc, numElements, [&](uint32_t i) { c[i] = a[i] + b[i]; });
     }
   };
 
@@ -29,7 +28,7 @@ namespace {
       // Global element index in 2D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
       const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-	cms::alpakatools::element_index_range_in_grid_truncated(acc, Vec2::all(numElements));
+          cms::alpakatools::element_index_range_in_grid_truncated(acc, Vec2::all(numElements));
 
       for (uint32_t col = firstElementIdxGlobal[0u]; col < endElementIdxGlobal[0u]; ++col) {
         for (uint32_t row = firstElementIdxGlobal[1u]; row < endElementIdxGlobal[1u]; ++row) {
@@ -73,12 +72,12 @@ namespace {
       // Global element index in 1D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
       cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t row) {
-	  T_Data tmp = 0;
-	  for (unsigned int i = 0; i < numElements; ++i) {
-	    tmp += a[row * numElements + i] * b[i];
-	  }
-	  c[row] = tmp;
-	});
+        T_Data tmp = 0;
+        for (unsigned int i = 0; i < numElements; ++i) {
+          tmp += a[row * numElements + i] * b[i];
+        }
+        c[row] = tmp;
+      });
     }
   };
 
@@ -94,12 +93,12 @@ namespace {
       ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
         // Global element index in 1D grid.
         // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-	cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t i) {
-	    // theoreticalResult = i+i^2 = i*(i+1)
-	    if (result[i] != i * (i + 1)) {
-	      printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);
-	    }
-	  });
+        cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t i) {
+          // theoreticalResult = i+i^2 = i*(i+1)
+          if (result[i] != i * (i + 1)) {
+            printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);
+          }
+        });
       }
     };
 

--- a/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
@@ -13,7 +13,7 @@ namespace {
                                   unsigned int numElements) const {
       // Global element index in 1D grid.
       // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-      cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t i) {
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t i) {
 	  c[i] = a[i] + b[i];
 	});
     }
@@ -29,7 +29,7 @@ namespace {
       // Global element index in 2D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
       const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-	cms::alpakatools::element_global_index_range_truncated(acc, Vec2::all(numElements));
+	cms::alpakatools::element_index_range_in_grid_truncated(acc, Vec2::all(numElements));
 
       for (uint32_t col = firstElementIdxGlobal[0u]; col < endElementIdxGlobal[0u]; ++col) {
         for (uint32_t row = firstElementIdxGlobal[1u]; row < endElementIdxGlobal[1u]; ++row) {
@@ -49,7 +49,7 @@ namespace {
       // Global element index in 2D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
       const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-          cms::alpakatools::element_global_index_range_truncated(acc, Vec2::all(numElements));
+          cms::alpakatools::element_index_range_in_grid_truncated(acc, Vec2::all(numElements));
 
       for (uint32_t col = firstElementIdxGlobal[0u]; col < endElementIdxGlobal[0u]; ++col) {
         for (uint32_t row = firstElementIdxGlobal[1u]; row < endElementIdxGlobal[1u]; ++row) {
@@ -72,7 +72,7 @@ namespace {
                                   unsigned int numElements) const {
       // Global element index in 1D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-      cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t row) {
+      cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t row) {
 	  T_Data tmp = 0;
 	  for (unsigned int i = 0; i < numElements; ++i) {
 	    tmp += a[row * numElements + i] * b[i];
@@ -94,7 +94,7 @@ namespace {
       ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
         // Global element index in 1D grid.
         // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-	cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t i) {
+	cms::alpakatools::for_each_element_in_thread_1D_index_in_grid(acc, numElements, [&](uint32_t i) {
 	    // theoreticalResult = i+i^2 = i*(i+1)
 	    if (result[i] != i * (i + 1)) {
 	      printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);

--- a/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
@@ -13,12 +13,9 @@ namespace {
                                   unsigned int numElements) const {
       // Global element index in 1D grid.
       // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-      const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-          cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(numElements));
-
-      for (uint32_t i = firstElementIdxGlobal[0u]; i < endElementIdxGlobal[0u]; ++i) {
-        c[i] = a[i] + b[i];
-      }
+      cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t i) {
+	  c[i] = a[i] + b[i];
+	});
     }
   };
 
@@ -32,7 +29,7 @@ namespace {
       // Global element index in 2D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
       const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-          cms::alpakatools::element_global_index_range_truncated(acc, Vec2::all(numElements));
+	cms::alpakatools::element_global_index_range_truncated(acc, Vec2::all(numElements));
 
       for (uint32_t col = firstElementIdxGlobal[0u]; col < endElementIdxGlobal[0u]; ++col) {
         for (uint32_t row = firstElementIdxGlobal[1u]; row < endElementIdxGlobal[1u]; ++row) {
@@ -75,16 +72,13 @@ namespace {
                                   unsigned int numElements) const {
       // Global element index in 1D grid.
       // NB: On GPU, threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-      const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-          cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(numElements));
-
-      for (uint32_t row = firstElementIdxGlobal[0u]; row < endElementIdxGlobal[0u]; ++row) {
-        T_Data tmp = 0;
-        for (unsigned int i = 0; i < numElements; ++i) {
-          tmp += a[row * numElements + i] * b[i];
-        }
-        c[row] = tmp;
-      }
+      cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t row) {
+	  T_Data tmp = 0;
+	  for (unsigned int i = 0; i < numElements; ++i) {
+	    tmp += a[row * numElements + i] * b[i];
+	  }
+	  c[row] = tmp;
+	});
     }
   };
 
@@ -100,15 +94,12 @@ namespace {
       ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
         // Global element index in 1D grid.
         // NB: On GPU, i = threadIndexGlobal = firstElementIdxGlobal = endElementIdxGlobal.
-        const auto& [firstElementIdxGlobal, endElementIdxGlobal] =
-            cms::alpakatools::element_global_index_range_truncated(acc, Vec1::all(numElements));
-
-        for (uint32_t i = firstElementIdxGlobal[0u]; i < endElementIdxGlobal[0u]; ++i) {
-          // theoreticalResult = i+i^2 = i*(i+1)
-          if (result[i] != i * (i + 1)) {
-            printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);
-          }
-        }
+	cms::alpakatools::for_each_element_in_thread_1D_global_index(acc, numElements, [&](uint32_t i) {
+	    // theoreticalResult = i+i^2 = i*(i+1)
+	    if (result[i] != i * (i + 1)) {
+	      printf("Wrong vectorAdd results, i = %u, c[i] = %f.\n", i, result[i]);
+	    }
+	  });
       }
     };
 


### PR DESCRIPTION
This contains a number of fixes in the prefixScan AlpakaCore version and its test.

The diff should appear clean after https://github.com/cms-patatrack/pixeltrack-standalone/pull/165 is merged. In the meantime, can also simply just click at the diff of src/alpaka/AlpakaCore/prefixScan.h and  src/alpaka/test/alpaka/prefixScan_t.cc.

**Minor corrections:**
- Remove unsupported use of `#pragma unroll`.

- Cannot use `__restrict__` in `warpPrefixScan `and `blockPrefixScan`, as they are called with `blockPrefixScan(acc, psum, psum, numBlocks, ws)`, in MultiBlock second step, hence with `ci = co = psum`.

- Remove unused variables.

- Handle element-dependency in `testPrefixScan` for the serial and TBB cases.

- Take into account the newly added back-ends in the workDiv computation.

- Make workloads identical for SERIAL, TBB, and CUDA cases. 
This allows to cleanly compare the performances between the 3 cases (after obviously removing all `printf `and `assert`, and choosing meaningful workDiv).

**Important fixes:**
- Memory allocations sizes should not contain the `sizeof(type)`. Only the number of elements is needed with Alpaka, as there is already a `* sizeof(type)` done internally. This resulted in x4 too much memory allocated.

- Should not call `alpaka::wait::wait(queue); `in between kernels. This had an important impact on perf (but ok this is just for prototyping purposes anyway).

- Use dynamic shared memory allocation in the secondStepMultiBlock block for `psum`, as is done in CUDACore, instead of global memory. 
Additionally, the number of elements in the `psum` array was set to `num_items`, while only `numBlocks` elements was needed. This is also addressed (dynamic shared memory size is handled with Alpaka with a `BlockSharedMemDynSizeBytes` struct, templated on the relevant kernel struct).
Finally, the new interface has the additional advantage of being closer to what is used in CUDACore.
This point is included in https://github.com/cms-patatrack/pixeltrack-standalone/pull/165 .




