### PR TITLE
Fix shorten function and add HIP workarounds

### DIFF
--- a/src/hip/CUDACore/radixSort.h
+++ b/src/hip/CUDACore/radixSort.h
@@ -92,8 +92,6 @@ __device__ __forceinline__ void radixSortImpl(
   __shared__ int32_t c[sb], ct[sb], cu[sb];
 
   __shared__ int ibs;
-  __shared__ int ibs2;
-  __shared__ int ibs3;
   __shared__ int p;
 
   assert(size > 0);
@@ -151,8 +149,6 @@ __device__ __forceinline__ void radixSortImpl(
     // broadcast
     ibs = size - 1;
 
-    // Workaround for hang in gpuVertexFinder_t.
-    ibs3 = ibs;
 
     __syncthreads();
     while (__syncthreads_and(ibs > 0)) {
@@ -185,8 +181,10 @@ __device__ __forceinline__ void radixSortImpl(
         assert(c[bin] >= 0);
       if (threadIdx.x == 0) {
         ibs -= sb;
-        // Workaround for problems in radixSort_t.
-        ibs2 = ibs;
+
+        // Fix for problems in radixSort_t.
+        // Without this, this c[bin] >=0 assert above will be triggered.
+        __threadfence();
       }
       __syncthreads();
     }

--- a/src/hip/CUDACore/radixSort.h
+++ b/src/hip/CUDACore/radixSort.h
@@ -150,7 +150,10 @@ __device__ __forceinline__ void radixSortImpl(
 
     // broadcast
     ibs = size - 1;
+
+    // Workaround for hang in gpuVertexFinder_t.
     ibs3 = ibs;
+
     __syncthreads();
     while (__syncthreads_and(ibs > 0)) {
       int i = ibs - threadIdx.x;
@@ -182,6 +185,7 @@ __device__ __forceinline__ void radixSortImpl(
         assert(c[bin] >= 0);
       if (threadIdx.x == 0) {
         ibs -= sb;
+        // Workaround for problems in radixSort_t.
         ibs2 = ibs;
       }
       __syncthreads();

--- a/src/hip/test/radixSort_t.cu
+++ b/src/hip/test/radixSort_t.cu
@@ -140,8 +140,9 @@ void go(bool useShared) {
         auto sh = sizeof(uint64_t) - NS;
         sh *= 8;
         auto shorten = [sh](T& t) {
-          auto k = (uint64_t*)(&t);
-          *k = (*k >> sh) << sh;
+          uint64_t k = *(uint64_t *)(&t);
+          k = (k >> sh) << sh;
+          t = *(T*)(&k);
         };
         shorten(k1);
         shorten(k2);


### PR DESCRIPTION
Add the workarounds listed in #178 

Assign the `ibs` variable to another variable - fixes radixSort_t (`ibs2`) and gpuVertexFinder (`ibs3`)

Remove launch bounds - fixes radixSort_t where the kernel silently fails to run

Fix the shorten function to avoid overwriting other memory if the type size is less than 8 bytes.