### PR TITLE
Print a stack trace on CUDA errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export BASE_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export CXX := g++
 USER_CXXFLAGS :=
 HOST_CXXFLAGS := -O2 -fPIC -fdiagnostics-show-option -felide-constructors -fmessage-length=0 -fno-math-errno -ftree-vectorize -fvisibility-inlines-hidden --param vect-max-version-for-alias-checks=50 -msse3 -pipe -pthread -Werror=address -Wall -Werror=array-bounds -Wno-attributes -Werror=conversion-null -Werror=delete-non-virtual-dtor -Wno-deprecated -Werror=format-contains-nul -Werror=format -Wno-long-long -Werror=main -Werror=missing-braces -Werror=narrowing -Wno-non-template-friend -Wnon-virtual-dtor -Werror=overflow -Werror=overlength-strings -Wparentheses -Werror=pointer-arith -Wno-psabi -Werror=reorder -Werror=return-local-addr -Wreturn-type -Werror=return-type -Werror=sign-compare -Werror=strict-aliasing -Wstrict-overflow -Werror=switch -Werror=type-limits -Wunused -Werror=unused-but-set-variable -Wno-unused-local-typedefs -Werror=unused-value -Wno-error=unused-variable -Wno-vla -Werror=write-strings
-export CXXFLAGS := -std=c++17 $(HOST_CXXFLAGS) $(USER_CXXFLAGS)
+export CXXFLAGS := -std=c++17 $(HOST_CXXFLAGS) $(USER_CXXFLAGS) -g
 export LDFLAGS := -O2 -fPIC -pthread -Wl,-E -lstdc++fs -ldl
 export LDFLAGS_NVCC := -ccbin $(CXX) --linker-options '-E' --linker-options '-lstdc++fs'
 export SO_LDFLAGS := -Wl,-z,defs
@@ -45,7 +45,7 @@ export CUDA_LDFLAGS := -L$(CUDA_BASE)/lib64 -lcudart -lcudadevrt
 export CUDA_NVCC := $(CUDA_BASE)/bin/nvcc
 define CUFLAGS_template
 $(2)NVCC_FLAGS := $$(foreach ARCH,$(1),-gencode arch=compute_$$(ARCH),code=sm_$$(ARCH)) -Wno-deprecated-gpu-targets -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --expt-relaxed-constexpr --expt-extended-lambda --generate-line-info --source-in-ptx --cudart=shared
-$(2)NVCC_COMMON := -std=c++17 -O3 $$($(2)NVCC_FLAGS) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS) $(USER_CXXFLAGS)'
+$(2)NVCC_COMMON := -std=c++17 -O3 $$($(2)NVCC_FLAGS) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS) $(USER_CXXFLAGS)' -g -lineinfo
 $(2)CUDA_CUFLAGS := -dc $$($(2)NVCC_COMMON) $(USER_CUDAFLAGS)
 $(2)CUDA_DLINKFLAGS := -dlink $$($(2)NVCC_COMMON)
 endef

--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,9 @@ env.sh: Makefile
 	@echo                                                                   >> $@
 	@echo -n 'export LD_LIBRARY_PATH='                                      >> $@
 	@echo -n '$(TBB_LIBDIR):'                                               >> $@
+ifeq ($(NEED_BOOST),true)
+	@echo -n '$(BOOST_BASE)/lib:'                                           >> $@
+endif
 ifdef CUDA_BASE
 	@echo -n '$(CUDA_LIBDIR):'                                              >> $@
 endif
@@ -456,7 +459,7 @@ $(BOOST_BASE): CXXFLAGS:=
 $(BOOST_BASE):
 	$(eval BOOST_TMP := $(shell mktemp -d))
 	curl -L -s -S https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 | tar xj -C $(BOOST_TMP)
-	cd $(BOOST_TMP)/boost_1_76_0 && ./bootstrap.sh && ./b2 install --prefix=$@
+	cd $(BOOST_TMP)/boost_1_76_0 && ./bootstrap.sh && ./b2 install --prefix=$@ --without-graph_parallel --without-mpi --without-python
 	@rm -rf $(BOOST_TMP)
 	$(eval undefine BOOST_TMP)
 

