### PR TITLE
[cudadev] Minimal updates from CMSSW_12_0_0_pre5

### DIFF
--- a/src/cudadev/CUDACore/cudaCompat.h
+++ b/src/cudadev/CUDACore/cudaCompat.h
@@ -40,11 +40,21 @@ namespace cms {
     }
 
     template <typename T1, typename T2>
+    T1 atomicCAS_block(T1* address, T1 compare, T2 val) {
+      return atomicCAS(address, compare, val);
+    }
+
+    template <typename T1, typename T2>
     T1 atomicInc(T1* a, T2 b) {
       auto ret = *a;
       if ((*a) < T1(b))
         (*a)++;
       return ret;
+    }
+
+    template <typename T1, typename T2>
+    T1 atomicInc_block(T1* a, T2 b) {
+      return atomicInc(a, b);
     }
 
     template <typename T1, typename T2>
@@ -55,10 +65,20 @@ namespace cms {
     }
 
     template <typename T1, typename T2>
+    T1 atomicAdd_block(T1* a, T2 b) {
+      return atomicAdd(a, b);
+    }
+
+    template <typename T1, typename T2>
     T1 atomicSub(T1* a, T2 b) {
       auto ret = *a;
       (*a) -= b;
       return ret;
+    }
+
+    template <typename T1, typename T2>
+    T1 atomicSub_block(T1* a, T2 b) {
+      return atomicSub(a, b);
     }
 
     template <typename T1, typename T2>
@@ -67,11 +87,22 @@ namespace cms {
       *a = std::min(*a, T1(b));
       return ret;
     }
+
+    template <typename T1, typename T2>
+    T1 atomicMin_block(T1* a, T2 b) {
+      return atomicMin(a, b);
+    }
+
     template <typename T1, typename T2>
     T1 atomicMax(T1* a, T2 b) {
       auto ret = *a;
       *a = std::max(*a, T1(b));
       return ret;
+    }
+
+    template <typename T1, typename T2>
+    T1 atomicMax_block(T1* a, T2 b) {
+      return atomicMax(a, b);
     }
 
     inline void __syncthreads() {}

--- a/src/cudadev/plugin-PixelTriplets/GPUCACell.h
+++ b/src/cudadev/plugin-PixelTriplets/GPUCACell.h
@@ -70,6 +70,7 @@ public:
       auto i = cellNeighbors.extend();  // maybe wasted....
       if (i > 0) {
         cellNeighbors[i].reset();
+        __threadfence();
 #ifdef __CUDACC__
         auto zero = (PtrAsInt)(&cellNeighbors[0]);
         atomicCAS((PtrAsInt*)(&theOuterNeighbors),
@@ -90,6 +91,7 @@ public:
       auto i = cellTracks.extend();  // maybe wasted....
       if (i > 0) {
         cellTracks[i].reset();
+        __threadfence();
 #ifdef __CUDACC__
         auto zero = (PtrAsInt)(&cellTracks[0]);
         atomicCAS((PtrAsInt*)(&theTracks), zero, (PtrAsInt)(&cellTracks[i]));  // if fails we cannot give "i" back...

--- a/src/cudadev/plugin-PixelVertexFinding/gpuFitVertices.h
+++ b/src/cudadev/plugin-PixelVertexFinding/gpuFitVertices.h
@@ -63,8 +63,13 @@ namespace gpuVertexFinder {
       assert(iv[i] >= 0);
       assert(iv[i] < int(foundClusters));
       auto w = 1.f / ezt2[i];
+#if ! defined __CUDA_ARCH__ || __CUDA_ARCH__ >= 600
+      atomicAdd_block(&zv[iv[i]], zt[i] * w);
+      atomicAdd_block(&wv[iv[i]], w);
+#else
       atomicAdd(&zv[iv[i]], zt[i] * w);
       atomicAdd(&wv[iv[i]], w);
+#endif
     }
 
     __syncthreads();
@@ -87,8 +92,13 @@ namespace gpuVertexFinder {
         iv[i] = 9999;
         continue;
       }
+#if ! defined __CUDA_ARCH__ || __CUDA_ARCH__ >= 600
+      atomicAdd_block(&chi2[iv[i]], c2);
+      atomicAdd_block(&nn[iv[i]], 1);
+#else
       atomicAdd(&chi2[iv[i]], c2);
       atomicAdd(&nn[iv[i]], 1);
+#endif
     }
     __syncthreads();
     for (auto i = threadIdx.x; i < foundClusters; i += blockDim.x)

--- a/src/cudadev/plugin-PixelVertexFinding/gpuSortByPt2.h
+++ b/src/cudadev/plugin-PixelVertexFinding/gpuSortByPt2.h
@@ -46,7 +46,11 @@ namespace gpuVertexFinder {
     for (auto i = threadIdx.x; i < nt; i += blockDim.x) {
       if (iv[i] > 9990)
         continue;
+#if ! defined __CUDA_ARCH__ || __CUDA_ARCH__ >= 600
+      atomicAdd_block(&ptv2[iv[i]], ptt2[i]);
+#else
       atomicAdd(&ptv2[iv[i]], ptt2[i]);
+#endif
     }
     __syncthreads();
 

--- a/src/cudadev/plugin-SiPixelClusterizer/gpuClustering.h
+++ b/src/cudadev/plugin-SiPixelClusterizer/gpuClustering.h
@@ -218,12 +218,21 @@ namespace gpuClustering {
               auto l = nn[k][kk];
               auto m = l + firstPixel;
               assert(m != i);
+#if ! defined __CUDA_ARCH__ || __CUDA_ARCH__ >= 600
+              auto old = atomicMin_block(&clusterId[m], clusterId[i]);
+#else
               auto old = atomicMin(&clusterId[m], clusterId[i]);
+#endif
+              // do we need memory fence?
               if (old != clusterId[i]) {
                 // end the loop only if no changes were applied
                 more = true;
               }
+#if ! defined __CUDA_ARCH__ || __CUDA_ARCH__ >= 600
+              atomicMin_block(&clusterId[i], old);
+#else
               atomicMin(&clusterId[i], old);
+#endif
             }  // nnloop
           }    // pixel loop
         }


### PR DESCRIPTION
Use block-wise atomic operations.
Add missing memory fences to avoid crashes on Ampere (and potentially other) GPUs.