### PR TITLE
Fix compile issue with BOOST_NOINLINE and HIP

### DIFF
--- a/src/hip/CUDACore/cudaCheck.h
+++ b/src/hip/CUDACore/cudaCheck.h
@@ -12,6 +12,8 @@
 // and the AMD HIP definition of __noinline__ is __attribute__((noinline))
 // The preprocessor mixes these to create an erroneous __attribute__ clause.
 // Workaround is to define BOOST_NOINLINE in the correct form directly.
+// Note: a fix has been merged upstream, so this might become unnecessary
+// in a future version of Boost (>= 1.78).
 #define BOOST_NOINLINE __attribute__((noinline))
 #include <boost/stacktrace.hpp>
 

--- a/src/hip/CUDACore/cudaCheck.h
+++ b/src/hip/CUDACore/cudaCheck.h
@@ -8,6 +8,11 @@
 
 // Boost headers
 #define BOOST_STACKTRACE_USE_BACKTRACE
+// The definition of BOOST_NOINLINE is __attribute__((__noinline__))
+// and the AMD HIP definition of __noinline__ is __attribute__((noinline))
+// The preprocessor mixes these to create an erroneous __attribute__ clause.
+// Workaround is to define BOOST_NOINLINE in the correct form directly.
+#define BOOST_NOINLINE __attribute__((noinline))
 #include <boost/stacktrace.hpp>
 
 // CUDA headers


### PR DESCRIPTION
The definition of BOOST_INLINE in boost and AMD's definition of `__noinline__ `collide to create an erroneous `__attribute_` clause.  Fix it by defining BOOST_INLINE.