### PR TITLE
CUDA: use the stream-ordered memory allocations if the caching allocator is disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export TEST_DIR := $(BASE_DIR)/test
 
 # System external definitions
 # CUDA
-CUDA_BASE := /usr/local/cuda-11.0
+CUDA_BASE := /usr/local/cuda
 ifeq ($(wildcard $(CUDA_BASE)),)
 # CUDA platform not found
 CUDA_BASE :=

--- a/README.md
+++ b/README.md
@@ -171,9 +171,19 @@ make fwtest ... USER_CXXFLAGS="-DFWTEST_SILENT"
 
 #### `cudatest`
 
-The use of caching allocator can be disabled at compile time with
+The use of caching allocator can be disabled at compile time setting the
+`CUDATEST_DISABLE_CACHING_ALLOCATOR` preprocessor symbol:
 ```
 make cudatest ... USER_CXXFLAGS="-DCUDATEST_DISABLE_CACHING_ALLOCATOR"
+```
+
+If the caching allocator is disabled and CUDA version is 11.2 or greater is detected,
+device allocations and deallocations will use the stream-ordered CUDA functions
+`cudaMallocAsync` and `cudaFreeAsync`. Their use can be disabled explicitly at
+compile time setting also the `CUDATEST_DISABLE_ASYNC_ALLOCATOR` preprocessor symbol:
+
+```
+make cudatest ... USER_CXXFLAGS="-DCUDATEST_DISABLE_CACHING_ALLOCATOR -DCUDATEST_DISABLE_ASYNC_ALLOCATOR"
 ```
 
 #### `cuda`
@@ -201,9 +211,19 @@ make cuda ... USER_CXXFLAGS="-DCUDA_DISABLE_CACHING_ALLOCATOR -DCUDA_DISABLE_ASY
 
 This program is currently equivalent to `cuda`.
 
-The use of caching allocator can be disabled at compile time with
+The use of caching allocator can be disabled at compile time setting the
+`CUDADEV_DISABLE_CACHING_ALLOCATOR` preprocessor symbol:
 ```
 make cudadev ... USER_CXXFLAGS="-DCUDADEV_DISABLE_CACHING_ALLOCATOR"
+```
+
+If the caching allocator is disabled and CUDA version is 11.2 or greater is detected,
+device allocations and deallocations will use the stream-ordered CUDA functions
+`cudaMallocAsync` and `cudaFreeAsync`. Their use can be disabled explicitly at
+compile time setting also the `CUDADEV_DISABLE_ASYNC_ALLOCATOR` preprocessor symbol:
+
+```
+make cudadev ... USER_CXXFLAGS="-DCUDADEV_DISABLE_CACHING_ALLOCATOR -DCUDADEV_DISABLE_ASYNC_ALLOCATOR"
 ```
 
 #### `cudauvm`

--- a/README.md
+++ b/README.md
@@ -182,9 +182,19 @@ This program is frozen to correspond to CMSSW_11_2_0_pre8_Patatrack.
 
 The location of CUDA 11 libraries can be set with `CUDA_BASE` variable.
 
-The use of caching allocator can be disabled at compile time with
+The use of caching allocator can be disabled at compile time setting the
+`CUDA_DISABLE_CACHING_ALLOCATOR` preprocessor symbol:
 ```
 make cuda ... USER_CXXFLAGS="-DCUDA_DISABLE_CACHING_ALLOCATOR"
+```
+
+If the caching allocator is disabled and CUDA version is 11.2 or greater is detected,
+device allocations and deallocations will use the stream-ordered CUDA functions
+`cudaMallocAsync` and `cudaFreeAsync`. Their use can be disabled explicitly at
+compile time setting also the `CUDA_DISABLE_ASYNC_ALLOCATOR` preprocessor symbol:
+
+```
+make cuda ... USER_CXXFLAGS="-DCUDA_DISABLE_CACHING_ALLOCATOR -DCUDA_DISABLE_ASYNC_ALLOCATOR"
 ```
 
 #### `cudadev`

--- a/src/cuda/CUDACore/allocate_device.cc
+++ b/src/cuda/CUDACore/allocate_device.cc
@@ -1,4 +1,7 @@
+#include <cassert>
 #include <limits>
+
+#include <cuda_runtime.h>
 
 #include "CUDACore/ScopedSetDevice.h"
 #include "CUDACore/allocate_device.h"
