### PR TITLE
Fix uploading EventSetup conditions from multiple CUDA streams

### DIFF
--- a/src/cuda/CUDACore/ESProduct.h
+++ b/src/cuda/CUDACore/ESProduct.h
@@ -74,6 +74,9 @@ namespace cms {
             transferAsync(data.m_data, cudaStream);
             assert(data.m_fillingStream == nullptr);
             data.m_fillingStream = cudaStream;
+            // Record in the cudaStream an event to mark the readiness of the
+            // EventSetup data on the GPU, so other streams can check for it
+            cudaCheck(cudaEventRecord(data.m_event.get(), cudaStream));
             // Now the filling has been enqueued to the cudaStream, so we
             // can return the GPU data immediately, since all subsequent
             // work must be either enqueued to the cudaStream, or the cudaStream

--- a/src/cudacompat/CUDACore/ESProduct.h
+++ b/src/cudacompat/CUDACore/ESProduct.h
@@ -74,6 +74,9 @@ namespace cms {
             transferAsync(data.m_data, cudaStream);
             assert(data.m_fillingStream == nullptr);
             data.m_fillingStream = cudaStream;
+            // Record in the cudaStream an event to mark the readiness of the
+            // EventSetup data on the GPU, so other streams can check for it
+            cudaCheck(cudaEventRecord(data.m_event.get(), cudaStream));
             // Now the filling has been enqueued to the cudaStream, so we
             // can return the GPU data immediately, since all subsequent
             // work must be either enqueued to the cudaStream, or the cudaStream

--- a/src/cudadev/CUDACore/ESProduct.h
+++ b/src/cudadev/CUDACore/ESProduct.h
@@ -74,6 +74,9 @@ namespace cms {
             transferAsync(data.m_data, cudaStream);
             assert(data.m_fillingStream == nullptr);
             data.m_fillingStream = cudaStream;
+            // Record in the cudaStream an event to mark the readiness of the
+            // EventSetup data on the GPU, so other streams can check for it
+            cudaCheck(cudaEventRecord(data.m_event.get(), cudaStream));
             // Now the filling has been enqueued to the cudaStream, so we
             // can return the GPU data immediately, since all subsequent
             // work must be either enqueued to the cudaStream, or the cudaStream

--- a/src/cudauvm/CUDACore/ESProduct.h
+++ b/src/cudauvm/CUDACore/ESProduct.h
@@ -74,6 +74,9 @@ namespace cms {
             transferAsync(data.m_data, cudaStream);
             assert(data.m_fillingStream == nullptr);
             data.m_fillingStream = cudaStream;
+            // Record in the cudaStream an event to mark the readiness of the
+            // EventSetup data on the GPU, so other streams can check for it
+            cudaCheck(cudaEventRecord(data.m_event.get(), cudaStream));
             // Now the filling has been enqueued to the cudaStream, so we
             // can return the GPU data immediately, since all subsequent
             // work must be either enqueued to the cudaStream, or the cudaStream

--- a/src/hip/CUDACore/ESProduct.h
+++ b/src/hip/CUDACore/ESProduct.h
@@ -74,6 +74,9 @@ namespace cms {
             transferAsync(data.m_data, cudaStream);
             assert(data.m_fillingStream == nullptr);
             data.m_fillingStream = cudaStream;
+            // Record in the cudaStream an event to mark the readiness of the
+            // EventSetup data on the GPU, so other streams can check for it
+            cudaCheck(hipEventRecord(data.m_event.get(), cudaStream));
             // Now the filling has been enqueued to the cudaStream, so we
             // can return the GPU data immediately, since all subsequent
             // work must be either enqueued to the cudaStream, or the cudaStream


### PR DESCRIPTION
When multiple CUDA streams are trying to initialise the same EventSetup object, the first one to do
so starts the asynchronous operations, and the others are supposed to wait for it to finish.
However, code for recording the CUDA event was missing, so the other streams would find the default-
constructed event, which is always "valid".

Adding the missing call to record the event fixes the problem.