### PR TITLE
Tune the CUDA memory pool used by the stream ordered memory operations

### DIFF
--- a/src/cuda/bin/main.cc
+++ b/src/cuda/bin/main.cc
@@ -11,6 +11,7 @@
 
 #include <cuda_runtime.h>
 
+#include "CUDACore/getCachingDeviceAllocator.h"
 #include "EventProcessor.h"
 
 namespace {
@@ -92,6 +93,16 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
   std::cout << "Found " << numberOfDevices << " devices" << std::endl;
+
+#if CUDA_VERSION >= 11020
+  // Initialize the CUDA memory pool
+  uint64_t threshold = cms::cuda::allocator::minCachedBytes();
+  for (int device = 0; device < numberOfDevices; ++device) {
+    cudaMemPool_t pool;
+    cudaDeviceGetDefaultMemPool(&pool, device);
+    cudaMemPoolSetAttribute(pool, cudaMemPoolAttrReleaseThreshold, &threshold);
+  }
+#endif
 
   // Initialize EventProcessor
   std::vector<std::string> edmodules;

--- a/src/cudadev/bin/main.cc
+++ b/src/cudadev/bin/main.cc
@@ -11,6 +11,7 @@
 
 #include <cuda_runtime.h>
 
+#include "CUDACore/getCachingDeviceAllocator.h"
 #include "EventProcessor.h"
 
 namespace {
@@ -92,6 +93,16 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
   std::cout << "Found " << numberOfDevices << " devices" << std::endl;
+
+#if CUDA_VERSION >= 11020
+  // Initialize the CUDA memory pool
+  uint64_t threshold = cms::cuda::allocator::minCachedBytes();
+  for (int device = 0; device < numberOfDevices; ++device) {
+    cudaMemPool_t pool;
+    cudaDeviceGetDefaultMemPool(&pool, device);
+    cudaMemPoolSetAttribute(pool, cudaMemPoolAttrReleaseThreshold, &threshold);
+  }
+#endif
 
   // Initialize EventProcessor
   std::vector<std::string> edmodules;

--- a/src/cudatest/bin/main.cc
+++ b/src/cudatest/bin/main.cc
@@ -10,6 +10,7 @@
 
 #include <cuda_runtime.h>
 
+#include "CUDACore/getCachingDeviceAllocator.h"
 #include "EventProcessor.h"
 
 namespace {
@@ -86,6 +87,16 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
   std::cout << "Found " << numberOfDevices << " devices" << std::endl;
+
+#if CUDA_VERSION >= 11020
+  // Initialize the CUDA memory pool
+  uint64_t threshold = cms::cuda::allocator::minCachedBytes();
+  for (int device = 0; device < numberOfDevices; ++device) {
+    cudaMemPool_t pool;
+    cudaDeviceGetDefaultMemPool(&pool, device);
+    cudaMemPoolSetAttribute(pool, cudaMemPoolAttrReleaseThreshold, &threshold);
+  }
+#endif
 
   // Initialize EventProcessor
   std::vector<std::string> edmodules;


### PR DESCRIPTION
Configure the default CUDA memory pool to cache memory allocations, following a similar behaviour to the cub caching allocator.

See *Using the NVIDIA CUDA Stream-Ordered Memory Allocator* in the NVIDIA developer blog ([part 1](https://developer.nvidia.com/blog/using-the-nvidia-cuda-stream-ordered-memory-allocator-part-1/), [part 2](https://developer.nvidia.com/blog/using-the-nvidia-cuda-stream-ordered-memory-allocator-part-2/)) for more information, and the various options for tuning the CUDA memory pools.

Achieves a small speed up when using the memory pool, but still much slower than the caching allocator:

#### cudadev, CUB caching allocator
```
Found 1 devices
Processing 8000 events, of which 8 concurrently, with 8 threads.
Processed 8000 events in 9.022492e+00 seconds, throughput 886.673 events/s.
Processed 8000 events in 9.038757e+00 seconds, throughput 885.077 events/s.
Processed 8000 events in 9.075188e+00 seconds, throughput 881.524 events/s.
```

#### cudadev, stream ordered memory operations
```
Found 1 devices
Processing 8000 events, of which 8 concurrently, with 8 threads.
Processed 8000 events in 1.328329e+01 seconds, throughput 602.26 events/s.
Processed 8000 events in 1.336558e+01 seconds, throughput 598.553 events/s.
Processed 8000 events in 1.326502e+01 seconds, throughput 603.09 events/s.
```

#### cudadev, stream ordered memory operations and caching
```
Found 1 devices
Processing 8000 events, of which 8 concurrently, with 8 threads.
Processed 8000 events in 1.255865e+01 seconds, throughput 637.011 events/s.
Processed 8000 events in 1.245068e+01 seconds, throughput 642.535 events/s.
Processed 8000 events in 1.243959e+01 seconds, throughput 643.108 events/s.
```

