### PR TITLE
[alpaka] change assert with ALPAKA_ASSERT_OFFLOAD

### DIFF
--- a/src/alpaka/AlpakaCore/HistoContainer.h
+++ b/src/alpaka/AlpakaCore/HistoContainer.h
@@ -24,10 +24,10 @@ namespace cms {
         const uint32_t nt = offsets[nh];
         cms::alpakatools::for_each_element_in_grid_strided(acc, nt, [&](uint32_t i) {
           auto off = alpaka_std::upper_bound(offsets, offsets + nh + 1, i);
-          assert((*off) > 0);
+          ALPAKA_ASSERT_OFFLOAD((*off) > 0);
           int32_t ih = off - offsets - 1;
-          assert(ih >= 0);
-          assert(ih < int(nh));
+          ALPAKA_ASSERT_OFFLOAD(ih >= 0);
+          ALPAKA_ASSERT_OFFLOAD(ih < int(nh));
           h->count(acc, v[i], ih);
         });
       }
@@ -43,10 +43,10 @@ namespace cms {
         const uint32_t nt = offsets[nh];
         cms::alpakatools::for_each_element_in_grid_strided(acc, nt, [&](uint32_t i) {
           auto off = alpaka_std::upper_bound(offsets, offsets + nh + 1, i);
-          assert((*off) > 0);
+          ALPAKA_ASSERT_OFFLOAD((*off) > 0);
           int32_t ih = off - offsets - 1;
-          assert(ih >= 0);
-          assert(ih < int(nh));
+          ALPAKA_ASSERT_OFFLOAD(ih >= 0);
+          ALPAKA_ASSERT_OFFLOAD(ih < int(nh));
           h->fill(acc, v[i], i, ih);
         });
       }