--- a/src/cuda/CUDACore/cudaCheck.h
+++ b/src/cuda/CUDACore/cudaCheck.h
@@ -6,6 +6,10 @@
 #include <sstream>
 #include <stdexcept>
 
+// Boost headers
+#define BOOST_STACKTRACE_USE_BACKTRACE
+#include <boost/stacktrace.hpp>
+
 // CUDA headers
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -26,6 +30,11 @@ namespace cms {
       out << error << ": " << message << "\n";
       if (description)
         out << description << "\n";
+
+      out << "\nCurrent stack trace:\n";
+      out << boost::stacktrace::stacktrace();
+      out << "\n";
+
       throw std::runtime_error(out.str());
     }
 

--- a/src/cuda/Makefile.deps
+++ b/src/cuda/Makefile.deps
@@ -1,4 +1,4 @@
-cuda_EXTERNAL_DEPENDS := TBB CUDA EIGEN
+cuda_EXTERNAL_DEPENDS := TBB CUDA EIGEN BOOST BACKTRACE
 BeamSpotProducer_DEPENDS := Framework CUDACore CUDADataFormats
 CUDACore_DEPENDS := Framework
 CUDADataFormats_DEPENDS := CUDACore DataFormats


### PR DESCRIPTION
When `cudaCheck()` detects a CUDA error, in addition to the file and line number of the call, print a full stack trace.

For example:
```
/home/cern/pixeltrack-standalone/src/cuda/CUDACore/CachingDeviceAllocator.h, line 559:
cudaCheck(error = cudaGetLastError());
cudaErrorIllegalAddress: an illegal memory access was encountered

Current stack trace:
 0# cms::cuda::abortOnCudaError(char const*, int, char const*, char const*, char const*, char const*) at /home/cern/pixeltrack-standalone/src/cuda/CUDACore/cudaCheck.h:35
 1# 0x00007F47541E637B at /home/cern/pixeltrack-standalone/src/cuda/CUDACore/cudaCheck.h:61
 2# cms::cuda::free_device(int, void*, CUstream_st*) at /home/cern/pixeltrack-standalone/src/cuda/CUDACore/allocate_device.cc:40
 3# TrackingRecHit2DHeterogeneous<cms::cudacompat::GPUTraits>::~TrackingRecHit2DHeterogeneous() at /home/cern/pixeltrack-standalone/src/cuda/CUDADataFormats/TrackingRecHit2DHeterogeneous.h:22
 4# pixelgpudetails::PixelRecHitGPUKernel::makeHitsAsync(SiPixelDigisCUDA const&, SiPixelClustersCUDA const&, BeamSpotCUDA const&, pixelCPEforGPU::ParamsOnGPU const*, CUstream_st*) const [clone .cold.119] at /usr/include/c++/8/bits/basic_string.tcc:138
 5# SiPixelRecHitCUDA::produce(edm::Event&, edm::EventSetup const&) at /home/cern/pixeltrack-standalone/src/cuda/plugin-SiPixelRecHits/SiPixelRecHitCUDA.cc:58
 6# edm::FunctorWaitingTask<edm::WorkerT<SiPixelRecHitCUDA>::doWorkAsync(edm::Event&, edm::EventSetup const&, edm::WaitingTask*)::{lambda(std::__exception_ptr::exception_ptr const*)#1}>::execute() at /home/cern/pixeltrack-standalone/src/cuda/Framework/WaitingTask.h:78
 7# tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::process_bypass_loop(tbb::internal::context_guard_helper<false>&, tbb::task*, long) at ../../src/tbb/custom_scheduler.h:469
 8# tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) at ../../src/tbb/custom_scheduler.h:631
 9# edm::EventProcessor::runToCompletion() at /home/cern/pixeltrack-standalone/src/cuda/bin/EventProcessor.cc:36
10# main at /home/cern/pixeltrack-standalone/src/cuda/bin/main.cc:147
11# __libc_start_main in /lib64/libc.so.6
12# _start in ./cuda
```

The stack trace is generated by [libbacktrace](https://github.com/ianlancetaylor/libbacktrace) and [Boost.Stacktrace](https://www.boost.org/doc/libs/1_76_0/doc/html/stacktrace.html).