### PR TITLE
Update Kokkos to 3.3.01

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ $(CUPLA_BASE)/lib: $(CUPLA_BASE) $(ALPAKA_DEPS) $(BOOST_DEPS) $(TBB_DEPS) $(CUDA
 external_kokkos: $(KOKKOS_LIB)
 
 $(KOKKOS_SRC):
-	git clone --branch 3.3.00 https://github.com/kokkos/kokkos.git $@
+	git clone --branch 3.3.01 https://github.com/kokkos/kokkos.git $@
 
 $(KOKKOS_BUILD):
 	mkdir -p $@


### PR DESCRIPTION
Implies `make distclean` or more surgical `rm -fR external/kokkos`.