@@ -126,7 +126,7 @@ namespace cms {
       int bs = Hist::bin(value);
       int be = std::min(int(Hist::nbins() - 1), bs + n);
       bs = std::max(0, bs - n);
-      assert(be >= bs);
+      ALPAKA_ASSERT_OFFLOAD(be >= bs);
       for (auto pj = hist.begin(bs); pj < hist.end(be); ++pj) {
         func(*pj);
       }
@@ -137,7 +137,7 @@ namespace cms {
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void forEachInWindow(Hist const &hist, V wmin, V wmax, Func const &func) {
       auto bs = Hist::bin(wmin);
       auto be = Hist::bin(wmax);
-      assert(be >= bs);
+      ALPAKA_ASSERT_OFFLOAD(be >= bs);
       for (auto pj = hist.begin(bs); pj < hist.end(be); ++pj) {
         func(*pj);
       }
@@ -211,15 +211,15 @@ namespace cms {
 
       template <typename T_Acc>
       ALPAKA_FN_ACC ALPAKA_FN_INLINE void countDirect(const T_Acc &acc, T b) {
-        assert(b < nbins());
+        ALPAKA_ASSERT_OFFLOAD(b < nbins());
         atomicIncrement(acc, off[b]);
       }
 
       template <typename T_Acc>
       ALPAKA_FN_ACC ALPAKA_FN_INLINE void fillDirect(const T_Acc &acc, T b, index_type j) {
-        assert(b < nbins());
+        ALPAKA_ASSERT_OFFLOAD(b < nbins());
         auto w = atomicDecrement(acc, off[b]);
-        assert(w > 0);
+        ALPAKA_ASSERT_OFFLOAD(w > 0);
         bins[w - 1] = j;
       }
 
@@ -256,44 +256,44 @@ namespace cms {
       template <typename T_Acc>
       ALPAKA_FN_ACC ALPAKA_FN_INLINE void count(const T_Acc &acc, T t) {
         uint32_t b = bin(t);
-        assert(b < nbins());
+        ALPAKA_ASSERT_OFFLOAD(b < nbins());
         atomicIncrement(acc, off[b]);
       }
 
       template <typename T_Acc>
       ALPAKA_FN_ACC ALPAKA_FN_INLINE void fill(const T_Acc &acc, T t, index_type j) {
         uint32_t b = bin(t);
-        assert(b < nbins());
+        ALPAKA_ASSERT_OFFLOAD(b < nbins());
         auto w = atomicDecrement(acc, off[b]);
-        assert(w > 0);
+        ALPAKA_ASSERT_OFFLOAD(w > 0);
         bins[w - 1] = j;
       }
 
       template <typename T_Acc>
       ALPAKA_FN_ACC ALPAKA_FN_INLINE void count(const T_Acc &acc, T t, uint32_t nh) {
         uint32_t b = bin(t);
-        assert(b < nbins());
+        ALPAKA_ASSERT_OFFLOAD(b < nbins());
         b += histOff(nh);
-        assert(b < totbins());
+        ALPAKA_ASSERT_OFFLOAD(b < totbins());
         atomicIncrement(acc, off[b]);
       }
 
       template <typename T_Acc>
       ALPAKA_FN_ACC ALPAKA_FN_INLINE void fill(const T_Acc &acc, T t, index_type j, uint32_t nh) {
         uint32_t b = bin(t);
-        assert(b < nbins());
+        ALPAKA_ASSERT_OFFLOAD(b < nbins());
         b += histOff(nh);
-        assert(b < totbins());
+        ALPAKA_ASSERT_OFFLOAD(b < totbins());
         auto w = atomicDecrement(acc, off[b]);
-        assert(w > 0);
+        ALPAKA_ASSERT_OFFLOAD(w > 0);
         bins[w - 1] = j;
       }
 
       template <typename T_Acc>
       ALPAKA_FN_ACC ALPAKA_FN_INLINE void finalize(const T_Acc &acc, Counter *ws = nullptr) {
-        assert(off[totbins() - 1] == 0);
+        ALPAKA_ASSERT_OFFLOAD(off[totbins() - 1] == 0);
         blockPrefixScan(acc, off, totbins(), ws);
-        assert(off[totbins() - 1] == off[totbins() - 2]);
+        ALPAKA_ASSERT_OFFLOAD(off[totbins() - 1] == off[totbins() - 2]);
       }
 
       constexpr auto size() const { return uint32_t(off[totbins() - 1]); }

--- a/src/alpaka/AlpakaCore/prefixScan.h
+++ b/src/alpaka/AlpakaCore/prefixScan.h
@@ -52,8 +52,8 @@ namespace cms {
       uint32_t const gridBlockIdx(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       uint32_t const blockThreadIdx(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
       assert(ws);
-      assert(size <= 1024);
-      assert(0 == blockDimension % 32);
+      ALPAKA_ASSERT_OFFLOAD(size <= 1024);
+      ALPAKA_ASSERT_OFFLOAD(0 == blockDimension % 32);
       auto first = blockThreadIdx;
       auto mask = __ballot_sync(0xffffffff, first < size);
       auto laneId = blockThreadIdx & 0x1f;
@@ -61,7 +61,7 @@ namespace cms {
       for (auto i = first; i < size; i += blockDimension) {
         warpPrefixScan(laneId, ci, co, i, mask);
         auto warpId = i / 32;
-        assert(warpId < 32);
+        ALPAKA_ASSERT_OFFLOAD(warpId < 32);
         if (31 == laneId)
           ws[warpId] = co[i];
         mask = __ballot_sync(mask, i + blockDimension < size);
@@ -100,8 +100,8 @@ namespace cms {
       uint32_t const gridBlockIdx(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       uint32_t const blockThreadIdx(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
       assert(ws);
-      assert(size <= 1024);
-      assert(0 == blockDimension % 32);
+      ALPAKA_ASSERT_OFFLOAD(size <= 1024);
+      ALPAKA_ASSERT_OFFLOAD(0 == blockDimension % 32);
       auto first = blockThreadIdx;
       auto mask = __ballot_sync(0xffffffff, first < size);
       auto laneId = blockThreadIdx & 0x1f;
@@ -109,7 +109,7 @@ namespace cms {
       for (auto i = first; i < size; i += blockDimension) {
         warpPrefixScan(laneId, c, i, mask);
         auto warpId = i / 32;
-        assert(warpId < 32);
+        ALPAKA_ASSERT_OFFLOAD(warpId < 32);
         if (31 == laneId)
           ws[warpId] = c[i];
         mask = __ballot_sync(mask, i + blockDimension < size);
@@ -145,7 +145,7 @@ namespace cms {
         // first each block does a scan of size 1024; (better be enough blocks....)
 #ifndef NDEBUG
         uint32_t const gridDimension(alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
-        assert(gridDimension / threadDimension <= 1024);
+        ALPAKA_ASSERT_OFFLOAD(gridDimension / threadDimension <= 1024);
 #endif
         int off = blockDimension * blockIdx * threadDimension;
         if (size - off > 0)
@@ -166,7 +166,7 @@ namespace cms {
         auto* const psum(alpaka::getDynSharedMem<T>(acc));
 
         // first each block does a scan of size 1024; (better be enough blocks....)
-        assert(static_cast<int32_t>(blockDimension * threadDimension) >= numBlocks);
+        ALPAKA_ASSERT_OFFLOAD(static_cast<int32_t>(blockDimension * threadDimension) >= numBlocks);
         for (int elemId = 0; elemId < static_cast<int>(threadDimension); ++elemId) {
           int index = +threadIdx * threadDimension + elemId;
 

--- a/src/alpaka/AlpakaCore/radixSort.h
+++ b/src/alpaka/AlpakaCore/radixSort.h
@@ -85,10 +85,10 @@ namespace cms {
       auto& ibs = alpaka::declareSharedVar<int, __COUNTER__>(acc);
       auto& p = alpaka::declareSharedVar<int, __COUNTER__>(acc);
 
-      assert(size > 0);
+      ALPAKA_ASSERT_OFFLOAD(size > 0);
 
       const uint32_t blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
-      assert(blockDimension >= sb);
+      ALPAKA_ASSERT_OFFLOAD(blockDimension >= sb);
 
       // bool debug = false; // threadIdx.x==0 && blockIdx.x==5;
 
@@ -190,7 +190,7 @@ namespace cms {
     */
 
         alpaka::syncBlockThreads(acc);
-        assert(c[0] == 0);
+        ALPAKA_ASSERT_OFFLOAD(c[0] == 0);
 
         // swap (local, ok)
         auto t = j;
@@ -204,7 +204,7 @@ namespace cms {
       }
 
       if ((w != 8) && (0 == (NS & 1)))
-        assert(j == ind);  // w/d is even so ind is correct
+        ALPAKA_ASSERT_OFFLOAD(j == ind);  // w/d is even so ind is correct
 
       if (j != ind)  // odd...
         cms::alpakatools::for_each_element_in_block_strided(acc, size, [&](uint32_t i) { ind[i] = ind2[i]; });

--- a/src/alpaka/AlpakaDataFormats/SiPixelDigiErrorsAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/SiPixelDigiErrorsAlpaka.h
@@ -18,8 +18,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           formatterErrors_h{std::move(errors)} {
       auto perror_h = alpaka::getPtrNative(error_h);
       perror_h->construct(maxFedWords, alpaka::getPtrNative(data_d));
-      assert(perror_h->empty());
-      assert(perror_h->capacity() == static_cast<int>(maxFedWords));
+      ALPAKA_ASSERT_OFFLOAD(perror_h->empty());
+      ALPAKA_ASSERT_OFFLOAD(perror_h->capacity() == static_cast<int>(maxFedWords));
 
       // TO DO: nothing really async in here for now... Pass the queue in constructor argument instead, and don't wait anymore!
       Queue queue(device);

--- a/src/alpaka/CondFormats/SiPixelGainForHLTonGPU.h
+++ b/src/alpaka/CondFormats/SiPixelGainForHLTonGPU.h
@@ -53,9 +53,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto offset =
           range.first + col * lengthOfColumnData + lengthOfAveragedDataInEachColumn * numberOfDataBlocksToSkip;
 
-      assert(offset < range.second);
-      assert(offset < 3088384);
-      assert(0 == offset % 2);
+      ALPAKA_ASSERT_OFFLOAD(offset < range.second);
+      ALPAKA_ASSERT_OFFLOAD(offset < 3088384);
+      ALPAKA_ASSERT_OFFLOAD(0 == offset % 2);
 
       auto s = v_pedestals[offset / 2];
 

--- a/src/alpaka/CondFormats/pixelCPEforGPU.h
+++ b/src/alpaka/CondFormats/pixelCPEforGPU.h
@@ -198,8 +198,8 @@ namespace pixelCPEforGPU {
 
     auto xsize = int(urxl) + 2 - int(llxl);
     auto ysize = int(uryl) + 2 - int(llyl);
-    assert(xsize >= 0);  // 0 if bixpix...
-    assert(ysize >= 0);
+    ALPAKA_ASSERT_OFFLOAD(xsize >= 0);  // 0 if bixpix...
+    ALPAKA_ASSERT_OFFLOAD(ysize >= 0);
 
     if (phase1PixelTopology::isBigPixX(cp.minRow[ic]))
       ++xsize;

--- a/src/alpaka/DataFormats/SiPixelDigisSoA.cc
+++ b/src/alpaka/DataFormats/SiPixelDigisSoA.cc
@@ -1,6 +1,7 @@
 #include "DataFormats/SiPixelDigisSoA.h"
 
 #include <cassert>
+#include <alpaka/alpaka.hpp>
 
 SiPixelDigisSoA::SiPixelDigisSoA(
     size_t nDigis, const uint32_t *pdigi, const uint32_t *rawIdArr, const uint16_t *adc, const int32_t *clus)
@@ -8,5 +9,5 @@ SiPixelDigisSoA::SiPixelDigisSoA(
       rawIdArr_(rawIdArr, rawIdArr + nDigis),
       adc_(adc, adc + nDigis),
       clus_(clus, clus + nDigis) {
-  assert(pdigi_.size() == nDigis);
+  ALPAKA_ASSERT_OFFLOAD(pdigi_.size() == nDigis);
 }

--- a/src/alpaka/Framework/ReusableObjectHolder.h
+++ b/src/alpaka/Framework/ReusableObjectHolder.h
@@ -84,10 +84,10 @@ namespace edm {
     ReusableObjectHolder() : m_outstandingObjects(0) {}
     ReusableObjectHolder(ReusableObjectHolder&& iOther)
         : m_availableQueue(std::move(iOther.m_availableQueue)), m_outstandingObjects(0) {
-      assert(0 == iOther.m_outstandingObjects);
+      ALPAKA_ASSERT_OFFLOAD(0 == iOther.m_outstandingObjects);
     }
     ~ReusableObjectHolder() {
-      assert(0 == m_outstandingObjects);
+      ALPAKA_ASSERT_OFFLOAD(0 == m_outstandingObjects);
       std::unique_ptr<T, Deleter> item;
       while (m_availableQueue.try_pop(item)) {
         item.reset();

--- a/src/alpaka/Framework/WaitingTaskList.cc
+++ b/src/alpaka/Framework/WaitingTaskList.cc
@@ -16,6 +16,7 @@
 // user include files
 #include "tbb/task.h"
 #include <cassert>
+#include <alpaka/alpaka.hpp>
 
 #include "WaitingTaskList.h"
 #include "hardware_pause.h"
@@ -51,7 +52,7 @@ void WaitingTaskList::reset() {
   m_exceptionPtr = std::exception_ptr{};
   unsigned int nSeenTasks = m_lastAssignedCacheIndex;
   m_lastAssignedCacheIndex = 0;
-  assert(m_head == nullptr);
+  ALPAKA_ASSERT_OFFLOAD(m_head == nullptr);
   if (nSeenTasks > m_nodeCacheSize) {
     //need to expand so next time we don't have to do any
     // memory requests

--- a/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLine.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLine.h
@@ -345,7 +345,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           -circle_results.q * (fast_fit(2) - sqrt(Rfit::sqr(fast_fit(2)) - 0.25 * (e - d).squaredNorm())),
           circle_results.q * (1. / fast_fit(2) + u(n));
 
-      assert(circle_results.q * circle_results.par(1) <= 0);
+      ALPAKA_ASSERT_OFFLOAD(circle_results.q * circle_results.par(1) <= 0);
 
       Rfit::Vector2d eMinusd = e - d;
       double tmp1 = eMinusd.squaredNorm();

--- a/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
@@ -8,7 +8,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                               uint32_t hitsInFit,
                                               uint32_t maxNumberOfTuples,
                                               Queue& queue) {
-    assert(tuples_d);
+    ALPAKA_ASSERT_OFFLOAD(tuples_d);
 
     const auto blockSize = 64;
     const auto numberOfBlocks = (maxNumberOfConcurrentFits_ + blockSize - 1) / blockSize;

--- a/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.h
@@ -36,12 +36,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   uint32_t offset) const {
       constexpr uint32_t hitsInFit = N;
 
-      assert(hitsInFit <= nHits);
+      ALPAKA_ASSERT_OFFLOAD(hitsInFit <= nHits);
 
-      assert(hhp);
-      assert(pfast_fit);
-      assert(foundNtuplets);
-      assert(tupleMultiplicity);
+      ALPAKA_ASSERT_OFFLOAD(hhp);
+      ALPAKA_ASSERT_OFFLOAD(pfast_fit);
+      ALPAKA_ASSERT_OFFLOAD(foundNtuplets);
+      ALPAKA_ASSERT_OFFLOAD(tupleMultiplicity);
 
       // look in bin for this hit multiplicity
 #ifdef BROKENLINE_DEBUG
@@ -60,9 +60,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         // get it from the ntuple container (one to one to helix)
         auto tkid = *(tupleMultiplicity->begin(nHits) + tuple_idx);
-        assert(tkid < foundNtuplets->nbins());
+        ALPAKA_ASSERT_OFFLOAD(tkid < foundNtuplets->nbins());
 
-        assert(foundNtuplets->size(tkid) == nHits);
+        ALPAKA_ASSERT_OFFLOAD(foundNtuplets->size(tkid) == nHits);
 
         Rfit::Map3xNd<N> hits(phits + local_idx);
         Rfit::Map4d fast_fit(pfast_fit + local_idx);
@@ -111,10 +111,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         BrokenLine::BL_Fast_fit(hits, fast_fit);
 
         // no NaN here....
-        assert(fast_fit(0) == fast_fit(0));
-        assert(fast_fit(1) == fast_fit(1));
-        assert(fast_fit(2) == fast_fit(2));
-        assert(fast_fit(3) == fast_fit(3));
+        ALPAKA_ASSERT_OFFLOAD(fast_fit(0) == fast_fit(0));
+        ALPAKA_ASSERT_OFFLOAD(fast_fit(1) == fast_fit(1));
+        ALPAKA_ASSERT_OFFLOAD(fast_fit(2) == fast_fit(2));
+        ALPAKA_ASSERT_OFFLOAD(fast_fit(3) == fast_fit(3));
       });
 
     }  // kernel operator()
@@ -132,10 +132,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   double *__restrict__ pfast_fit,
                                   uint32_t nHits,
                                   uint32_t offset) const {
-      assert(N <= nHits);
+      ALPAKA_ASSERT_OFFLOAD(N <= nHits);
 
-      assert(results);
-      assert(pfast_fit);
+      ALPAKA_ASSERT_OFFLOAD(results);
+      ALPAKA_ASSERT_OFFLOAD(pfast_fit);
 
       // same as above...
 

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.cc
@@ -26,7 +26,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     launchZero(tuples_d, queue);
 
     auto nhits = hh.nHits();
-    assert(nhits <= pixelGPUConstants::maxNumberOfHits);
+    ALPAKA_ASSERT_OFFLOAD(nhits <= pixelGPUConstants::maxNumberOfHits);
 
     // std::cout << "N hits " << nhits << std::endl;
     // if (nhits<2) std::cout << "too few hits " << nhits << std::endl;
@@ -42,8 +42,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const uint32_t rescale = numberOfBlocks / 65536;
     blockSize *= (rescale + 1);
     numberOfBlocks = (3 * m_params.maxNumberOfDoublets_ / 4 + blockSize - 1) / blockSize;
-    assert(numberOfBlocks < 65536);
-    assert(blockSize > 0 && 0 == blockSize % 16);
+    ALPAKA_ASSERT_OFFLOAD(numberOfBlocks < 65536);
+    ALPAKA_ASSERT_OFFLOAD(blockSize > 0 && 0 == blockSize % 16);
     const Vec2 blks(numberOfBlocks, 1u);
     const Vec2 thrs(blockSize, stride);
     const WorkDiv2 kernelConnectWorkDiv = cms::alpakatools::make_workdiv(blks, thrs);
@@ -210,7 +210,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     alpaka::wait(queue);
 #endif
 
-    assert(alpaka::getPtrNative(device_isOuterHitOfCell_));
+    ALPAKA_ASSERT_OFFLOAD(alpaka::getPtrNative(device_isOuterHitOfCell_));
 
     {
       int threadsPerBlock = 128;
@@ -244,7 +244,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       nActualPairs = 13;
     }
 
-    assert(nActualPairs <= gpuPixelDoublets::nPairs);
+    ALPAKA_ASSERT_OFFLOAD(nActualPairs <= gpuPixelDoublets::nPairs);
     const uint32_t stride = 4;
     const uint32_t threadsPerBlock = gpuPixelDoublets::getDoubletsFromHistoMaxBlockSize / stride;
     const uint32_t blocks = (4 * nhits + threadsPerBlock - 1) / threadsPerBlock;

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernelsImpl.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernelsImpl.h
@@ -66,8 +66,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                apc->get().n,
                nHits);
         if (apc->get().m < CAConstants::maxNumberOfQuadruplets()) {
-          assert(foundNtuplets->size(apc->get().m) == 0);
-          assert(foundNtuplets->size() == apc->get().n);
+          ALPAKA_ASSERT_OFFLOAD(foundNtuplets->size(apc->get().m) == 0);
+          ALPAKA_ASSERT_OFFLOAD(foundNtuplets->size() == apc->get().n);
         }
       }
 
@@ -75,9 +75,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       cms::alpakatools::for_each_element_in_grid_strided(acc, ntNbins, [&](uint32_t idx) {
         if (foundNtuplets->size(idx) > 5)
           printf("ERROR %d, %d\n", idx, foundNtuplets->size(idx));
-        assert(foundNtuplets->size(idx) < 6);
+        ALPAKA_ASSERT_OFFLOAD(foundNtuplets->size(idx) < 6);
         for (auto ih = foundNtuplets->begin(idx); ih != foundNtuplets->end(idx); ++ih)
-          assert(*ih < nHits);
+          ALPAKA_ASSERT_OFFLOAD(*ih < nHits);
       });
 #endif
 
@@ -145,7 +145,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       constexpr auto dup = trackQuality::dup;
       // constexpr auto loose = trackQuality::loose;
 
-      assert(nCells);
+      ALPAKA_ASSERT_OFFLOAD(nCells);
       const auto ntNCells = (*nCells);
       cms::alpakatools::for_each_element_in_grid_strided(acc, ntNCells, [&](uint32_t idx) {
         auto const &thisCell = cells[idx];
@@ -182,7 +182,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       constexpr auto dup = trackQuality::dup;
       constexpr auto loose = trackQuality::loose;
 
-      assert(nCells);
+      ALPAKA_ASSERT_OFFLOAD(nCells);
 
       cms::alpakatools::for_each_element_in_grid_strided(acc, (*nCells), [&](uint32_t idx) {
         auto const &thisCell = cells[idx];
@@ -329,7 +329,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             stack.reset();
             thisCell.find_ntuplets(
                 acc, hh, cells, *cellTracks, *foundNtuplets, *apc, quality, stack, minHitsPerNtuplet, pid < 3);
-            assert(stack.empty());
+            ALPAKA_ASSERT_OFFLOAD(stack.empty());
             // printf("in %d found quadruplets: %d\n", cellIndex, apc->get());
           }
         }
@@ -361,10 +361,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       cms::alpakatools::for_each_element_in_grid_strided(acc, foundNtuplets->nbins(), [&](uint32_t it) {
         auto nhits = foundNtuplets->size(it);
         if (nhits >= 3 && quality[it] != trackQuality::dup) {
-          assert(quality[it] == trackQuality::bad);
+          ALPAKA_ASSERT_OFFLOAD(quality[it] == trackQuality::bad);
           if (nhits > 5)
             printf("wrong mult %d %d\n", it, nhits);
-          assert(nhits < 8);
+          ALPAKA_ASSERT_OFFLOAD(nhits < 8);
           tupleMultiplicity->countDirect(acc, nhits);
         }
       });
@@ -380,10 +380,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       cms::alpakatools::for_each_element_in_grid_strided(acc, foundNtuplets->nbins(), [&](uint32_t it) {
         auto nhits = foundNtuplets->size(it);
         if (nhits >= 3 && quality[it] != trackQuality::dup) {
-          assert(quality[it] == trackQuality::bad);
+          ALPAKA_ASSERT_OFFLOAD(quality[it] == trackQuality::bad);
           if (nhits > 5)
             printf("wrong mult %d %d\n", it, nhits);
-          assert(nhits < 8);
+          ALPAKA_ASSERT_OFFLOAD(nhits < 8);
           tupleMultiplicity->fillDirect(acc, nhits, it);
         }
       });
@@ -405,7 +405,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         // if duplicate: not even fit
         // mark doublets as bad
         if (quality[it] != trackQuality::dup && nhits >= 3) {
-          assert(quality[it] == trackQuality::bad);
+          ALPAKA_ASSERT_OFFLOAD(quality[it] == trackQuality::bad);
 
           // if the fit has any invalid parameters, mark it as bad
           bool isNaN = false;
@@ -522,7 +522,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto nhits = hh.nHits();
 #endif
       cms::alpakatools::for_each_element_in_grid_strided(acc, tuples->size(), [&](uint32_t idx) {
-        assert(tuples->bins[idx] < nhits);
+        ALPAKA_ASSERT_OFFLOAD(tuples->bins[idx] < nhits);
         hitDetIndices->bins[idx] = hh.detectorIndex(tuples->bins[idx]);
       });
     }

--- a/src/alpaka/plugin-PixelTriplets/alpaka/GPUCACell.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/GPUCACell.h
@@ -61,8 +61,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // link to default empty
       theOuterNeighbors = &cellNeighbors[0];
       theTracks = &cellTracks[0];
-      assert(outerNeighbors().empty());
-      assert(tracks().empty());
+      ALPAKA_ASSERT_OFFLOAD(outerNeighbors().empty());
+      ALPAKA_ASSERT_OFFLOAD(tracks().empty());
     }
 
     template <typename T_Acc>
@@ -341,7 +341,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // than a threshold
 
       tmpNtuplet.push_back_unsafe(theDoubletId);
-      assert(tmpNtuplet.size() <= 4);
+      ALPAKA_ASSERT_OFFLOAD(tmpNtuplet.size() <= 4);
 
       bool last = true;
       for (int j = 0; j < outerNeighbors().size(); ++j) {
@@ -376,7 +376,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         }
       }
       tmpNtuplet.pop_back();
-      assert(tmpNtuplet.size() < 4);
+      ALPAKA_ASSERT_OFFLOAD(tmpNtuplet.size() < 4);
     }
 
   private:

--- a/src/alpaka/plugin-PixelTriplets/alpaka/HelixFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/HelixFitOnGPU.cc
@@ -9,9 +9,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     tupleMultiplicity_d = tupleMultiplicity;
     outputSoa_d = helix_fit_results;
 
-    assert(tuples_d);
-    assert(tupleMultiplicity_d);
-    assert(outputSoa_d);
+    ALPAKA_ASSERT_OFFLOAD(tuples_d);
+    ALPAKA_ASSERT_OFFLOAD(tupleMultiplicity_d);
+    ALPAKA_ASSERT_OFFLOAD(outputSoa_d);
   }
 
   void HelixFitOnGPU::deallocateOnGPU() {}

--- a/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
@@ -8,7 +8,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                            uint32_t nhits,
                                            uint32_t maxNumberOfTuples,
                                            Queue& queue) {
-    assert(tuples_d);
+    ALPAKA_ASSERT_OFFLOAD(tuples_d);
 
     const auto blockSize = 64;
     const auto numberOfBlocks = (maxNumberOfConcurrentFits_ + blockSize - 1) / blockSize;

--- a/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.h
@@ -32,11 +32,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   uint32_t offset) const {
       constexpr uint32_t hitsInFit = N;
 
-      assert(hitsInFit <= nHits);
+      ALPAKA_ASSERT_OFFLOAD(hitsInFit <= nHits);
 
-      assert(pfast_fit);
-      assert(foundNtuplets);
-      assert(tupleMultiplicity);
+      ALPAKA_ASSERT_OFFLOAD(pfast_fit);
+      ALPAKA_ASSERT_OFFLOAD(foundNtuplets);
+      ALPAKA_ASSERT_OFFLOAD(tupleMultiplicity);
 
       // look in bin for this hit multiplicity
 
@@ -54,9 +54,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         // get it from the ntuple container (one to one to helix)
         auto tkid = *(tupleMultiplicity->begin(nHits) + tuple_idx);
-        assert(tkid < foundNtuplets->nbins());
+        ALPAKA_ASSERT_OFFLOAD(tkid < foundNtuplets->nbins());
 
-        assert(foundNtuplets->size(tkid) == nHits);
+        ALPAKA_ASSERT_OFFLOAD(foundNtuplets->size(tkid) == nHits);
 
         Rfit::Map3xNd<N> hits(phits + local_idx);
         Rfit::Map4d fast_fit(pfast_fit + local_idx);
@@ -79,10 +79,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         Rfit::Fast_fit(hits, fast_fit);
 
         // no NaN here....
-        assert(fast_fit(0) == fast_fit(0));
-        assert(fast_fit(1) == fast_fit(1));
-        assert(fast_fit(2) == fast_fit(2));
-        assert(fast_fit(3) == fast_fit(3));
+        ALPAKA_ASSERT_OFFLOAD(fast_fit(0) == fast_fit(0));
+        ALPAKA_ASSERT_OFFLOAD(fast_fit(1) == fast_fit(1));
+        ALPAKA_ASSERT_OFFLOAD(fast_fit(2) == fast_fit(2));
+        ALPAKA_ASSERT_OFFLOAD(fast_fit(3) == fast_fit(3));
       });
 
     }  // kernel operator()
@@ -100,8 +100,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   double *__restrict__ pfast_fit_input,
                                   Rfit::circle_fit *circle_fit,
                                   uint32_t offset) const {
-      assert(circle_fit);
-      assert(N <= nHits);
+      ALPAKA_ASSERT_OFFLOAD(circle_fit);
+      ALPAKA_ASSERT_OFFLOAD(N <= nHits);
 
       // same as above...
 
@@ -146,9 +146,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   double *__restrict__ pfast_fit_input,
                                   Rfit::circle_fit *__restrict__ circle_fit,
                                   uint32_t offset) const {
-      assert(results);
-      assert(circle_fit);
-      assert(N <= nHits);
+      ALPAKA_ASSERT_OFFLOAD(results);
+      ALPAKA_ASSERT_OFFLOAD(circle_fit);
+      ALPAKA_ASSERT_OFFLOAD(N <= nHits);
 
       // same as above...
 

--- a/src/alpaka/plugin-PixelTriplets/alpaka/gpuPixelDoublets.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/gpuPixelDoublets.h
@@ -73,7 +73,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                     CellNeighbors* cellNeighborsContainer,
                                     CellTracksVector* cellTracks,
                                     CellTracks* cellTracksContainer) const {
-        assert(isOuterHitOfCell);
+        ALPAKA_ASSERT_OFFLOAD(isOuterHitOfCell);
         cms::alpakatools::for_each_element_in_grid_strided(
             acc, nHits, [&](uint32_t i) { isOuterHitOfCell[i].reset(); });
 
@@ -83,11 +83,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           cellTracks->construct(CAConstants::maxNumOfActiveDoublets(), cellTracksContainer);
           auto i = cellNeighbors->extend(
               acc);  // NB: Increases cellNeighbors size by 1, returns previous size which should be 0.
-          assert(0 == i);
+          ALPAKA_ASSERT_OFFLOAD(0 == i);
           (*cellNeighbors)[0].reset();
           auto ii =
               cellTracks->extend(acc);  // NB: Increases cellTracks size by 1, returns previous size which should be 0.
-          assert(0 == ii);
+          ALPAKA_ASSERT_OFFLOAD(0 == ii);
           (*cellTracks)[0].reset();
         }
       }  // initDoublets kernel operator()

--- a/src/alpaka/plugin-PixelTriplets/alpaka/gpuPixelDoubletsAlgos.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/gpuPixelDoubletsAlgos.h
@@ -60,7 +60,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       auto const& __restrict__ hist = hh.phiBinner();
       uint32_t const* __restrict__ offsets = hh.hitsLayerStart();
-      assert(offsets);
+      ALPAKA_ASSERT_OFFLOAD(offsets);
 
       auto layerSize = [=](uint8_t li) { return offsets[li + 1] - offsets[li]; };
 
@@ -68,7 +68,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // If it should be much bigger, consider using a block-wide parallel prefix scan,
       // e.g. see  https://nvlabs.github.io/cub/classcub_1_1_warp_scan.html
       const int nPairsMax = CAConstants::maxNumberOfLayerPairs();  // add constexpr?
-      assert(nPairs <= nPairsMax);
+      ALPAKA_ASSERT_OFFLOAD(nPairs <= nPairsMax);
       auto& innerLayerCumulativeSize = alpaka::declareSharedVar<uint32_t[nPairsMax], __COUNTER__>(acc);
       auto& ntot = alpaka::declareSharedVar<uint32_t, __COUNTER__>(acc);
 
@@ -107,13 +107,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           ;
         --pairLayerId;  // move to lower_bound ??
 
-        assert(pairLayerId < nPairs);
-        assert(j < innerLayerCumulativeSize[pairLayerId]);
-        assert(0 == pairLayerId || j >= innerLayerCumulativeSize[pairLayerId - 1]);
+        ALPAKA_ASSERT_OFFLOAD(pairLayerId < nPairs);
+        ALPAKA_ASSERT_OFFLOAD(j < innerLayerCumulativeSize[pairLayerId]);
+        ALPAKA_ASSERT_OFFLOAD(0 == pairLayerId || j >= innerLayerCumulativeSize[pairLayerId - 1]);
 
         uint8_t inner = layerPairs[2 * pairLayerId];
         uint8_t outer = layerPairs[2 * pairLayerId + 1];
-        assert(outer > inner);
+        ALPAKA_ASSERT_OFFLOAD(outer > inner);
 
         auto hoff = Hist::histOff(outer);
 
@@ -122,8 +122,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         // printf("Hit in Layer %d %d %d %d\n", i, inner, pairLayerId, j);
 
-        assert(i >= offsets[inner]);
-        assert(i < offsets[inner + 1]);
+        ALPAKA_ASSERT_OFFLOAD(i >= offsets[inner]);
+        ALPAKA_ASSERT_OFFLOAD(i < offsets[inner + 1]);
 
         // found hit corresponding to our cuda thread, now do the job
         auto mi = hh.detectorIndex(i);
@@ -145,7 +145,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         if (doClusterCut) {
           // if ideal treat inner ladder as outer
           if (inner == 0)
-            assert(mi < 96);
+            ALPAKA_ASSERT_OFFLOAD(mi < 96);
           isOuterLadder = ideal_cond ? true : 0 == (mi / 8) % 2;  // only for B1/B2/B3 B4 is opposite, FPIX:noclue...
 
           // in any case we always test mes>0 ...
@@ -229,8 +229,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
               break;
 
             auto oi = p[pIndex];  // auto oi = __ldg(p); is not allowed since __ldg is device-only
-            assert(oi >= offsets[outer]);
-            assert(oi < offsets[outer + 1]);
+            ALPAKA_ASSERT_OFFLOAD(oi >= offsets[outer]);
+            ALPAKA_ASSERT_OFFLOAD(oi < offsets[outer + 1]);
             auto mo = hh.detectorIndex(oi);
             if (mo > 2000)
               continue;  //    invalid

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksByDensity.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksByDensity.h
@@ -48,8 +48,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       int32_t* __restrict__ nn = data.ndof;
       int32_t* __restrict__ iv = ws.iv;
 
-      assert(pdata);
-      assert(zt);
+      ALPAKA_ASSERT_OFFLOAD(pdata);
+      ALPAKA_ASSERT_OFFLOAD(zt);
 
       using Hist = cms::alpakatools::HistoContainer<uint8_t, 256, 16000, 8, uint16_t>;
       auto& hist = alpaka::declareSharedVar<Hist, __COUNTER__>(acc);
@@ -61,17 +61,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       if (verbose && 0 == threadIdxLocal)
         printf("booked hist with %d bins, size %d for %d tracks\n", hist.nbins(), hist.capacity(), nt);
 
-      assert(nt <= hist.capacity());
+      ALPAKA_ASSERT_OFFLOAD(nt <= hist.capacity());
 
       // fill hist  (bin shall be wider than "eps")
       cms::alpakatools::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
-        assert(i < ZVertices::MAXTRACKS);
+        ALPAKA_ASSERT_OFFLOAD(i < ZVertices::MAXTRACKS);
         int iz = int(zt[i] * 10.);  // valid if eps<=0.1
         // iz = std::clamp(iz, INT8_MIN, INT8_MAX);  // sorry c++17 only
         iz = std::min(std::max(iz, INT8_MIN), INT8_MAX);
         izt[i] = iz - INT8_MIN;
-        assert(iz - INT8_MIN >= 0);
-        assert(iz - INT8_MIN < 256);
+        ALPAKA_ASSERT_OFFLOAD(iz - INT8_MIN >= 0);
+        ALPAKA_ASSERT_OFFLOAD(iz - INT8_MIN < 256);
         hist.count(acc, izt[i]);
         iv[i] = i;
         nn[i] = 0;
@@ -86,7 +86,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       hist.finalize(acc, hws);
       alpaka::syncBlockThreads(acc);
 
-      assert(hist.size() == nt);
+      ALPAKA_ASSERT_OFFLOAD(hist.size() == nt);
       cms::alpakatools::for_each_element_in_block_strided(
           acc, nt, [&](uint32_t i) { hist.fill(acc, izt[i], uint16_t(i)); });
       alpaka::syncBlockThreads(acc);
@@ -136,7 +136,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       //  mini verification
       cms::alpakatools::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
         if (iv[i] != int(i))
-          assert(iv[iv[i]] != int(i));
+          ALPAKA_ASSERT_OFFLOAD(iv[iv[i]] != int(i));
       });
       alpaka::syncBlockThreads(acc);
 #endif
@@ -154,7 +154,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       //  mini verification
       cms::alpakatools::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
         if (iv[i] != int(i))
-          assert(iv[iv[i]] != int(i));
+          ALPAKA_ASSERT_OFFLOAD(iv[iv[i]] != int(i));
       });
 #endif
 
@@ -178,8 +178,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         };
         cms::alpakatools::forEachInBins(hist, izt[i], 1, loop);
         // should belong to the same cluster...
-        assert(iv[i] == iv[minJ]);
-        assert(nn[i] <= nn[iv[i]]);
+        ALPAKA_ASSERT_OFFLOAD(iv[i] == iv[minJ]);
+        ALPAKA_ASSERT_OFFLOAD(nn[i] <= nn[iv[i]]);
       });
       alpaka::syncBlockThreads(acc);
 #endif
@@ -202,7 +202,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       });
       alpaka::syncBlockThreads(acc);
 
-      assert(foundClusters < ZVertices::MAXVTX);
+      ALPAKA_ASSERT_OFFLOAD(foundClusters < ZVertices::MAXVTX);
 
       // propagate the negative id to all the tracks in the cluster.
       cms::alpakatools::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksDBSCAN.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksDBSCAN.h
@@ -44,8 +44,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         int32_t* __restrict__ nn = data.ndof;
         int32_t* __restrict__ iv = ws.iv;
 
-        assert(pdata);
-        assert(zt);
+        ALPAKA_ASSERT_OFFLOAD(pdata);
+        ALPAKA_ASSERT_OFFLOAD(zt);
 
         using Hist = cms::alpakatools::HistoContainer<uint8_t, 256, 16000, 8, uint16_t>;
         auto& hist = alpaka::declareSharedVar<Hist, __COUNTER__>(acc);
@@ -56,17 +56,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         if (verbose && 0 == threadIdxLocal)
           printf("booked hist with %d bins, size %d for %d tracks\n", hist.nbins(), hist.capacity(), nt);
 
-        assert(nt <= hist.capacity());
+        ALPAKA_ASSERT_OFFLOAD(nt <= hist.capacity());
 
         // fill hist  (bin shall be wider than "eps")
         cms::alpakatools::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
-          assert(i < ZVertices::MAXTRACKS);
+          ALPAKA_ASSERT_OFFLOAD(i < ZVertices::MAXTRACKS);
           int iz = int(zt[i] * 10.);  // valid if eps<=0.1
           // iz = std::clamp(iz, INT8_MIN, INT8_MAX);  // sorry c++17 only
           iz = std::min(std::max(iz, INT8_MIN), INT8_MAX);
           izt[i] = iz - INT8_MIN;
-          assert(iz - INT8_MIN >= 0);
-          assert(iz - INT8_MIN < 256);
+          ALPAKA_ASSERT_OFFLOAD(iz - INT8_MIN >= 0);
+          ALPAKA_ASSERT_OFFLOAD(iz - INT8_MIN < 256);
           hist.count(acc, izt[i]);
           iv[i] = i;
           nn[i] = 0;
@@ -80,7 +80,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::syncBlockThreads(acc);
         hist.finalize(acc, hws);
         alpaka::syncBlockThreads(acc);
-        assert(hist.size() == nt);
+        ALPAKA_ASSERT_OFFLOAD(hist.size() == nt);
         cms::alpakatools::for_each_element_in_block_strided(
             acc, nt, [&](uint32_t i) { hist.fill(acc, izt[i], uint16_t(i)); });
         alpaka::syncBlockThreads(acc);
@@ -128,7 +128,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         //  mini verification
         cms::alpakatools::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
           if (iv[i] != int(i))
-            assert(iv[iv[i]] != int(i));
+            ALPAKA_ASSERT_OFFLOAD(iv[iv[i]] != int(i));
         });
         alpaka::syncBlockThreads(acc);
 #endif
@@ -146,7 +146,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         //  mini verification
         cms::alpakatools::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
           if (iv[i] != int(i))
-            assert(iv[iv[i]] != int(i));
+            ALPAKA_ASSERT_OFFLOAD(iv[iv[i]] != int(i));
         });
         alpaka::syncBlockThreads(acc);
 #endif
@@ -155,7 +155,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         // and verify that we did not spit any cluster...
         cms::alpakatools::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
           if (nn[i] >= minT) {  // DBSCAN core rule
-            assert(zt[iv[i]] <= zt[i]);
+            ALPAKA_ASSERT_OFFLOAD(zt[iv[i]] <= zt[i]);
             auto loop = [&](uint32_t j) {
               if (nn[j] < minT)
                 return;  // DBSCAN core rule
@@ -169,7 +169,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                 printf("      %d %d %f %f %d\n", j, iv[j], zt[j], zt[iv[j]], iv[iv[j]]);
                 ;
               }
-              assert(iv[i] == iv[j]);
+              ALPAKA_ASSERT_OFFLOAD(iv[i] == iv[j]);
             };
             cms::alpakatools::forEachInBins(hist, izt[i], 1, loop);
           }
@@ -215,7 +215,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         });
         alpaka::syncBlockThreads(acc);
 
-        assert(foundClusters < ZVertices::MAXVTX);
+        ALPAKA_ASSERT_OFFLOAD(foundClusters < ZVertices::MAXVTX);
 
         // propagate the negative id to all the tracks in the cluster.
         cms::alpakatools::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksIterative.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksIterative.h
@@ -44,8 +44,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         int32_t* __restrict__ nn = data.ndof;
         int32_t* __restrict__ iv = ws.iv;
 
-        assert(pdata);
-        assert(zt);
+        ALPAKA_ASSERT_OFFLOAD(pdata);
+        ALPAKA_ASSERT_OFFLOAD(zt);
 
         using Hist = cms::alpakatools::HistoContainer<uint8_t, 256, 16000, 8, uint16_t>;
         auto& hist = alpaka::declareSharedVar<Hist, __COUNTER__>(acc);
@@ -56,17 +56,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         if (verbose && 0 == threadIdxLocal)
           printf("booked hist with %d bins, size %d for %d tracks\n", hist.nbins(), hist.capacity(), nt);
 
-        assert(nt <= hist.capacity());
+        ALPAKA_ASSERT_OFFLOAD(nt <= hist.capacity());
 
         // fill hist  (bin shall be wider than "eps")
         cms::alpakatools::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
-          assert(i < ZVertices::MAXTRACKS);
+          ALPAKA_ASSERT_OFFLOAD(i < ZVertices::MAXTRACKS);
           int iz = int(zt[i] * 10.);  // valid if eps<=0.1
           // iz = std::clamp(iz, INT8_MIN, INT8_MAX);  // sorry c++17 only
           iz = std::min(std::max(iz, INT8_MIN), INT8_MAX);
           izt[i] = iz - INT8_MIN;
-          assert(iz - INT8_MIN >= 0);
-          assert(iz - INT8_MIN < 256);
+          ALPAKA_ASSERT_OFFLOAD(iz - INT8_MIN >= 0);
+          ALPAKA_ASSERT_OFFLOAD(iz - INT8_MIN < 256);
           hist.count(acc, izt[i]);
           iv[i] = i;
           nn[i] = 0;
@@ -80,7 +80,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::syncBlockThreads(acc);
         hist.finalize(acc, hws);
         alpaka::syncBlockThreads(acc);
-        assert(hist.size() == nt);
+        ALPAKA_ASSERT_OFFLOAD(hist.size() == nt);
         cms::alpakatools::for_each_element_in_block_strided(
             acc, nt, [&](uint32_t i) { hist.fill(acc, izt[i], uint16_t(i)); });
         alpaka::syncBlockThreads(acc);
@@ -126,7 +126,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
               auto be = std::min(Hist::bin(izt[i]) + 1, int(hist.nbins() - 1));
               if (nn[i] >= minT) {  // DBSCAN core rule
                 auto loop = [&](uint32_t j) {
-                  assert(i != j);
+                  ALPAKA_ASSERT_OFFLOAD(i != j);
                   if (nn[j] < minT)
                     return;  // DBSCAN core rule
                   auto dist = std::abs(zt[i] - zt[j]);
@@ -190,7 +190,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         });
         alpaka::syncBlockThreads(acc);
 
-        assert(foundClusters < ZVertices::MAXVTX);
+        ALPAKA_ASSERT_OFFLOAD(foundClusters < ZVertices::MAXVTX);
 
         // propagate the negative id to all the tracks in the cluster.
         cms::alpakatools::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuFitVertices.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuFitVertices.h
@@ -34,10 +34,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       int32_t* __restrict__ nn = data.ndof;
       int32_t* __restrict__ iv = ws.iv;
 
-      assert(pdata);
-      assert(zt);
+      ALPAKA_ASSERT_OFFLOAD(pdata);
+      ALPAKA_ASSERT_OFFLOAD(zt);
 
-      assert(nvFinal <= nvIntermediate);
+      ALPAKA_ASSERT_OFFLOAD(nvFinal <= nvIntermediate);
       nvFinal = nvIntermediate;
       auto foundClusters = nvFinal;
 
@@ -62,8 +62,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           if (verbose)
             alpaka::atomicAdd(acc, &noise, 1, alpaka::hierarchy::Blocks{});
         } else {
-          assert(iv[i] >= 0);
-          assert(iv[i] < int(foundClusters));
+          ALPAKA_ASSERT_OFFLOAD(iv[i] >= 0);
+          ALPAKA_ASSERT_OFFLOAD(iv[i] < int(foundClusters));
           auto w = 1.f / ezt2[i];
           alpaka::atomicAdd(acc, &zv[iv[i]], zt[i] * w, alpaka::hierarchy::Blocks{});
           alpaka::atomicAdd(acc, &wv[iv[i]], w, alpaka::hierarchy::Blocks{});
@@ -73,7 +73,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       alpaka::syncBlockThreads(acc);
       // reuse nn
       cms::alpakatools::for_each_element_in_block_strided(acc, foundClusters, [&](uint32_t i) {
-        assert(wv[i] > 0.f);
+        ALPAKA_ASSERT_OFFLOAD(wv[i] > 0.f);
         zv[i] /= wv[i];
         nn[i] = -1;  // ndof
       });

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuSplitVertices.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuSplitVertices.h
@@ -33,8 +33,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       int32_t const* __restrict__ nn = data.ndof;
       int32_t* __restrict__ iv = ws.iv;
 
-      assert(pdata);
-      assert(zt);
+      ALPAKA_ASSERT_OFFLOAD(pdata);
+      ALPAKA_ASSERT_OFFLOAD(zt);
 
       constexpr uint32_t MAXTK = 512;
       // NB: Shared memory size? Is it enough?
@@ -60,7 +60,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         if (chi2[kv] < maxChi2 * float(nn[kv]))
           continue;
 
-        assert((uint32_t)nn[kv] < MAXTK);
+        ALPAKA_ASSERT_OFFLOAD((uint32_t)nn[kv] < MAXTK);
 
         if ((uint32_t)nn[kv] >= MAXTK)
           continue;
@@ -85,7 +85,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         auto& wnew = alpaka::declareSharedVar<float[2], __COUNTER__>(acc);
         alpaka::syncBlockThreads(acc);
 
-        assert(int(nq) == nn[kv] + 1);
+        ALPAKA_ASSERT_OFFLOAD(int(nq) == nn[kv] + 1);
 
         int maxiter = 20;
         // kt-min....

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
@@ -16,8 +16,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       template <typename T_Acc>
       ALPAKA_FN_ACC void operator()(
           const T_Acc& acc, TkSoA const* ptracks, ZVertexSoA* soa, WorkSpace* pws, float ptMin) const {
-        assert(ptracks);
-        assert(soa);
+        ALPAKA_ASSERT_OFFLOAD(ptracks);
+        ALPAKA_ASSERT_OFFLOAD(soa);
         auto const& tracks = *ptracks;
         auto const& fit = tracks.stateAtBS;
         auto const* quality = tracks.qualityData();
@@ -104,11 +104,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     ZVertexAlpaka Producer::makeAsync(TkSoA const* tksoa, float ptMin, Queue& queue) const {
       // std::cout << "producing Vertices on GPU" << std::endl;
-      assert(tksoa);
+      ALPAKA_ASSERT_OFFLOAD(tksoa);
 
       ZVertexAlpaka vertices{cms::alpakatools::allocDeviceBuf<ZVertexSoA>(1u)};
       auto* soa = alpaka::getPtrNative(vertices);
-      assert(soa);
+      ALPAKA_ASSERT_OFFLOAD(soa);
 
       auto ws_dBuf{cms::alpakatools::allocDeviceBuf<WorkSpace>(1u)};
       auto ws_d = alpaka::getPtrNative(ws_dBuf);

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToCluster.cc
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToCluster.cc
@@ -91,7 +91,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // for GPU
       // first 150 index stores the fedId and next 150 will store the
       // start index of word in that fed
-      assert(fedId >= 1200);
+      ALPAKA_ASSERT_OFFLOAD(fedId >= 1200);
       fedCounter++;
 
       // get event data for this fed
@@ -131,7 +131,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       const uint32_t* bw = (const uint32_t*)(header + 1);
       const uint32_t* ew = (const uint32_t*)(trailer);
 
-      assert(0 == (ew - bw) % 2);
+      ALPAKA_ASSERT_OFFLOAD(0 == (ew - bw) % 2);
       wordFedAppender_->initializeWordFed(fedId, wordCounterGPU, bw, (ew - bw));
       wordCounterGPU += (ew - bw);
 

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
@@ -483,13 +483,13 @@ namespace pixelgpudetails {
     ALPAKA_FN_ACC void operator()(const T_Acc &acc,
                                   uint32_t const *__restrict__ cluStart,
                                   uint32_t *__restrict__ moduleStart) const {
-      assert(gpuClustering::MaxNumModules < 2048);  // easy to extend at least till 32*1024
+      ALPAKA_ASSERT_OFFLOAD(gpuClustering::MaxNumModules < 2048);  // easy to extend at least till 32*1024
 
 #ifndef NDEBUG
       const uint32_t blockIdxLocal(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
-      assert(0 == blockIdxLocal);
+      ALPAKA_ASSERT_OFFLOAD(0 == blockIdxLocal);
       const uint32_t gridDimension(alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
-      assert(1 == gridDimension);
+      ALPAKA_ASSERT_OFFLOAD(1 == gridDimension);
 #endif
 
       // limit to MaxHitsInModule;
@@ -507,17 +507,17 @@ namespace pixelgpudetails {
       alpaka::syncBlockThreads(acc);
 
 #ifdef GPU_DEBUG
-      assert(0 == moduleStart[0]);
+      ALPAKA_ASSERT_OFFLOAD(0 == moduleStart[0]);
       auto c0 = std::min(gpuClustering::maxHitsInModule(), cluStart[0]);
-      assert(c0 == moduleStart[1]);
-      assert(moduleStart[1024] >= moduleStart[1023]);
-      assert(moduleStart[1025] >= moduleStart[1024]);
-      assert(moduleStart[gpuClustering::MaxNumModules] >= moduleStart[1025]);
+      ALPAKA_ASSERT_OFFLOAD(c0 == moduleStart[1]);
+      ALPAKA_ASSERT_OFFLOAD(moduleStart[1024] >= moduleStart[1023]);
+      ALPAKA_ASSERT_OFFLOAD(moduleStart[1025] >= moduleStart[1024]);
+      ALPAKA_ASSERT_OFFLOAD(moduleStart[gpuClustering::MaxNumModules] >= moduleStart[1025]);
 
       //for (int i = first, iend = gpuClustering::MaxNumModules + 1; i < iend; i += blockDim.x) {
       cms::alpakatools::for_each_element_in_block_strided(acc, gpuClustering::MaxNumModules + 1, [&](uint32_t i) {
         if (0 != i)
-          assert(moduleStart[i] >= moduleStart[i - i]);
+          ALPAKA_ASSERT_OFFLOAD(moduleStart[i] >= moduleStart[i - i]);
         // [BPX1, BPX2, BPX3, BPX4,  FP1,  FP2,  FP3,  FN1,  FN2,  FN3, LAST_VALID]
         // [   0,   96,  320,  672, 1184, 1296, 1408, 1520, 1632, 1744,       1856]
         if (i == 96 || i == 1184 || i == 1744 || i == gpuClustering::MaxNumModules)
@@ -578,7 +578,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         const WorkDiv1 &workDiv =
             cms::alpakatools::make_workdiv(Vec1::all(blocks), Vec1::all(threadsPerBlockOrElementsPerThread));
 
-        assert(0 == wordCounter % 2);
+        ALPAKA_ASSERT_OFFLOAD(0 == wordCounter % 2);
         // wordCounter is the total no of words in each event to be trasfered on device
         auto word_d = cms::alpakatools::allocDeviceBuf<uint32_t>(wordCounter);
         // NB: IMPORTANT: fedId_d: In legacy, wordCounter elements are allocated.

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/gpuClusterChargeCut.h
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/gpuClusterChargeCut.h
@@ -27,8 +27,8 @@ namespace gpuClustering {
 
       auto firstPixel = moduleStart[1 + blockIdx];
       auto thisModuleId = id[firstPixel];
-      assert(thisModuleId < MaxNumModules);
-      assert(thisModuleId == moduleId[blockIdx]);
+      ALPAKA_ASSERT_OFFLOAD(thisModuleId < MaxNumModules);
+      ALPAKA_ASSERT_OFFLOAD(thisModuleId == moduleId[blockIdx]);
 
       auto nclus = nClustersInModule[thisModuleId];
       if (nclus == 0)
@@ -79,7 +79,7 @@ namespace gpuClustering {
       auto& ok = alpaka::declareSharedVar<uint8_t[MaxNumClustersPerModules], __COUNTER__>(acc);
       auto& newclusId = alpaka::declareSharedVar<uint16_t[MaxNumClustersPerModules], __COUNTER__>(acc);
 
-      assert(nclus <= MaxNumClustersPerModules);
+      ALPAKA_ASSERT_OFFLOAD(nclus <= MaxNumClustersPerModules);
       cms::alpakatools::for_each_element_in_block_strided(acc, nclus, [&](uint32_t i) { charge[i] = 0; });
       alpaka::syncBlockThreads(acc);
 
@@ -106,7 +106,7 @@ namespace gpuClustering {
       auto& ws = alpaka::declareSharedVar<uint16_t[32], __COUNTER__>(acc);
       cms::alpakatools::blockPrefixScan(acc, newclusId, nclus, ws);
 
-      assert(nclus >= newclusId[nclus - 1]);
+      ALPAKA_ASSERT_OFFLOAD(nclus >= newclusId[nclus - 1]);
 
       if (nclus == newclusId[nclus - 1])
         return;

--- a/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelRecHits.cc
+++ b/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelRecHits.cc
@@ -10,7 +10,7 @@ namespace {
                                   uint32_t const* __restrict__ hitsModuleStart,
                                   pixelCPEforGPU::ParamsOnGPU const* cpeParams,
                                   uint32_t* hitsLayerStart) const {
-      assert(0 == hitsModuleStart[0]);
+      ALPAKA_ASSERT_OFFLOAD(0 == hitsModuleStart[0]);
 
       cms::alpakatools::for_each_element_in_grid(acc, 11, [&](uint32_t i) {
         hitsLayerStart[i] = hitsModuleStart[cpeParams->layerGeometry().layerStart[i]];

--- a/src/alpaka/plugin-SiPixelRecHits/alpaka/gpuPixelRecHits.h
+++ b/src/alpaka/plugin-SiPixelRecHits/alpaka/gpuPixelRecHits.h
@@ -30,8 +30,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         // The whole gimnastic here of copying or not is a pure heuristic exercise that seems to produce the fastest code with the above signature
         // not using views (passing a gazzilion of array pointers) seems to produce the fastest code (but it is harder to mantain)
 
-        assert(phits);
-        assert(cpeParams);
+        ALPAKA_ASSERT_OFFLOAD(phits);
+        ALPAKA_ASSERT_OFFLOAD(cpeParams);
 
         auto& hits = *phits;
 
@@ -78,7 +78,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           auto k = clusters.moduleStart(1 + blockIdx);
           while (digis.moduleInd(k) == InvId)
             ++k;
-          assert(digis.moduleInd(k) == me);
+          ALPAKA_ASSERT_OFFLOAD(digis.moduleInd(k) == me);
         }
 #endif
 
@@ -93,11 +93,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
           int nClusInIter = std::min(MaxHitsInIter, endClus - startClus);
           int lastClus = startClus + nClusInIter;
-          assert(nClusInIter <= nclus);
-          assert(nClusInIter > 0);
-          assert(lastClus <= nclus);
+          ALPAKA_ASSERT_OFFLOAD(nClusInIter <= nclus);
+          ALPAKA_ASSERT_OFFLOAD(nClusInIter > 0);
+          ALPAKA_ASSERT_OFFLOAD(lastClus <= nclus);
 
-          assert(nclus > MaxHitsInIter || (0 == startClus && nClusInIter == nclus && lastClus == nclus));
+          ALPAKA_ASSERT_OFFLOAD(nclus > MaxHitsInIter || (0 == startClus && nClusInIter == nclus && lastClus == nclus));
 
           // init
           cms::alpakatools::for_each_element_in_block_strided(acc, nClusInIter, [&](uint32_t ic) {
@@ -136,8 +136,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             const uint32_t x = digis.xx(i);
             const uint32_t y = digis.yy(i);
             cl -= startClus;
-            assert(cl >= 0);
-            assert(cl < MaxHitsInIter);
+            ALPAKA_ASSERT_OFFLOAD(cl >= 0);
+            ALPAKA_ASSERT_OFFLOAD(cl < MaxHitsInIter);
             alpaka::atomicMin(acc, &clusParams.minRow[cl], x, alpaka::hierarchy::Blocks{});
             alpaka::atomicMax(acc, &clusParams.maxRow[cl], x, alpaka::hierarchy::Blocks{});
             alpaka::atomicMin(acc, &clusParams.minCol[cl], y, alpaka::hierarchy::Blocks{});
@@ -164,8 +164,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             if (cl < startClus || cl >= lastClus)
               continue;
             cl -= startClus;
-            assert(cl >= 0);
-            assert(cl < MaxHitsInIter);
+            ALPAKA_ASSERT_OFFLOAD(cl >= 0);
+            ALPAKA_ASSERT_OFFLOAD(cl < MaxHitsInIter);
             const uint32_t x = digis.xx(i);
             const uint32_t y = digis.yy(i);
             const int32_t ch = std::min(digis.adc(i), pixmx);
@@ -193,8 +193,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             // TODO: was 'break', OTOH comment above says "should not happen", so hopefully 'return' is ok
             if (h >= TrackingRecHit2DSOAView::maxHits())
               return;  // overflow...
-            assert(h < hits.nHits());
-            assert(h < clusters.clusModuleStart(me + 1));
+            ALPAKA_ASSERT_OFFLOAD(h < hits.nHits());
+            ALPAKA_ASSERT_OFFLOAD(h < clusters.clusModuleStart(me + 1));
 
             pixelCPEforGPU::position(cpeParams->commonParams(), cpeParams->detParams(me), clusParams, ic);
             pixelCPEforGPU::errorFromDB(cpeParams->commonParams(), cpeParams->detParams(me), clusParams, ic);

--- a/src/alpaka/plugin-Validation/SimpleAtomicHisto.h
+++ b/src/alpaka/plugin-Validation/SimpleAtomicHisto.h
@@ -36,7 +36,7 @@ public:
       }
       ++i;
     }
-    assert(i >= 0 and static_cast<unsigned int>(i) < data_.size());
+    ALPAKA_ASSERT_OFFLOAD(i >= 0 and static_cast<unsigned int>(i) < data_.size());
     data_[i] += 1;
   }
 


### PR DESCRIPTION
Some Alpaka kernels have the occupancy lower than the Native CUDA implementation (for example ```countFromVector``` kernel from ```HistoContainer```). 

I found out that the problem was related to the ```assert``` use in Alpaka. In Native CUDA, the assert is disabled by default, becoming enabled only if the macro ```GPU_DEBUG``` is set (this is not the case in Alpaka). I changed the assert from the Alpaka implementation with the macro ```ALPAKA_ASSERT_OFFLOAD``` from the Alpaka library (compatible from Alpaka 0.6.1). This macro enables assert only if ```ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST``` is set. This change increased the occupancy for some kernels in Alpaka.