### PR TITLE
Update Alpaka to 0.6.0, and Cupla to the latest dev snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -457,15 +457,15 @@ $(BOOST_BASE):
 external_alpaka: $(ALPAKA_BASE)
 
 $(ALPAKA_BASE):
-	git clone git@github.com:alpaka-group/alpaka.git -b 0.5.0 $@
+	git clone git@github.com:alpaka-group/alpaka.git -b 0.6.0 $@
 
 # Cupla
 .PHONY: external_cupla
 external_cupla: $(CUPLA_BASE)/lib
 
 $(CUPLA_BASE):
-	git clone git@github.com:alpaka-group/cupla.git -b master $@
-	cd $@ && git reset --hard 0.2.0
+	git clone git@github.com:alpaka-group/cupla.git -b dev $@
+	cd $@ && git reset --hard 545702f1947feb1d46b2230b502f1f46179b3665
 	cd $@ && git config core.sparsecheckout true && /usr/bin/echo -e '/*\n!/alpaka\n!/build\n!/lib' > .git/info/sparse-checkout && git read-tree -v -mu HEAD
 
 $(CUPLA_BASE)/lib: $(CUPLA_BASE) $(ALPAKA_DEPS) $(BOOST_DEPS) $(TBB_DEPS) $(CUDA_DEPS)

--- a/Makefile.cupla
+++ b/Makefile.cupla
@@ -28,7 +28,7 @@ OMP_FLAGS       := -fopenmp -foffload=disable
 # CUDA compiler
 ifdef CUDA_BASE
 NVCC            := $(CUDA_BASE)/bin/nvcc
-NVCC_FLAGS      := --generate-line-info --source-in-ptx --expt-extended-lambda --expt-relaxed-constexpr --generate-code arch=compute_35,code=sm_35 --generate-code arch=compute_50,code=sm_50 --generate-code arch=compute_60,code=sm_60 --generate-code arch=compute_70,code=sm_70 --generate-code arch=compute_70,code=compute_70 --cudart shared -ccbin $(CXX) -Xcudafe --display_error_number -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
+NVCC_FLAGS      := --generate-line-info --source-in-ptx --expt-extended-lambda --expt-relaxed-constexpr --generate-code arch=compute_35,code=[sm_35,compute_35] --generate-code arch=compute_50,code=[sm_50,compute_50] --generate-code arch=compute_60,code=[sm_60,compute_60] --generate-code arch=compute_70,code=[sm_70,compute_70] --generate-code arch=compute_75,code=[sm_75,compute_75] -Wno-deprecated-gpu-targets -t 0 --cudart shared -ccbin $(CXX) -Xcudafe --display_error_number -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
 CUDA_CXXFLAGS   := -I$(CUDA_BASE)/include
 CUDA_LDFLAGS    := -L$(CUDA_BASE)/lib64 -lcudart
 endif