@@ -14,12 +17,17 @@ namespace {
 namespace cms::cuda {
   void *allocate_device(int dev, size_t nbytes, cudaStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
+#if CUDA_VERSION >= 11020
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(dev);
+      cudaCheck(cudaMallocAsync(&ptr, nbytes, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(dev);
       cudaCheck(cudaMalloc(&ptr, nbytes));
@@ -27,9 +35,14 @@ namespace cms::cuda {
     return ptr;
   }
 
-  void free_device(int device, void *ptr) {
-    if constexpr (allocator::useCaching) {
+  void free_device(int device, void *ptr, cudaStream_t stream) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceFree(device, ptr));
+#if CUDA_VERSION >= 11020
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(device);
+      cudaCheck(cudaFreeAsync(ptr, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(device);
       cudaCheck(cudaFree(ptr));

--- a/src/cuda/CUDACore/allocate_device.h
+++ b/src/cuda/CUDACore/allocate_device.h
@@ -6,10 +6,10 @@
 namespace cms {
   namespace cuda {
     // Allocate device memory
-    void *allocate_device(int dev, size_t nbytes, cudaStream_t stream);
+    void *allocate_device(int device, size_t nbytes, cudaStream_t stream);
 
     // Free device memory (to be called from unique_ptr)
-    void free_device(int device, void *ptr);
+    void free_device(int device, void *ptr, cudaStream_t stream);
   }  // namespace cuda
 }  // namespace cms
 

--- a/src/cuda/CUDACore/allocate_host.cc
+++ b/src/cuda/CUDACore/allocate_host.cc
@@ -13,7 +13,7 @@ namespace {
 namespace cms::cuda {
   void *allocate_host(size_t nbytes, cudaStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
@@ -26,7 +26,7 @@ namespace cms::cuda {
   }
 
   void free_host(void *ptr) {
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingHostAllocator().HostFree(ptr));
     } else {
       cudaCheck(cudaFreeHost(ptr));

--- a/src/cuda/CUDACore/device_unique_ptr.h
+++ b/src/cuda/CUDACore/device_unique_ptr.h
@@ -1,8 +1,10 @@
 #ifndef HeterogeneousCore_CUDAUtilities_interface_device_unique_ptr_h
 #define HeterogeneousCore_CUDAUtilities_interface_device_unique_ptr_h
 
-#include <memory>
 #include <functional>
+#include <memory>
+
+#include <cuda_runtime.h>
 
 #include "CUDACore/allocate_device.h"
 #include "CUDACore/currentDevice.h"
@@ -15,16 +17,17 @@ namespace cms {
         class DeviceDeleter {
         public:
           DeviceDeleter() = default;  // for edm::Wrapper
-          DeviceDeleter(int device) : device_{device} {}
+          DeviceDeleter(int device, cudaStream_t stream) : device_{device}, stream_{stream} {}
 
           void operator()(void *ptr) {
             if (device_ >= 0) {
-              free_device(device_, ptr);
+              free_device(device_, ptr, stream_);
             }
           }
 
         private:
           int device_ = -1;
+          cudaStream_t stream_ = cudaStreamDefault;
         };
       }  // namespace impl
 
@@ -54,7 +57,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, sizeof(T), stream);
       return typename device::impl::make_device_unique_selector<T>::non_array{reinterpret_cast<T *>(mem),
-                                                                              device::impl::DeviceDeleter{dev}};
+                                                                              device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T>
@@ -66,7 +69,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, n * sizeof(element_type), stream);
       return typename device::impl::make_device_unique_selector<T>::unbounded_array{
-          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev}};
+          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T, typename... Args>
@@ -79,7 +82,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, sizeof(T), stream);
       return typename device::impl::make_device_unique_selector<T>::non_array{reinterpret_cast<T *>(mem),
-                                                                              device::impl::DeviceDeleter{dev}};
+                                                                              device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T>
@@ -89,7 +92,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, n * sizeof(element_type), stream);
       return typename device::impl::make_device_unique_selector<T>::unbounded_array{
-          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev}};
+          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T, typename... Args>

--- a/src/cuda/CUDACore/getCachingDeviceAllocator.h
+++ b/src/cuda/CUDACore/getCachingDeviceAllocator.h
@@ -4,16 +4,25 @@
 #include <iomanip>
 #include <iostream>
 
+#include <cuda_runtime.h>
+
 #include "CUDACore/cudaCheck.h"
 #include "CUDACore/deviceCount.h"
 #include "CachingDeviceAllocator.h"
 
 namespace cms::cuda::allocator {
   // Use caching or not
-#ifdef CUDA_DISABLE_CACHING_ALLOCATOR
-  constexpr bool useCaching = false;
+  enum class Policy {
+    Synchronous = 0,
+    Asynchronous = 1,
+    Caching = 2
+  };
+#ifndef CUDA_DISABLE_CACHING_ALLOCATOR
+  constexpr Policy policy =  Policy::Caching;
+#elif CUDA_VERSION >= 11020 && ! defined CUDA_DISABLE_ASYNC_ALLOCATOR
+  constexpr Policy policy =  Policy::Asynchronous;
 #else
-  constexpr bool useCaching = true;
+  constexpr Policy policy =  Policy::Synchronous;
 #endif
   // Growth factor (bin_growth in cub::CachingDeviceAllocator
   constexpr unsigned int binGrowth = 2;

--- a/src/cudadev/CUDACore/allocate_device.cc
+++ b/src/cudadev/CUDACore/allocate_device.cc
@@ -1,4 +1,7 @@
+#include <cassert>
 #include <limits>
+
+#include <cuda_runtime.h>
 
 #include "CUDACore/ScopedSetDevice.h"
 #include "CUDACore/allocate_device.h"
@@ -14,12 +17,17 @@ namespace {
 namespace cms::cuda {
   void *allocate_device(int dev, size_t nbytes, cudaStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
+#if CUDA_VERSION >= 11020
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(dev);
+      cudaCheck(cudaMallocAsync(&ptr, nbytes, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(dev);
       cudaCheck(cudaMalloc(&ptr, nbytes));
@@ -27,9 +35,14 @@ namespace cms::cuda {
     return ptr;
   }
 
-  void free_device(int device, void *ptr) {
-    if constexpr (allocator::useCaching) {
+  void free_device(int device, void *ptr, cudaStream_t stream) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceFree(device, ptr));
+#if CUDA_VERSION >= 11020
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(device);
+      cudaCheck(cudaFreeAsync(ptr, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(device);
       cudaCheck(cudaFree(ptr));

--- a/src/cudadev/CUDACore/allocate_device.h
+++ b/src/cudadev/CUDACore/allocate_device.h
@@ -6,10 +6,10 @@
 namespace cms {
   namespace cuda {
     // Allocate device memory
-    void *allocate_device(int dev, size_t nbytes, cudaStream_t stream);
+    void *allocate_device(int device, size_t nbytes, cudaStream_t stream);
 
     // Free device memory (to be called from unique_ptr)
-    void free_device(int device, void *ptr);
+    void free_device(int device, void *ptr, cudaStream_t stream);
   }  // namespace cuda
 }  // namespace cms
 

--- a/src/cudadev/CUDACore/allocate_host.cc
+++ b/src/cudadev/CUDACore/allocate_host.cc
@@ -13,7 +13,7 @@ namespace {
 namespace cms::cuda {
   void *allocate_host(size_t nbytes, cudaStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
@@ -26,7 +26,7 @@ namespace cms::cuda {
   }
 
   void free_host(void *ptr) {
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingHostAllocator().HostFree(ptr));
     } else {
       cudaCheck(cudaFreeHost(ptr));

--- a/src/cudadev/CUDACore/device_unique_ptr.h
+++ b/src/cudadev/CUDACore/device_unique_ptr.h
@@ -1,8 +1,10 @@
 #ifndef HeterogeneousCore_CUDAUtilities_interface_device_unique_ptr_h
 #define HeterogeneousCore_CUDAUtilities_interface_device_unique_ptr_h
 
-#include <memory>
 #include <functional>
+#include <memory>
+
+#include <cuda_runtime.h>
 
 #include "CUDACore/allocate_device.h"
 #include "CUDACore/currentDevice.h"
@@ -15,16 +17,17 @@ namespace cms {
         class DeviceDeleter {
         public:
           DeviceDeleter() = default;  // for edm::Wrapper
-          DeviceDeleter(int device) : device_{device} {}
+          DeviceDeleter(int device, cudaStream_t stream) : device_{device}, stream_{stream} {}
 
           void operator()(void *ptr) {
             if (device_ >= 0) {
-              free_device(device_, ptr);
+              free_device(device_, ptr, stream_);
             }
           }
 
         private:
           int device_ = -1;
+          cudaStream_t stream_ = cudaStreamDefault;
         };
       }  // namespace impl
 
@@ -54,7 +57,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, sizeof(T), stream);
       return typename device::impl::make_device_unique_selector<T>::non_array{reinterpret_cast<T *>(mem),
-                                                                              device::impl::DeviceDeleter{dev}};
+                                                                              device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T>
@@ -66,7 +69,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, n * sizeof(element_type), stream);
       return typename device::impl::make_device_unique_selector<T>::unbounded_array{
-          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev}};
+          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T, typename... Args>
@@ -79,7 +82,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, sizeof(T), stream);
       return typename device::impl::make_device_unique_selector<T>::non_array{reinterpret_cast<T *>(mem),
-                                                                              device::impl::DeviceDeleter{dev}};
+                                                                              device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T>
@@ -89,7 +92,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, n * sizeof(element_type), stream);
       return typename device::impl::make_device_unique_selector<T>::unbounded_array{
-          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev}};
+          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T, typename... Args>

--- a/src/cudadev/CUDACore/getCachingDeviceAllocator.h
+++ b/src/cudadev/CUDACore/getCachingDeviceAllocator.h
@@ -4,16 +4,25 @@
 #include <iomanip>
 #include <iostream>
 
+#include <cuda_runtime.h>
+
 #include "CUDACore/cudaCheck.h"
 #include "CUDACore/deviceCount.h"
 #include "CachingDeviceAllocator.h"
 
 namespace cms::cuda::allocator {
   // Use caching or not
-#ifdef CUDADEV_DISABLE_CACHING_ALLOCATOR
-  constexpr bool useCaching = false;
+  enum class Policy {
+    Synchronous = 0,
+    Asynchronous = 1,
+    Caching = 2
+  };
+#ifndef CUDADEV_DISABLE_CACHING_ALLOCATOR
+  constexpr Policy policy =  Policy::Caching;
+#elif CUDADEV_VERSION >= 11020 && ! defined CUDADEV_DISABLE_ASYNC_ALLOCATOR
+  constexpr Policy policy =  Policy::Asynchronous;
 #else
-  constexpr bool useCaching = true;
+  constexpr Policy policy =  Policy::Synchronous;
 #endif
   // Growth factor (bin_growth in cub::CachingDeviceAllocator
   constexpr unsigned int binGrowth = 2;

--- a/src/cudatest/CUDACore/allocate_device.cc
+++ b/src/cudatest/CUDACore/allocate_device.cc
@@ -1,4 +1,7 @@
+#include <cassert>
 #include <limits>
+
+#include <cuda_runtime.h>
 
 #include "CUDACore/ScopedSetDevice.h"
 #include "CUDACore/allocate_device.h"
@@ -14,12 +17,17 @@ namespace {
 namespace cms::cuda {
   void *allocate_device(int dev, size_t nbytes, cudaStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
+#if CUDA_VERSION >= 11020
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(dev);
+      cudaCheck(cudaMallocAsync(&ptr, nbytes, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(dev);
       cudaCheck(cudaMalloc(&ptr, nbytes));
@@ -27,9 +35,14 @@ namespace cms::cuda {
     return ptr;
   }
 
-  void free_device(int device, void *ptr) {
-    if constexpr (allocator::useCaching) {
+  void free_device(int device, void *ptr, cudaStream_t stream) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceFree(device, ptr));
+#if CUDA_VERSION >= 11020
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(device);
+      cudaCheck(cudaFreeAsync(ptr, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(device);
       cudaCheck(cudaFree(ptr));

--- a/src/cudatest/CUDACore/allocate_device.h
+++ b/src/cudatest/CUDACore/allocate_device.h
@@ -6,10 +6,10 @@
 namespace cms {
   namespace cuda {
     // Allocate device memory
-    void *allocate_device(int dev, size_t nbytes, cudaStream_t stream);
+    void *allocate_device(int device, size_t nbytes, cudaStream_t stream);
 
     // Free device memory (to be called from unique_ptr)
-    void free_device(int device, void *ptr);
+    void free_device(int device, void *ptr, cudaStream_t stream);
   }  // namespace cuda
 }  // namespace cms
 

--- a/src/cudatest/CUDACore/allocate_host.cc
+++ b/src/cudatest/CUDACore/allocate_host.cc
@@ -13,7 +13,7 @@ namespace {
 namespace cms::cuda {
   void *allocate_host(size_t nbytes, cudaStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
@@ -26,7 +26,7 @@ namespace cms::cuda {
   }
 
   void free_host(void *ptr) {
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingHostAllocator().HostFree(ptr));
     } else {
       cudaCheck(cudaFreeHost(ptr));

--- a/src/cudatest/CUDACore/device_unique_ptr.h
+++ b/src/cudatest/CUDACore/device_unique_ptr.h
@@ -1,8 +1,10 @@
 #ifndef HeterogeneousCore_CUDAUtilities_interface_device_unique_ptr_h
 #define HeterogeneousCore_CUDAUtilities_interface_device_unique_ptr_h
 
-#include <memory>
 #include <functional>
+#include <memory>
+
+#include <cuda_runtime.h>
 
 #include "CUDACore/allocate_device.h"
 #include "CUDACore/currentDevice.h"
@@ -15,16 +17,17 @@ namespace cms {
         class DeviceDeleter {
         public:
           DeviceDeleter() = default;  // for edm::Wrapper
-          DeviceDeleter(int device) : device_{device} {}
+          DeviceDeleter(int device, cudaStream_t stream) : device_{device}, stream_{stream} {}
 
           void operator()(void *ptr) {
             if (device_ >= 0) {
-              free_device(device_, ptr);
+              free_device(device_, ptr, stream_);
             }
           }
 
         private:
           int device_ = -1;
+          cudaStream_t stream_ = cudaStreamDefault;
         };
       }  // namespace impl
 
@@ -54,7 +57,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, sizeof(T), stream);
       return typename device::impl::make_device_unique_selector<T>::non_array{reinterpret_cast<T *>(mem),
-                                                                              device::impl::DeviceDeleter{dev}};
+                                                                              device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T>
@@ -66,7 +69,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, n * sizeof(element_type), stream);
       return typename device::impl::make_device_unique_selector<T>::unbounded_array{
-          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev}};
+          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T, typename... Args>
@@ -79,7 +82,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, sizeof(T), stream);
       return typename device::impl::make_device_unique_selector<T>::non_array{reinterpret_cast<T *>(mem),
-                                                                              device::impl::DeviceDeleter{dev}};
+                                                                              device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T>
@@ -89,7 +92,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, n * sizeof(element_type), stream);
       return typename device::impl::make_device_unique_selector<T>::unbounded_array{
-          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev}};
+          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T, typename... Args>

--- a/src/cudatest/CUDACore/getCachingDeviceAllocator.h
+++ b/src/cudatest/CUDACore/getCachingDeviceAllocator.h
@@ -4,16 +4,25 @@
 #include <iomanip>
 #include <iostream>
 
+#include <cuda_runtime.h>
+
 #include "CUDACore/cudaCheck.h"
 #include "CUDACore/deviceCount.h"
 #include "CachingDeviceAllocator.h"
 
 namespace cms::cuda::allocator {
   // Use caching or not
-#ifdef CUDATEST_DISABLE_CACHING_ALLOCATOR
-  constexpr bool useCaching = false;
+  enum class Policy {
+    Synchronous = 0,
+    Asynchronous = 1,
+    Caching = 2
+  };
+#ifndef CUDATEST_DISABLE_CACHING_ALLOCATOR
+  constexpr Policy policy =  Policy::Caching;
+#elif CUDATEST_VERSION >= 11020 && ! defined CUDATEST_DISABLE_ASYNC_ALLOCATOR
+  constexpr Policy policy =  Policy::Asynchronous;
 #else
-  constexpr bool useCaching = true;
+  constexpr Policy policy =  Policy::Synchronous;
 #endif
   // Growth factor (bin_growth in cub::CachingDeviceAllocator
   constexpr unsigned int binGrowth = 2;


### PR DESCRIPTION
If the caching allocator is disabled and CUDA version is 11.2 or greater is detected, device allocations and deallocations will use the stream-ordered CUDA functions `cudaMallocAsync` and `cudaFreeAsync`.

Their use can be disabled explicitly at compile time setting also the `CUDA_DISABLE_ASYNC_ALLOCATOR` preprocessor symbol.