### PR TITLE
Updates to alpaka

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -526,7 +526,7 @@ $(HWLOC_BASE):
 external_alpaka: $(ALPAKA_BASE)
 
 $(ALPAKA_BASE):
-	git clone git@github.com:alpaka-group/alpaka.git -b 0.6.0 $@
+	git clone git@github.com:alpaka-group/alpaka.git -b 0.6.1 $@
 
 # Cupla
 .PHONY: external_cupla

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ else
 # CUDA platform at $(CUDA_BASE)
 CUDA_LIBDIR := $(CUDA_BASE)/lib64
 USER_CUDAFLAGS :=
+export CUDA_BASE
 export CUDA_DEPS := $(CUDA_BASE)/lib64/libcudart.so
 export CUDA_ARCH := 35 50 60 70
 export CUDA_CXXFLAGS := -I$(CUDA_BASE)/include


### PR DESCRIPTION
CUDA_BASE is used by the alpaka sub-make to decide whether to build CUDA support or not. However, the top-level Makefile did not export it, so the detection would work only if the variable was set explicitly in the environment or on the command line.
Export CUDA_BASE so the the Alpaka sub-make can find properly it.

Update alpaka to version 0.6.1.