### PR TITLE
Use explicit number of threads per team for remaining team-wide parallel_scan

### DIFF
--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
@@ -694,7 +694,11 @@ namespace KOKKOS_NAMESPACE {
             execSpace, Kokkos::subview(nModules_Clusters_h, 0), Kokkos::subview(clusters_d.moduleStart(), 0));
 
         const uint32_t blocks = ::gpuClustering::MaxNumModules;
+#if defined KOKKOS_BACKEND_SERIAL || defined KOKKOS_BACKEND_PTHREAD
         Kokkos::TeamPolicy<KokkosExecSpace> teamPolicy(execSpace, blocks, Kokkos::AUTO());
+#else
+        Kokkos::TeamPolicy<KokkosExecSpace> teamPolicy(execSpace, blocks, 256);
+#endif
 #ifdef GPU_DEBUG
         std::cout << "CUDA findClus kernel launch with " << blocks << " blocks of " << teamPolicy.team_size()
                   << " threads\n";


### PR DESCRIPTION
The `kokkos --cuda` failed in asserts with CUDA 11.2 o V100 about parallel_scan being used without power-of-2 number of threads per team. This was the only use of `TeamPolicy` wit `Kokkos::AUTO()` number of threads that calls team-wide `parallel_scan`.

The `kokkos --cuda`  runs now with both CUDA 11.2 and 11.3 on V100.