@@ -62,7 +62,7 @@ SRC=$(wildcard src/*.cpp src/manager/*.cpp)
 
 all: library
 
-library: lib/libcupla-cuda.so lib/libcupla-serial.so lib/libcupla-threads.so lib/libcupla-omp2-threads.so lib/libcupla-omp2-blocks.so lib/libcupla-omp4.so lib/libcupla-tbb.so
+library: lib/libcupla-cuda.so lib/libcupla-serial.so lib/libcupla-threads.so lib/libcupla-omp2-threads.so lib/libcupla-omp2-blocks.so lib/libcupla-omp5.so lib/libcupla-tbb.so
 
 clean:
 	rm -rf build lib
@@ -170,22 +170,22 @@ lib/libcupla-omp2-blocks.so: $(OMP2_SEQ_SYNC_OBJ) $(OMP2_SEQ_ASYNC_OBJ)
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(HOST_CXXFLAGS) $(OMP_FLAGS) $^ -shared -o $@
 
-# OpenMP 4.0 parallel CPU backend with synchronous queues
-OMP4_SYNC_OBJ = $(SRC:src/%.cpp=build/omp4-sync/%.o)
+# OpenMP 5.0 parallel CPU backend with synchronous queues
+OMP4_SYNC_OBJ = $(SRC:src/%.cpp=build/omp5-sync/%.o)
 
-$(OMP4_SYNC_OBJ): build/omp4-sync/%.o: src/%.cpp
+$(OMP4_SYNC_OBJ): build/omp5-sync/%.o: src/%.cpp
 	@mkdir -p $(dir $@)
-	$(CXX) $(CXXFLAGS) $(HOST_CXXFLAGS) $(OMP_FLAGS) $(BOOST_CXXFLAGS) $(ALPAKA_CXXFLAGS) -Iinclude -DALPAKA_ACC_CPU_BT_OMP4_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=0 -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(HOST_CXXFLAGS) $(OMP_FLAGS) $(BOOST_CXXFLAGS) $(ALPAKA_CXXFLAGS) -Iinclude -DALPAKA_ACC_ANY_BT_OMP5_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=0 -c $< -o $@
 
-# OpenMP 4.0 parallel CPU backend with asynchronous queues
-OMP4_ASYNC_OBJ = $(SRC:src/%.cpp=build/omp4-async/%.o)
+# OpenMP 5.0 parallel CPU backend with asynchronous queues
+OMP4_ASYNC_OBJ = $(SRC:src/%.cpp=build/omp5-async/%.o)
 
-$(OMP4_ASYNC_OBJ): build/omp4-async/%.o: src/%.cpp
+$(OMP4_ASYNC_OBJ): build/omp5-async/%.o: src/%.cpp
 	@mkdir -p $(dir $@)
-	$(CXX) $(CXXFLAGS) $(HOST_CXXFLAGS) $(OMP_FLAGS) $(BOOST_CXXFLAGS) $(ALPAKA_CXXFLAGS) -Iinclude -DALPAKA_ACC_CPU_BT_OMP4_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=1 -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(HOST_CXXFLAGS) $(OMP_FLAGS) $(BOOST_CXXFLAGS) $(ALPAKA_CXXFLAGS) -Iinclude -DALPAKA_ACC_ANY_BT_OMP5_ENABLED -DCUPLA_STREAM_ASYNC_ENABLED=1 -c $< -o $@
 
-# cupla shared library for the OpenMP 4.0 parallel CPU backend
-lib/libcupla-omp4.so: $(OMP4_SYNC_OBJ) $(OMP4_ASYNC_OBJ)
+# cupla shared library for the OpenMP 5.0 parallel CPU backend
+lib/libcupla-omp5.so: $(OMP4_SYNC_OBJ) $(OMP4_ASYNC_OBJ)
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(HOST_CXXFLAGS) $(OMP_FLAGS) $^ -shared -o $@
 

--- a/src/alpaka/AlpakaCore/AtomicPairCounter.h
+++ b/src/alpaka/AlpakaCore/AtomicPairCounter.h
@@ -39,7 +39,7 @@ namespace cms {
         c += incr;
 
         Atomic2 ret;
-        ret.ac = alpaka::atomic::atomicOp<alpaka::atomic::op::Add>(acc, &counter.ac, c);
+        ret.ac = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &counter.ac, c);
         return ret.counters;
       }
 

--- a/src/alpaka/AlpakaCore/HistoContainer.h
+++ b/src/alpaka/AlpakaCore/HistoContainer.h
@@ -75,15 +75,15 @@ namespace cms {
       const Vec1 blocksPerGrid(nblocks);
 
       const WorkDiv1 &workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
-      alpaka::queue::enqueue(queue,
-                             alpaka::kernel::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+      alpaka::enqueue(queue,
+                             alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
                                  workDiv, multiBlockPrefixScanFirstStep<uint32_t>(), poff, poff, num_items));
 
       const WorkDiv1 &workDivWith1Block =
           cms::alpakatools::make_workdiv(Vec1::all(1), threadsPerBlockOrElementsPerThread);
-      alpaka::queue::enqueue(
+      alpaka::enqueue(
           queue,
-          alpaka::kernel::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+          alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
               workDivWith1Block, multiBlockPrefixScanSecondStep<uint32_t>(), poff, poff, num_items, nblocks));
     }
 
@@ -101,16 +101,16 @@ namespace cms {
       const Vec1 threadsPerBlockOrElementsPerThread(nthreads);
       const WorkDiv1 &workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
 
-      alpaka::queue::enqueue(
-          queue, alpaka::kernel::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(workDiv, launchZero(), h));
+      alpaka::enqueue(
+          queue, alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(workDiv, launchZero(), h));
 
-      alpaka::queue::enqueue(queue,
-                             alpaka::kernel::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+      alpaka::enqueue(queue,
+                             alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
                                  workDiv, countFromVector(), h, nh, v, offsets));
       launchFinalize(h, queue);
 
-      alpaka::queue::enqueue(queue,
-                             alpaka::kernel::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+      alpaka::enqueue(queue,
+                             alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
                                  workDiv, fillFromVector(), h, nh, v, offsets));
     }
 
@@ -196,18 +196,18 @@ namespace cms {
       template <typename T_Acc>
       ALPAKA_FN_ACC ALPAKA_FN_INLINE void add(const T_Acc &acc, CountersOnly const &co) {
         for (uint32_t i = 0; i < totbins(); ++i) {
-          alpaka::atomic::atomicOp<alpaka::atomic::op::Add>(acc, off + i, co.off[i]);
+          alpaka::atomicOp<alpaka::AtomicAdd>(acc, off + i, co.off[i]);
         }
       }
 
       template <typename T_Acc>
       static ALPAKA_FN_ACC ALPAKA_FN_INLINE uint32_t atomicIncrement(const T_Acc &acc, Counter &x) {
-        return alpaka::atomic::atomicOp<alpaka::atomic::op::Add>(acc, &x, 1u);
+        return alpaka::atomicOp<alpaka::AtomicAdd>(acc, &x, 1u);
       }
 
       template <typename T_Acc>
       static ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE uint32_t atomicDecrement(const T_Acc &acc, Counter &x) {
-        return alpaka::atomic::atomicOp<alpaka::atomic::op::Sub>(acc, &x, 1u);
+        return alpaka::atomicOp<alpaka::AtomicSub>(acc, &x, 1u);
       }
 
       template <typename T_Acc>

--- a/src/alpaka/AlpakaCore/alpakaConfig.h
+++ b/src/alpaka/AlpakaCore/alpakaConfig.h
@@ -6,19 +6,19 @@
 namespace alpaka_common {
   using Idx = uint32_t;
   using Extent = uint32_t;
-  using DevHost = alpaka::dev::DevCpu;
-  using PltfHost = alpaka::pltf::Pltf<DevHost>;
+  using DevHost = alpaka::DevCpu;
+  using PltfHost = alpaka::Pltf<DevHost>;
 
-  using Dim1 = alpaka::dim::DimInt<1u>;
-  using Dim2 = alpaka::dim::DimInt<2u>;
+  using Dim1 = alpaka::DimInt<1u>;
+  using Dim2 = alpaka::DimInt<2u>;
 
   template <typename T_Dim>
-  using Vec = alpaka::vec::Vec<T_Dim, Idx>;
+  using Vec = alpaka::Vec<T_Dim, Idx>;
   using Vec1 = Vec<Dim1>;
   using Vec2 = Vec<Dim2>;
 
   template <typename T_Dim>
-  using WorkDiv = alpaka::workdiv::WorkDivMembers<T_Dim, Idx>;
+  using WorkDiv = alpaka::WorkDivMembers<T_Dim, Idx>;
   using WorkDiv1 = WorkDiv<Dim1>;
   using WorkDiv2 = WorkDiv<Dim2>;
 }  // namespace alpaka_common
@@ -27,17 +27,17 @@ namespace alpaka_common {
 #define ALPAKA_ACC_GPU_CUDA_ASYNC_BACKEND
 namespace alpaka_cuda_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::acc::AccGpuCudaRt<Dim1, Extent>;
-  using Acc2 = alpaka::acc::AccGpuCudaRt<Dim2, Extent>;
-  using DevAcc1 = alpaka::dev::Dev<Acc1>;
-  using DevAcc2 = alpaka::dev::Dev<Acc2>;
-  using PltfAcc1 = alpaka::pltf::Pltf<DevAcc1>;
-  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+  using Acc1 = alpaka::AccGpuCudaRt<Dim1, Extent>;
+  using Acc2 = alpaka::AccGpuCudaRt<Dim2, Extent>;
+  using DevAcc1 = alpaka::Dev<Acc1>;
+  using DevAcc2 = alpaka::Dev<Acc2>;
+  using PltfAcc1 = alpaka::Pltf<DevAcc1>;
+  using PltfAcc2 = alpaka::Pltf<DevAcc2>;
 
   template <class T_Data>
-  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::Buf<Acc2, T_Data, Dim2, Idx>;
 
-  using Queue = alpaka::queue::QueueCudaRtNonBlocking;
+  using Queue = alpaka::QueueCudaRtNonBlocking;
 }  // namespace alpaka_cuda_async
 
 #endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -51,17 +51,17 @@ namespace alpaka_cuda_async {
 #define ALPAKA_ACC_CPU_B_SEQ_T_SEQ_SYNC_BACKEND
 namespace alpaka_serial_sync {
   using namespace alpaka_common;
-  using Acc1 = alpaka::acc::AccCpuSerial<Dim1, Extent>;
-  using Acc2 = alpaka::acc::AccCpuSerial<Dim2, Extent>;
-  using DevAcc1 = alpaka::dev::Dev<Acc1>;
-  using DevAcc2 = alpaka::dev::Dev<Acc2>;
-  using PltfAcc1 = alpaka::pltf::Pltf<DevAcc1>;
-  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+  using Acc1 = alpaka::AccCpuSerial<Dim1, Extent>;
+  using Acc2 = alpaka::AccCpuSerial<Dim2, Extent>;
+  using DevAcc1 = alpaka::Dev<Acc1>;
+  using DevAcc2 = alpaka::Dev<Acc2>;
+  using PltfAcc1 = alpaka::Pltf<DevAcc1>;
+  using PltfAcc2 = alpaka::Pltf<DevAcc2>;
 
   template <class T_Data>
-  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::Buf<Acc2, T_Data, Dim2, Idx>;
 
-  using Queue = alpaka::queue::QueueCpuBlocking;
+  using Queue = alpaka::QueueCpuBlocking;
 }  // namespace alpaka_serial_sync
 
 #endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
@@ -75,17 +75,17 @@ namespace alpaka_serial_sync {
 #define ALPAKA_ACC_CPU_B_TBB_T_SEQ_ASYNC_BACKEND
 namespace alpaka_tbb_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::acc::AccCpuTbbBlocks<Dim1, Extent>;
-  using Acc2 = alpaka::acc::AccCpuTbbBlocks<Dim2, Extent>;
-  using DevAcc1 = alpaka::dev::Dev<Acc1>;
-  using DevAcc2 = alpaka::dev::Dev<Acc2>;
-  using PltfAcc1 = alpaka::pltf::Pltf<DevAcc1>;
-  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+  using Acc1 = alpaka::AccCpuTbbBlocks<Dim1, Extent>;
+  using Acc2 = alpaka::AccCpuTbbBlocks<Dim2, Extent>;
+  using DevAcc1 = alpaka::Dev<Acc1>;
+  using DevAcc2 = alpaka::Dev<Acc2>;
+  using PltfAcc1 = alpaka::Pltf<DevAcc1>;
+  using PltfAcc2 = alpaka::Pltf<DevAcc2>;
 
   template <class T_Data>
-  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::Buf<Acc2, T_Data, Dim2, Idx>;
 
-  using Queue = alpaka::queue::QueueCpuNonBlocking;
+  using Queue = alpaka::QueueCpuNonBlocking;
 }  // namespace alpaka_tbb_async
 
 #endif  // ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
@@ -99,17 +99,17 @@ namespace alpaka_tbb_async {
 #define ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ASYNC_BACKEND
 namespace alpaka_omp2_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::acc::AccCpuOmp2Blocks<Dim1, Extent>;
-  using Acc2 = alpaka::acc::AccCpuOmp2Blocks<Dim2, Extent>;
-  using DevAcc1 = alpaka::dev::Dev<Acc1>;
-  using DevAcc2 = alpaka::dev::Dev<Acc2>;
-  using PltfAcc1 = alpaka::pltf::Pltf<DevAcc1>;
-  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+  using Acc1 = alpaka::AccCpuOmp2Blocks<Dim1, Extent>;
+  using Acc2 = alpaka::AccCpuOmp2Blocks<Dim2, Extent>;
+  using DevAcc1 = alpaka::Dev<Acc1>;
+  using DevAcc2 = alpaka::Dev<Acc2>;
+  using PltfAcc1 = alpaka::Pltf<DevAcc1>;
+  using PltfAcc2 = alpaka::Pltf<DevAcc2>;
 
   template <class T_Data>
-  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::Buf<Acc2, T_Data, Dim2, Idx>;
 
-  using Queue = alpaka::queue::QueueCpuNonBlocking;
+  using Queue = alpaka::QueueCpuNonBlocking;
 }  // namespace alpaka_omp2_async
 
 #endif  // ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
@@ -123,17 +123,17 @@ namespace alpaka_omp2_async {
 #define ALPAKA_ACC_CPU_BT_OMP4_ASYNC_BACKEND
 namespace alpaka_omp4_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::acc::AccCpuOmp4<Dim1, Extent>;
-  using Acc2 = alpaka::acc::AccCpuOmp4<Dim2, Extent>;
-  using DevAcc1 = alpaka::dev::Dev<Acc1>;
-  using DevAcc2 = alpaka::dev::Dev<Acc2>;
-  using PltfAcc1 = alpaka::pltf::Pltf<DevAcc1>;
-  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+  using Acc1 = alpaka::AccCpuOmp4<Dim1, Extent>;
+  using Acc2 = alpaka::AccCpuOmp4<Dim2, Extent>;
+  using DevAcc1 = alpaka::Dev<Acc1>;
+  using DevAcc2 = alpaka::Dev<Acc2>;
+  using PltfAcc1 = alpaka::Pltf<DevAcc1>;
+  using PltfAcc2 = alpaka::Pltf<DevAcc2>;
 
   template <class T_Data>
-  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::Buf<Acc2, T_Data, Dim2, Idx>;
 
-  using Queue = alpaka::queue::QueueCpuNonBlocking;
+  using Queue = alpaka::QueueCpuNonBlocking;
 }  // namespace alpaka_omp4_async
 
 #endif  // ALPAKA_ACC_CPU_BT_OMP4_ENABLED

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -34,7 +34,7 @@ namespace cms {
      */
     template <typename T_Acc>
     ALPAKA_FN_ACC bool once_per_block_1D(const T_Acc& acc, uint32_t i) {
-      const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+      const uint32_t blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
       return (i % blockDimension == 0);
     }
 
@@ -42,7 +42,7 @@ namespace cms {
      * Computes the range of the elements indexes, local to the block.
      * Warning: the max index is not truncated by the max number of elements of interest.
      */
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
+    template <typename T_Acc, typename T_Dim = alpaka::Dim<T_Acc>>
     ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block(const T_Acc& acc,
                                                                                  const Vec<T_Dim>& elementIdxShift) {
       Vec<T_Dim> firstElementIdxVec = Vec<T_Dim>::zeros();
@@ -51,8 +51,8 @@ namespace cms {
       // Loop on all grid dimensions.
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
         // Take into account the thread index in block.
-        const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[dimIndex]);
-        const uint32_t threadDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[dimIndex]);
+        const uint32_t threadIdxLocal(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[dimIndex]);
+        const uint32_t threadDimension(alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[dimIndex]);
 
         // Compute the elements indexes in block.
         // Obviously relevant for CPU only.
@@ -77,7 +77,7 @@ namespace cms {
     ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_block_truncated(
         const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, const Vec<T_Dim>& elementIdxShift) {
       // Check dimension
-      static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
+      static_assert(alpaka::Dim<T_Acc>::value == T_Dim::value,
                     "Accelerator and maxNumberOfElements need to have same dimension.");
       auto&& [firstElementIdxLocalVec, endElementIdxLocalVec] = element_index_range_in_block(acc, elementIdxShift);
 
@@ -94,14 +94,14 @@ namespace cms {
      * Computes the range of the elements indexes in grid.
      * Warning: the max index is not truncated by the max number of elements of interest.
      */
-    template <typename T_Acc, typename T_Dim = alpaka::dim::Dim<T_Acc>>
+    template <typename T_Acc, typename T_Dim = alpaka::Dim<T_Acc>>
     ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid(const T_Acc& acc,
                                                                                 Vec<T_Dim>& elementIdxShift) {
       // Loop on all grid dimensions.
       for (typename T_Dim::value_type dimIndex(0); dimIndex < T_Dim::value; ++dimIndex) {
         // Take into account the block index in grid.
-        const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[dimIndex]);
-        const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[dimIndex]);
+        const uint32_t blockIdxInGrid(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[dimIndex]);
+        const uint32_t blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[dimIndex]);
 
         // Shift to get global indices in grid (instead of local to the block)
         elementIdxShift[dimIndex] += blockIdxInGrid * blockDimension;
@@ -119,7 +119,7 @@ namespace cms {
     ALPAKA_FN_ACC std::pair<Vec<T_Dim>, Vec<T_Dim>> element_index_range_in_grid_truncated(
         const T_Acc& acc, const Vec<T_Dim>& maxNumberOfElements, Vec<T_Dim>& elementIdxShift) {
       // Check dimension
-      static_assert(alpaka::dim::Dim<T_Acc>::value == T_Dim::value,
+      static_assert(alpaka::Dim<T_Acc>::value == T_Dim::value,
                     "Accelerator and maxNumberOfElements need to have same dimension.");
       auto&& [firstElementIdxGlobalVec, endElementIdxGlobalVec] = element_index_range_in_grid(acc, elementIdxShift);
 
@@ -187,8 +187,8 @@ namespace cms {
                                                                    uint32_t elementIdxShift,
                                                                    const Func func) {
       // Take into account the block index in grid to compute the element indices.
-      const uint32_t blockIdxInGrid(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
-      const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+      const uint32_t blockIdxInGrid(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+      const uint32_t blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
       elementIdxShift += blockIdxInGrid * blockDimension;
 
       for_each_element_in_thread_1D_index_in_block(acc, maxNumberOfElements, elementIdxShift, func);
@@ -225,7 +225,7 @@ namespace cms {
           cms::alpakatools::element_index_range_in_block(acc, Vec1::all(elementIdxShift));
 
       // Stride = block size.
-      const uint32_t blockDimension(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+      const uint32_t blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
 
       // Strided access.
       for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];
@@ -270,7 +270,7 @@ namespace cms {
           cms::alpakatools::element_index_range_in_grid(acc, elementIdxShiftVec);
 
       // Stride = grid size.
-      const uint32_t gridDimension(alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
+      const uint32_t gridDimension(alpaka::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u]);
 
       // Strided access.
       for (uint32_t threadIdx = firstElementIdxNoStride[0u], endElementIdx = endElementIdxNoStride[0u];

--- a/src/alpaka/test/alpaka/OneHistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/OneHistoContainer_t.cc
@@ -13,50 +13,50 @@ struct mykernel {
     assert(v);
     assert(N == 12000);
 
-    const uint32_t threadIdxLocal(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+    const uint32_t threadIdxLocal(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
     if (threadIdxLocal == 0) {
       printf("start kernel for %d data\n", N);
     }
 
     using Hist = cms::alpakatools::HistoContainer<T, NBINS, 12000, S, uint16_t>;
 
-    auto&& hist = alpaka::block::shared::st::allocVar<Hist, __COUNTER__>(acc);
-    auto&& ws = alpaka::block::shared::st::allocVar<typename Hist::Counter[32], __COUNTER__>(acc);
+    auto&& hist = alpaka::declareSharedVar<Hist, __COUNTER__>(acc);
+    auto&& ws = alpaka::declareSharedVar<typename Hist::Counter[32], __COUNTER__>(acc);
 
     // set off zero
     cms::alpakatools::for_each_element_1D_block_stride(acc, Hist::totbins(), [&](uint32_t j) { hist.off[j] = 0; });
-    alpaka::block::sync::syncBlockThreads(acc);
+    alpaka::syncBlockThreads(acc);
 
     // set bins zero
     cms::alpakatools::for_each_element_1D_block_stride(acc, Hist::totbins(), [&](uint32_t j) { hist.bins[j] = 0; });
-    alpaka::block::sync::syncBlockThreads(acc);
+    alpaka::syncBlockThreads(acc);
 
     // count
     cms::alpakatools::for_each_element_1D_block_stride(acc, N, [&](uint32_t j) { hist.count(acc, v[j]); });
-    alpaka::block::sync::syncBlockThreads(acc);
+    alpaka::syncBlockThreads(acc);
 
     assert(0 == hist.size());
-    alpaka::block::sync::syncBlockThreads(acc);
+    alpaka::syncBlockThreads(acc);
 
     // finalize
     hist.finalize(acc, ws);
-    alpaka::block::sync::syncBlockThreads(acc);
+    alpaka::syncBlockThreads(acc);
 
     assert(N == hist.size());
 
     // verify
     cms::alpakatools::for_each_element_1D_block_stride(
         acc, Hist::nbins(), [&](uint32_t j) { assert(hist.off[j] <= hist.off[j + 1]); });
-    alpaka::block::sync::syncBlockThreads(acc);
+    alpaka::syncBlockThreads(acc);
 
     cms::alpakatools::for_each_element_in_thread_1D_index_in_block(acc, 32, [&](uint32_t i) {
       ws[i] = 0;  // used by prefix scan...
     });
-    alpaka::block::sync::syncBlockThreads(acc);
+    alpaka::syncBlockThreads(acc);
 
     // fill
     cms::alpakatools::for_each_element_1D_block_stride(acc, N, [&](uint32_t j) { hist.fill(acc, v[j], j); });
-    alpaka::block::sync::syncBlockThreads(acc);
+    alpaka::syncBlockThreads(acc);
 
     assert(0 == hist.off[0]);
     assert(N == hist.size());
@@ -122,9 +122,9 @@ void go(const DevHost& host,
             << (rmax - rmin) / Hist::nbins() << std::endl;
   std::cout << "bins " << int(Hist::bin(0)) << ' ' << int(Hist::bin(rmin)) << ' ' << int(Hist::bin(rmax)) << std::endl;
 
-  auto v_hbuf = alpaka::mem::buf::alloc<T, Idx>(host, N);
-  auto v = alpaka::mem::view::getPtrNative(v_hbuf);
-  auto v_dbuf = alpaka::mem::buf::alloc<T, Idx>(device, N);
+  auto v_hbuf = alpaka::allocBuf<T, Idx>(host, N);
+  auto v = alpaka::getPtrNative(v_hbuf);
+  auto v_dbuf = alpaka::allocBuf<T, Idx>(device, N);
 
   for (int it = 0; it < 5; ++it) {
     for (long long j = 0; j < N; j++)
@@ -133,22 +133,22 @@ void go(const DevHost& host,
       for (long long j = N / 2; j < N / 2 + N / 4; j++)
         v[j] = 4;
 
-    alpaka::mem::view::copy(queue, v_dbuf, v_hbuf, N);
+    alpaka::memcpy(queue, v_dbuf, v_hbuf, N);
 
     const Vec1& threadsPerBlockOrElementsPerThread(Vec1::all(256));
     const Vec1& blocksPerGrid(Vec1::all(1));
     const WorkDiv1& workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
-    alpaka::queue::enqueue(queue,
-                           alpaka::kernel::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
-                               workDiv, mykernel<NBINS, S, DELTA>(), alpaka::mem::view::getPtrNative(v_dbuf), N));
+    alpaka::enqueue(queue,
+                           alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+                               workDiv, mykernel<NBINS, S, DELTA>(), alpaka::getPtrNative(v_dbuf), N));
   }
-  alpaka::wait::wait(queue);
+  alpaka::wait(queue);
 }
 
 int main() {
-  const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
+  const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
   const ALPAKA_ACCELERATOR_NAMESPACE::DevAcc1 device(
-      alpaka::pltf::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::PltfAcc1>(0u));
+      alpaka::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::PltfAcc1>(0u));
   ALPAKA_ACCELERATOR_NAMESPACE::Queue queue(device);
 
   go<int16_t>(host, device, queue);

--- a/src/alpaka/test/alpaka/clustering_t.cc
+++ b/src/alpaka/test/alpaka/clustering_t.cc
@@ -19,34 +19,34 @@
 int main(void) {
   using namespace gpuClustering;
 
-  const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
+  const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
   const ALPAKA_ACCELERATOR_NAMESPACE::DevAcc1 device(
-      alpaka::pltf::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::PltfAcc1>(0u));
+      alpaka::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::PltfAcc1>(0u));
   ALPAKA_ACCELERATOR_NAMESPACE::Queue queue(device);
 
   constexpr unsigned int numElements = 256 * 2000;
   // these in reality are already on GPU
-  auto h_id_buf = alpaka::mem::buf::alloc<uint16_t, Idx>(host, numElements);
-  auto h_id = alpaka::mem::view::getPtrNative(h_id_buf);
-  auto h_x_buf = alpaka::mem::buf::alloc<uint16_t, Idx>(host, numElements);
-  auto h_x = alpaka::mem::view::getPtrNative(h_x_buf);
-  auto h_y_buf = alpaka::mem::buf::alloc<uint16_t, Idx>(host, numElements);
-  auto h_y = alpaka::mem::view::getPtrNative(h_y_buf);
-  auto h_adc_buf = alpaka::mem::buf::alloc<uint16_t, Idx>(host, numElements);
-  auto h_adc = alpaka::mem::view::getPtrNative(h_adc_buf);
+  auto h_id_buf = alpaka::allocBuf<uint16_t, Idx>(host, numElements);
+  auto h_id = alpaka::getPtrNative(h_id_buf);
+  auto h_x_buf = alpaka::allocBuf<uint16_t, Idx>(host, numElements);
+  auto h_x = alpaka::getPtrNative(h_x_buf);
+  auto h_y_buf = alpaka::allocBuf<uint16_t, Idx>(host, numElements);
+  auto h_y = alpaka::getPtrNative(h_y_buf);
+  auto h_adc_buf = alpaka::allocBuf<uint16_t, Idx>(host, numElements);
+  auto h_adc = alpaka::getPtrNative(h_adc_buf);
 
-  auto h_clus_buf = alpaka::mem::buf::alloc<int, Idx>(host, numElements);
-  auto h_clus = alpaka::mem::view::getPtrNative(h_clus_buf);
+  auto h_clus_buf = alpaka::allocBuf<int, Idx>(host, numElements);
+  auto h_clus = alpaka::getPtrNative(h_clus_buf);
 
-  auto d_id_buf = alpaka::mem::buf::alloc<uint16_t, Idx>(device, numElements);
-  auto d_x_buf = alpaka::mem::buf::alloc<uint16_t, Idx>(device, numElements);
-  auto d_y_buf = alpaka::mem::buf::alloc<uint16_t, Idx>(device, numElements);
-  auto d_adc_buf = alpaka::mem::buf::alloc<uint16_t, Idx>(device, numElements);
-  auto d_clus_buf = alpaka::mem::buf::alloc<int, Idx>(device, numElements);
+  auto d_id_buf = alpaka::allocBuf<uint16_t, Idx>(device, numElements);
+  auto d_x_buf = alpaka::allocBuf<uint16_t, Idx>(device, numElements);
+  auto d_y_buf = alpaka::allocBuf<uint16_t, Idx>(device, numElements);
+  auto d_adc_buf = alpaka::allocBuf<uint16_t, Idx>(device, numElements);
+  auto d_clus_buf = alpaka::allocBuf<int, Idx>(device, numElements);
 
-  auto d_moduleStart_buf = alpaka::mem::buf::alloc<uint32_t, Idx>(device, MaxNumModules + 1);
-  auto d_clusInModule_buf = alpaka::mem::buf::alloc<uint32_t, Idx>(device, MaxNumModules);
-  auto d_moduleId_buf = alpaka::mem::buf::alloc<uint32_t, Idx>(device, MaxNumModules);
+  auto d_moduleStart_buf = alpaka::allocBuf<uint32_t, Idx>(device, MaxNumModules + 1);
+  auto d_clusInModule_buf = alpaka::allocBuf<uint32_t, Idx>(device, MaxNumModules);
+  auto d_moduleId_buf = alpaka::allocBuf<uint32_t, Idx>(device, MaxNumModules);
 
   // later random number
   unsigned int n = 0;
@@ -232,15 +232,15 @@ int main(void) {
     std::cout << "created " << n << " digis in " << ncl << " clusters" << std::endl;
     assert(n <= numElements);
 
-    auto h_nModules_buf = alpaka::mem::buf::alloc<uint32_t, Idx>(host, 1u);
-    auto nModules = alpaka::mem::view::getPtrNative(h_nModules_buf);
+    auto h_nModules_buf = alpaka::allocBuf<uint32_t, Idx>(host, 1u);
+    auto nModules = alpaka::getPtrNative(h_nModules_buf);
     nModules[0] = 0;
-    alpaka::mem::view::copy(queue, d_moduleStart_buf, h_nModules_buf, 1u);
+    alpaka::memcpy(queue, d_moduleStart_buf, h_nModules_buf, 1u);
 
-    alpaka::mem::view::copy(queue, d_id_buf, h_id_buf, n);
-    alpaka::mem::view::copy(queue, d_x_buf, h_x_buf, n);
-    alpaka::mem::view::copy(queue, d_y_buf, h_y_buf, n);
-    alpaka::mem::view::copy(queue, d_adc_buf, h_adc_buf, n);
+    alpaka::memcpy(queue, d_id_buf, h_id_buf, n);
+    alpaka::memcpy(queue, d_x_buf, h_x_buf, n);
+    alpaka::memcpy(queue, d_y_buf, h_y_buf, n);
+    alpaka::memcpy(queue, d_adc_buf, h_adc_buf, n);
 
     // Launch CUDA Kernels
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -262,13 +262,13 @@ int main(void) {
     std::cout << "CUDA countModules kernel launch with " << blocksPerGridCountModules << " blocks of "
               << threadsPerBlockOrElementsPerThread << " threads (GPU) or elements (CPU). \n";
 
-    alpaka::queue::enqueue(queue,
-                           alpaka::kernel::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+    alpaka::enqueue(queue,
+                           alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
                                workDivCountModules,
                                countModules(),
-                               alpaka::mem::view::getPtrNative(d_id_buf),
-                               alpaka::mem::view::getPtrNative(d_moduleStart_buf),
-                               alpaka::mem::view::getPtrNative(d_clus_buf),
+                               alpaka::getPtrNative(d_id_buf),
+                               alpaka::getPtrNative(d_moduleStart_buf),
+                               alpaka::getPtrNative(d_clus_buf),
                                n));
 
     // FIND CLUSTER
@@ -277,31 +277,31 @@ int main(void) {
     std::cout << "CUDA findModules kernel launch with " << MaxNumModules << " blocks of "
               << threadsPerBlockOrElementsPerThread << " threads (GPU) or elements (CPU). \n";
 
-    alpaka::mem::view::set(queue, d_clusInModule_buf, 0, MaxNumModules);
+    alpaka::memset(queue, d_clusInModule_buf, 0, MaxNumModules);
 
-    alpaka::queue::enqueue(queue,
-                           alpaka::kernel::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+    alpaka::enqueue(queue,
+                           alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
                                workDivMaxNumModules,
                                findClus(),
-                               alpaka::mem::view::getPtrNative(d_id_buf),
-                               alpaka::mem::view::getPtrNative(d_x_buf),
-                               alpaka::mem::view::getPtrNative(d_y_buf),
-                               alpaka::mem::view::getPtrNative(d_moduleStart_buf),
-                               alpaka::mem::view::getPtrNative(d_clusInModule_buf),
-                               alpaka::mem::view::getPtrNative(d_moduleId_buf),
-                               alpaka::mem::view::getPtrNative(d_clus_buf),
+                               alpaka::getPtrNative(d_id_buf),
+                               alpaka::getPtrNative(d_x_buf),
+                               alpaka::getPtrNative(d_y_buf),
+                               alpaka::getPtrNative(d_moduleStart_buf),
+                               alpaka::getPtrNative(d_clusInModule_buf),
+                               alpaka::getPtrNative(d_moduleId_buf),
+                               alpaka::getPtrNative(d_clus_buf),
                                n));
-    alpaka::mem::view::copy(queue, h_nModules_buf, d_moduleStart_buf, 1u);
+    alpaka::memcpy(queue, h_nModules_buf, d_moduleStart_buf, 1u);
 
-    auto h_nclus_buf = alpaka::mem::buf::alloc<uint32_t, Idx>(host, MaxNumModules);
-    auto nclus = alpaka::mem::view::getPtrNative(h_nclus_buf);
-    alpaka::mem::view::copy(queue, h_nclus_buf, d_clusInModule_buf, MaxNumModules);
+    auto h_nclus_buf = alpaka::allocBuf<uint32_t, Idx>(host, MaxNumModules);
+    auto nclus = alpaka::getPtrNative(h_nclus_buf);
+    alpaka::memcpy(queue, h_nclus_buf, d_clusInModule_buf, MaxNumModules);
 
     // Wait for memory transfers to be completed
-    alpaka::wait::wait(queue);
+    alpaka::wait(queue);
 
-    auto h_moduleId_buf = alpaka::mem::buf::alloc<uint32_t, Idx>(host, nModules[0]);
-    //auto moduleId = alpaka::mem::view::getPtrNative(h_moduleId_buf);
+    auto h_moduleId_buf = alpaka::allocBuf<uint32_t, Idx>(host, nModules[0]);
+    //auto moduleId = alpaka::getPtrNative(h_moduleId_buf);
 
     std::cout << "before charge cut found " << std::accumulate(nclus, nclus + MaxNumModules, 0) << " clusters"
               << std::endl;
@@ -314,24 +314,24 @@ int main(void) {
       std::cout << "ERROR!!!!! wrong number of cluster found" << std::endl;
 
     // CLUSTER CHARGE CUT
-    alpaka::queue::enqueue(queue,
-                           alpaka::kernel::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+    alpaka::enqueue(queue,
+                           alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
                                workDivMaxNumModules,
                                clusterChargeCut(),
-                               alpaka::mem::view::getPtrNative(d_id_buf),
-                               alpaka::mem::view::getPtrNative(d_adc_buf),
-                               alpaka::mem::view::getPtrNative(d_moduleStart_buf),
-                               alpaka::mem::view::getPtrNative(d_clusInModule_buf),
-                               alpaka::mem::view::getPtrNative(d_moduleId_buf),
-                               alpaka::mem::view::getPtrNative(d_clus_buf),
+                               alpaka::getPtrNative(d_id_buf),
+                               alpaka::getPtrNative(d_adc_buf),
+                               alpaka::getPtrNative(d_moduleStart_buf),
+                               alpaka::getPtrNative(d_clusInModule_buf),
+                               alpaka::getPtrNative(d_moduleId_buf),
+                               alpaka::getPtrNative(d_clus_buf),
                                n));
-    alpaka::mem::view::copy(queue, h_id_buf, d_id_buf, n);
-    alpaka::mem::view::copy(queue, h_clus_buf, d_clus_buf, n);
-    alpaka::mem::view::copy(queue, h_nclus_buf, d_clusInModule_buf, MaxNumModules);
-    alpaka::mem::view::copy(queue, h_moduleId_buf, d_moduleId_buf, nModules[0]);
+    alpaka::memcpy(queue, h_id_buf, d_id_buf, n);
+    alpaka::memcpy(queue, h_clus_buf, d_clus_buf, n);
+    alpaka::memcpy(queue, h_nclus_buf, d_clusInModule_buf, MaxNumModules);
+    alpaka::memcpy(queue, h_moduleId_buf, d_moduleId_buf, nModules[0]);
 
     // Wait for memory transfers to be completed
-    alpaka::wait::wait(queue);
+    alpaka::wait(queue);
     std::cout << "found " << nModules[0] << " Modules active" << std::endl;
 
     // CROSS-CHECK

--- a/src/alpakatest/AlpakaCore/alpakaConfig.h
+++ b/src/alpakatest/AlpakaCore/alpakaConfig.h
@@ -6,19 +6,19 @@
 namespace alpaka_common {
   using Idx = uint32_t;
   using Extent = uint32_t;
-  using DevHost = alpaka::dev::DevCpu;
-  using PltfHost = alpaka::pltf::Pltf<DevHost>;
+  using DevHost = alpaka::DevCpu;
+  using PltfHost = alpaka::Pltf<DevHost>;
 
-  using Dim1 = alpaka::dim::DimInt<1u>;
-  using Dim2 = alpaka::dim::DimInt<2u>;
+  using Dim1 = alpaka::DimInt<1u>;
+  using Dim2 = alpaka::DimInt<2u>;
 
   template <typename T_Dim>
-  using Vec = alpaka::vec::Vec<T_Dim, Idx>;
+  using Vec = alpaka::Vec<T_Dim, Idx>;
   using Vec1 = Vec<Dim1>;
   using Vec2 = Vec<Dim2>;
 
   template <typename T_Dim>
-  using WorkDiv = alpaka::workdiv::WorkDivMembers<T_Dim, Idx>;
+  using WorkDiv = alpaka::WorkDivMembers<T_Dim, Idx>;
   using WorkDiv1 = WorkDiv<Dim1>;
   using WorkDiv2 = WorkDiv<Dim2>;
 }  // namespace alpaka_common
@@ -27,17 +27,17 @@ namespace alpaka_common {
 #define ALPAKA_ACC_GPU_CUDA_ASYNC_BACKEND
 namespace alpaka_cuda_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::acc::AccGpuCudaRt<Dim1, Extent>;
-  using Acc2 = alpaka::acc::AccGpuCudaRt<Dim2, Extent>;
-  using DevAcc1 = alpaka::dev::Dev<Acc1>;
-  using DevAcc2 = alpaka::dev::Dev<Acc2>;
-  using PltfAcc1 = alpaka::pltf::Pltf<DevAcc1>;
-  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+  using Acc1 = alpaka::AccGpuCudaRt<Dim1, Extent>;
+  using Acc2 = alpaka::AccGpuCudaRt<Dim2, Extent>;
+  using DevAcc1 = alpaka::Dev<Acc1>;
+  using DevAcc2 = alpaka::Dev<Acc2>;
+  using PltfAcc1 = alpaka::Pltf<DevAcc1>;
+  using PltfAcc2 = alpaka::Pltf<DevAcc2>;
 
   template <class T_Data>
-  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::Buf<Acc2, T_Data, Dim2, Idx>;
 
-  using Queue = alpaka::queue::QueueCudaRtNonBlocking;
+  using Queue = alpaka::QueueCudaRtNonBlocking;
 }  // namespace alpaka_cuda_async
 
 #endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -51,17 +51,17 @@ namespace alpaka_cuda_async {
 #define ALPAKA_ACC_CPU_B_SEQ_T_SEQ_SYNC_BACKEND
 namespace alpaka_serial_sync {
   using namespace alpaka_common;
-  using Acc1 = alpaka::acc::AccCpuSerial<Dim1, Extent>;
-  using Acc2 = alpaka::acc::AccCpuSerial<Dim2, Extent>;
-  using DevAcc1 = alpaka::dev::Dev<Acc1>;
-  using DevAcc2 = alpaka::dev::Dev<Acc2>;
-  using PltfAcc1 = alpaka::pltf::Pltf<DevAcc1>;
-  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+  using Acc1 = alpaka::AccCpuSerial<Dim1, Extent>;
+  using Acc2 = alpaka::AccCpuSerial<Dim2, Extent>;
+  using DevAcc1 = alpaka::Dev<Acc1>;
+  using DevAcc2 = alpaka::Dev<Acc2>;
+  using PltfAcc1 = alpaka::Pltf<DevAcc1>;
+  using PltfAcc2 = alpaka::Pltf<DevAcc2>;
 
   template <class T_Data>
-  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::Buf<Acc2, T_Data, Dim2, Idx>;
 
-  using Queue = alpaka::queue::QueueCpuBlocking;
+  using Queue = alpaka::QueueCpuBlocking;
 }  // namespace alpaka_serial_sync
 
 #endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
@@ -75,17 +75,17 @@ namespace alpaka_serial_sync {
 #define ALPAKA_ACC_CPU_B_TBB_T_SEQ_ASYNC_BACKEND
 namespace alpaka_tbb_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::acc::AccCpuTbbBlocks<Dim1, Extent>;
-  using Acc2 = alpaka::acc::AccCpuTbbBlocks<Dim2, Extent>;
-  using DevAcc1 = alpaka::dev::Dev<Acc1>;
-  using DevAcc2 = alpaka::dev::Dev<Acc2>;
-  using PltfAcc1 = alpaka::pltf::Pltf<DevAcc1>;
-  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+  using Acc1 = alpaka::AccCpuTbbBlocks<Dim1, Extent>;
+  using Acc2 = alpaka::AccCpuTbbBlocks<Dim2, Extent>;
+  using DevAcc1 = alpaka::Dev<Acc1>;
+  using DevAcc2 = alpaka::Dev<Acc2>;
+  using PltfAcc1 = alpaka::Pltf<DevAcc1>;
+  using PltfAcc2 = alpaka::Pltf<DevAcc2>;
 
   template <class T_Data>
-  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::Buf<Acc2, T_Data, Dim2, Idx>;
 
-  using Queue = alpaka::queue::QueueCpuNonBlocking;
+  using Queue = alpaka::QueueCpuNonBlocking;
 }  // namespace alpaka_tbb_async
 
 #endif  // ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
@@ -99,17 +99,17 @@ namespace alpaka_tbb_async {
 #define ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ASYNC_BACKEND
 namespace alpaka_omp2_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::acc::AccCpuOmp2Blocks<Dim1, Extent>;
-  using Acc2 = alpaka::acc::AccCpuOmp2Blocks<Dim2, Extent>;
-  using DevAcc1 = alpaka::dev::Dev<Acc1>;
-  using DevAcc2 = alpaka::dev::Dev<Acc2>;
-  using PltfAcc1 = alpaka::pltf::Pltf<DevAcc1>;
-  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+  using Acc1 = alpaka::AccCpuOmp2Blocks<Dim1, Extent>;
+  using Acc2 = alpaka::AccCpuOmp2Blocks<Dim2, Extent>;
+  using DevAcc1 = alpaka::Dev<Acc1>;
+  using DevAcc2 = alpaka::Dev<Acc2>;
+  using PltfAcc1 = alpaka::Pltf<DevAcc1>;
+  using PltfAcc2 = alpaka::Pltf<DevAcc2>;
 
   template <class T_Data>
-  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::Buf<Acc2, T_Data, Dim2, Idx>;
 
-  using Queue = alpaka::queue::QueueCpuNonBlocking;
+  using Queue = alpaka::QueueCpuNonBlocking;
 }  // namespace alpaka_omp2_async
 
 #endif  // ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
@@ -123,17 +123,17 @@ namespace alpaka_omp2_async {
 #define ALPAKA_ACC_CPU_BT_OMP4_ASYNC_BACKEND
 namespace alpaka_omp4_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::acc::AccCpuOmp4<Dim1, Extent>;
-  using Acc2 = alpaka::acc::AccCpuOmp4<Dim2, Extent>;
-  using DevAcc1 = alpaka::dev::Dev<Acc1>;
-  using DevAcc2 = alpaka::dev::Dev<Acc2>;
-  using PltfAcc1 = alpaka::pltf::Pltf<DevAcc1>;
-  using PltfAcc2 = alpaka::pltf::Pltf<DevAcc2>;
+  using Acc1 = alpaka::AccCpuOmp4<Dim1, Extent>;
+  using Acc2 = alpaka::AccCpuOmp4<Dim2, Extent>;
+  using DevAcc1 = alpaka::Dev<Acc1>;
+  using DevAcc2 = alpaka::Dev<Acc2>;
+  using PltfAcc1 = alpaka::Pltf<DevAcc1>;
+  using PltfAcc2 = alpaka::Pltf<DevAcc2>;
 
   template <class T_Data>
-  using AlpakaAccBuf2 = alpaka::mem::buf::Buf<Acc2, T_Data, Dim2, Idx>;
+  using AlpakaAccBuf2 = alpaka::Buf<Acc2, T_Data, Dim2, Idx>;
 
-  using Queue = alpaka::queue::QueueCpuNonBlocking;
+  using Queue = alpaka::QueueCpuNonBlocking;
 }  // namespace alpaka_omp4_async
 
 #endif  // ALPAKA_ACC_CPU_BT_OMP4_ENABLED

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
@@ -105,7 +105,7 @@ namespace {
     struct verifyVectorProd {
       template <typename T_Acc, typename T_Data>
       ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
-        const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+        const auto& threadIdxGlobal(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc));
         const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
         const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
 
@@ -130,7 +130,7 @@ namespace {
     struct verifyMatrixMul {
       template <typename T_Acc, typename T_Data>
       ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
-        const auto& threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+        const auto& threadIdxGlobal(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc));
         const uint32_t threadIdxGlobalX(threadIdxGlobal[0u]);
         const uint32_t threadIdxGlobalY(threadIdxGlobal[1u]);
 
@@ -163,7 +163,7 @@ namespace {
     struct verifyMatrixMulVector {
       template <typename T_Acc, typename T_Data>
       ALPAKA_FN_ACC void operator()(const T_Acc& acc, const T_Data* result, unsigned int numElements) const {
-        const uint32_t threadIdxGlobal(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+        const uint32_t threadIdxGlobal(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
 
         if (threadIdxGlobal == 0) {
           const unsigned long int N = numElements - 1;
@@ -198,27 +198,27 @@ namespace {
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   AlpakaAccBuf2<float> alpakaAlgo1() {
-    const DevHost host(alpaka::pltf::getDevByIdx<PltfHost>(0u));
-    const DevAcc2 device(alpaka::pltf::getDevByIdx<PltfAcc2>(0u));
+    const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
+    const DevAcc2 device(alpaka::getDevByIdx<PltfAcc2>(0u));
     const Vec1 size(NUM_VALUES);
     Queue queue(device);
 
     // Host data
-    auto h_a_buf = alpaka::mem::buf::alloc<float, Idx>(host, size);
-    auto h_b_buf = alpaka::mem::buf::alloc<float, Idx>(host, size);
-    auto h_a = alpaka::mem::view::getPtrNative(h_a_buf);
-    auto h_b = alpaka::mem::view::getPtrNative(h_b_buf);
+    auto h_a_buf = alpaka::allocBuf<float, Idx>(host, size);
+    auto h_b_buf = alpaka::allocBuf<float, Idx>(host, size);
+    auto h_a = alpaka::getPtrNative(h_a_buf);
+    auto h_b = alpaka::getPtrNative(h_b_buf);
     for (auto i = 0U; i < NUM_VALUES; i++) {
       h_a[i] = i;
       h_b[i] = i * i;
     }
 
     // Device data
-    auto d_a_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
-    auto d_b_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
-    alpaka::mem::view::copy(queue, d_a_buf, h_a_buf, size);
-    alpaka::mem::view::copy(queue, d_b_buf, h_b_buf, size);
-    auto d_c_buf = alpaka::mem::buf::alloc<float, Idx>(device, size);
+    auto d_a_buf = alpaka::allocBuf<float, Idx>(device, size);
+    auto d_b_buf = alpaka::allocBuf<float, Idx>(device, size);
+    alpaka::memcpy(queue, d_a_buf, h_a_buf, size);
+    alpaka::memcpy(queue, d_b_buf, h_b_buf, size);
+    auto d_c_buf = alpaka::allocBuf<float, Idx>(device, size);
 
     // Prepare 1D workDiv
     const Vec1& blocksPerGrid1(Vec1::all((NUM_VALUES + 32 - 1) / 32));
@@ -226,12 +226,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const WorkDiv1& workDiv1 = cms::alpakatools::make_workdiv(blocksPerGrid1, threadsPerBlockOrElementsPerThread1);
 
     // VECTOR ADDITION
-    alpaka::queue::enqueue(queue,
-                           alpaka::kernel::createTaskKernel<Acc1>(workDiv1,
+    alpaka::enqueue(queue,
+                           alpaka::createTaskKernel<Acc1>(workDiv1,
                                                                   vectorAdd(),
-                                                                  alpaka::mem::view::getPtrNative(d_a_buf),
-                                                                  alpaka::mem::view::getPtrNative(d_b_buf),
-                                                                  alpaka::mem::view::getPtrNative(d_c_buf),
+                                                                  alpaka::getPtrNative(d_a_buf),
+                                                                  alpaka::getPtrNative(d_b_buf),
+                                                                  alpaka::getPtrNative(d_c_buf),
                                                                   NUM_VALUES));
 
     // Prepare 2D workDiv
@@ -243,46 +243,46 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     // Device data
     const Vec2 sizeSquare(NUM_VALUES, NUM_VALUES);
-    auto d_ma_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
-    auto d_mb_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
-    auto d_mc_buf = alpaka::mem::buf::alloc<float, Idx>(device, sizeSquare);
+    auto d_ma_buf = alpaka::allocBuf<float, Idx>(device, sizeSquare);
+    auto d_mb_buf = alpaka::allocBuf<float, Idx>(device, sizeSquare);
+    auto d_mc_buf = alpaka::allocBuf<float, Idx>(device, sizeSquare);
 
     // VECTOR MULTIPLICATION
-    alpaka::queue::enqueue(queue,
-                           alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+    alpaka::enqueue(queue,
+                           alpaka::createTaskKernel<Acc2>(workDiv2,
                                                                   vectorProd(),
-                                                                  alpaka::mem::view::getPtrNative(d_a_buf),
-                                                                  alpaka::mem::view::getPtrNative(d_b_buf),
-                                                                  alpaka::mem::view::getPtrNative(d_ma_buf),
+                                                                  alpaka::getPtrNative(d_a_buf),
+                                                                  alpaka::getPtrNative(d_b_buf),
+                                                                  alpaka::getPtrNative(d_ma_buf),
                                                                   NUM_VALUES));
 
-    alpaka::queue::enqueue(queue,
-                           alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+    alpaka::enqueue(queue,
+                           alpaka::createTaskKernel<Acc2>(workDiv2,
                                                                   vectorProd(),
-                                                                  alpaka::mem::view::getPtrNative(d_a_buf),
-                                                                  alpaka::mem::view::getPtrNative(d_c_buf),
-                                                                  alpaka::mem::view::getPtrNative(d_mb_buf),
+                                                                  alpaka::getPtrNative(d_a_buf),
+                                                                  alpaka::getPtrNative(d_c_buf),
+                                                                  alpaka::getPtrNative(d_mb_buf),
                                                                   NUM_VALUES));
 
     // MATRIX MULTIPLICATION
-    alpaka::queue::enqueue(queue,
-                           alpaka::kernel::createTaskKernel<Acc2>(workDiv2,
+    alpaka::enqueue(queue,
+                           alpaka::createTaskKernel<Acc2>(workDiv2,
                                                                   matrixMul(),
-                                                                  alpaka::mem::view::getPtrNative(d_ma_buf),
-                                                                  alpaka::mem::view::getPtrNative(d_mb_buf),
-                                                                  alpaka::mem::view::getPtrNative(d_mc_buf),
+                                                                  alpaka::getPtrNative(d_ma_buf),
+                                                                  alpaka::getPtrNative(d_mb_buf),
+                                                                  alpaka::getPtrNative(d_mc_buf),
                                                                   NUM_VALUES));
 
     // MATRIX - VECTOR MULTIPLICATION
-    alpaka::queue::enqueue(queue,
-                           alpaka::kernel::createTaskKernel<Acc1>(workDiv1,
+    alpaka::enqueue(queue,
+                           alpaka::createTaskKernel<Acc1>(workDiv1,
                                                                   matrixMulVector(),
-                                                                  alpaka::mem::view::getPtrNative(d_mc_buf),
-                                                                  alpaka::mem::view::getPtrNative(d_b_buf),
-                                                                  alpaka::mem::view::getPtrNative(d_c_buf),
+                                                                  alpaka::getPtrNative(d_mc_buf),
+                                                                  alpaka::getPtrNative(d_b_buf),
+                                                                  alpaka::getPtrNative(d_c_buf),
                                                                   NUM_VALUES));
 
-    alpaka::wait::wait(queue);
+    alpaka::wait(queue);
     return d_mc_buf;
   }
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpakatest/test/alpaka/world.cc
+++ b/src/alpakatest/test/alpaka/world.cc
@@ -7,8 +7,8 @@ namespace {
   struct Print {
     template <typename T_Acc>
     ALPAKA_FN_ACC void operator()(T_Acc const& acc) const {
-      uint32_t const blockThreadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
-      uint32_t const elemDimension(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+      uint32_t const blockThreadIdx(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+      uint32_t const elemDimension(alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
       printf("Alpaka kernel thread index %u, number of elements %u\n", blockThreadIdx, elemDimension);
     }
   };
@@ -18,7 +18,7 @@ int main() {
   std::cout << "World" << std::endl;
 
   using namespace ALPAKA_ACCELERATOR_NAMESPACE;
-  const DevAcc1 device(alpaka::pltf::getDevByIdx<PltfAcc1>(0u));
+  const DevAcc1 device(alpaka::getDevByIdx<PltfAcc1>(0u));
   Queue queue(device);
 
   // Prepare 1D workDiv
@@ -26,7 +26,7 @@ int main() {
   const Vec1& threadsPerBlockOrElementsPerThread(Vec1(4u));
   const WorkDiv1& workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
 
-  alpaka::queue::enqueue(queue, alpaka::kernel::createTaskKernel<Acc1>(workDiv, Print()));
-  alpaka::wait::wait(queue);
+  alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1>(workDiv, Print()));
+  alpaka::wait(queue);
   return 0;
 }


### PR DESCRIPTION
Update the `alpakatest` and `alpaka` sources following the changes in the Alpaka namespaces and symbol names:
```sed
s#alpaka::acc::#alpaka::#g
s#alpaka::atomic::atomicOp#alpaka::atomicOp#g
s#alpaka::atomic::op::Add#alpaka::AtomicAdd#g
s#alpaka::atomic::op::And#alpaka::AtomicAnd#g
s#alpaka::atomic::op::Cas#alpaka::AtomicCas#g
s#alpaka::atomic::op::Dec#alpaka::AtomicDec#g
s#alpaka::atomic::op::Exch#alpaka::AtomicExch#g
s#alpaka::atomic::op::Inc#alpaka::AtomicInc#g
s#alpaka::atomic::op::Max#alpaka::AtomicMax#g
s#alpaka::atomic::op::Min#alpaka::AtomicMin#g
s#alpaka::atomic::op::Or#alpaka::AtomicOr#g
s#alpaka::atomic::op::Sub#alpaka::AtomicSub#g
s#alpaka::atomic::op::Xor#alpaka::AtomicXor#g
s#alpaka::block::shared::dyn::getMem#alpaka::getDynSharedMem#g
s#alpaka::block::shared::st::allocVar#alpaka::declareSharedVar#g
s#alpaka::block::sync::syncBlockThreads#alpaka::syncBlockThreads#g
s#alpaka::block::sync::op::LogicalOr#alpaka::BlockOr#g
s#alpaka::block::sync::op::LogicalAnd#alpaka::BlockAnd#g
s#alpaka::dev::#alpaka::#g
s#alpaka::dev::getFreeMemBytes#alpaka::getFreeMemBytes#g
s#alpaka::dev::getMemBytes#alpaka::getMemBytes#g
s#alpaka::dim::#alpaka::#g
s#alpaka::event::test#alpaka::isComplete#g
s#alpaka::idx::#alpaka::#g
s#alpaka::kernel::#alpaka::#g
s#alpaka::mem::buf::Buf#alpaka::Buf#g
s#alpaka::mem::buf::alloc#alpaka::allocBuf#g
s#alpaka::mem::view::copy#alpaka::memcpy#g
s#alpaka::mem::view::getPitchBytes#alpaka::getPitchBytes#g
s#alpaka::mem::view::getPtrNative#alpaka::getPtrNative#g
s#alpaka::mem::view::set#alpaka::memset#g
s#alpaka::pltf::#alpaka::#g
s#alpaka::queue::#alpaka::#g
s#alpaka::vec::Vec#alpaka::Vec#g
s#alpaka::wait::wait#alpaka::wait#g
s#alpaka::workdiv::#alpaka::#g
```

Replace the Alpaka/Cupla OpenMP 4 backend with the OpenMP 5 bacakend.