### PR TITLE
[cudatest,cudadev] Fix the fallback to the stream ordered CUDA memory operations

### DIFF
--- a/src/cudadev/CUDACore/getCachingDeviceAllocator.h
+++ b/src/cudadev/CUDACore/getCachingDeviceAllocator.h
@@ -15,7 +15,7 @@ namespace cms::cuda::allocator {
   enum class Policy { Synchronous = 0, Asynchronous = 1, Caching = 2 };
 #ifndef CUDADEV_DISABLE_CACHING_ALLOCATOR
   constexpr Policy policy = Policy::Caching;
-#elif CUDADEV_VERSION >= 11020 && !defined CUDADEV_DISABLE_ASYNC_ALLOCATOR
+#elif CUDA_VERSION >= 11020 && !defined CUDADEV_DISABLE_ASYNC_ALLOCATOR
   constexpr Policy policy = Policy::Asynchronous;
 #else
   constexpr Policy policy = Policy::Synchronous;

--- a/src/cudatest/CUDACore/getCachingDeviceAllocator.h
+++ b/src/cudatest/CUDACore/getCachingDeviceAllocator.h
@@ -15,7 +15,7 @@ namespace cms::cuda::allocator {
   enum class Policy { Synchronous = 0, Asynchronous = 1, Caching = 2 };
 #ifndef CUDATEST_DISABLE_CACHING_ALLOCATOR
   constexpr Policy policy = Policy::Caching;
-#elif CUDATEST_VERSION >= 11020 && !defined CUDATEST_DISABLE_ASYNC_ALLOCATOR
+#elif CUDA_VERSION >= 11020 && !defined CUDATEST_DISABLE_ASYNC_ALLOCATOR
   constexpr Policy policy = Policy::Asynchronous;
 #else
   constexpr Policy policy = Policy::Synchronous;


### PR DESCRIPTION
Fix the CUDA version detection for the `cudatest` and `cudadev` programs.