### PR TITLE
[kokkos] Use "device framework" in Kokkos version

### DIFF
--- a/src/kokkos/CUDACore/EventCache.cc
+++ b/src/kokkos/CUDACore/EventCache.cc
@@ -1,0 +1,68 @@
+#include "CUDACore/EventCache.h"
+#include "CUDACore/cudaCheck.h"
+#include "CUDACore/currentDevice.h"
+#include "CUDACore/deviceCount.h"
+#include "CUDACore/eventWorkHasCompleted.h"
+#include "CUDACore/ScopedSetDevice.h"
+
+namespace cms::cuda {
+  void EventCache::Deleter::operator()(cudaEvent_t event) const {
+    if (device_ != -1) {
+      ScopedSetDevice deviceGuard{device_};
+      cudaCheck(cudaEventDestroy(event));
+    }
+  }
+
+  // EventCache should be constructed by the first call to
+  // getEventCache() only if we have CUDA devices present
+  EventCache::EventCache() : cache_(deviceCount()) {}
+
+  SharedEventPtr EventCache::get() {
+    const auto dev = currentDevice();
+    auto event = makeOrGet(dev);
+    // captured work has completed, or a just-created event
+    if (eventWorkHasCompleted(event.get())) {
+      return event;
+    }
+
+    // Got an event with incomplete captured work. Try again until we
+    // get a completed (or a just-created) event. Need to keep all
+    // incomplete events until a completed event is found in order to
+    // avoid ping-pong with an incomplete event.
+    std::vector<SharedEventPtr> ptrs{std::move(event)};
+    bool completed;
+    do {
+      event = makeOrGet(dev);
+      completed = eventWorkHasCompleted(event.get());
+      if (not completed) {
+        ptrs.emplace_back(std::move(event));
+      }
+    } while (not completed);
+    return event;
+  }
+
+  SharedEventPtr EventCache::makeOrGet(int dev) {
+    return cache_[dev].makeOrGet([dev]() {
+      cudaEvent_t event;
+      // it should be a bit faster to ignore timings
+      cudaCheck(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
+      return std::unique_ptr<BareEvent, Deleter>(event, Deleter{dev});
+    });
+  }
+
+  void EventCache::clear() {
+    // Reset the contents of the caches, but leave an
+    // edm::ReusableObjectHolder alive for each device. This is needed
+    // mostly for the unit tests, where the function-static
+    // EventCache lives through multiple tests (and go through
+    // multiple shutdowns of the framework).
+    cache_.clear();
+    cache_.resize(deviceCount());
+  }
+
+  EventCache& getEventCache() {
+    // the public interface is thread safe
+    static EventCache cache;
+    return cache;
+  }
+}  // namespace cms::cuda

--- a/src/kokkos/CUDACore/EventCache.h
+++ b/src/kokkos/CUDACore/EventCache.h
@@ -1,0 +1,57 @@
+#ifndef HeterogeneousCore_CUDAUtilities_EventCache_h
+#define HeterogeneousCore_CUDAUtilities_EventCache_h
+
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "Framework/ReusableObjectHolder.h"
+#include "CUDACore/SharedEventPtr.h"
+
+class CUDAService;
+
+namespace cms {
+  namespace cuda {
+    class EventCache {
+    public:
+      using BareEvent = SharedEventPtr::element_type;
+
+      EventCache();
+
+      // Gets a (cached) CUDA event for the current device. The event
+      // will be returned to the cache by the shared_ptr destructor. The
+      // returned event is guaranteed to be in the state where all
+      // captured work has completed, i.e. cudaEventQuery() == cudaSuccess.
+      //
+      // This function is thread safe
+      SharedEventPtr get();
+
+    private:
+      friend class ::CUDAService;
+
+      // thread safe
+      SharedEventPtr makeOrGet(int dev);
+
+      // not thread safe, intended to be called only from CUDAService destructor
+      void clear();
+
+      class Deleter {
+      public:
+        Deleter() = default;
+        Deleter(int d) : device_{d} {}
+        void operator()(cudaEvent_t event) const;
+
+      private:
+        int device_ = -1;
+      };
+
+      std::vector<edm::ReusableObjectHolder<BareEvent, Deleter>> cache_;
+    };
+
+    // Gets the global instance of a EventCache
+    // This function is thread safe
+    EventCache& getEventCache();
+  }  // namespace cuda
+}  // namespace cms
+
+#endif

--- a/src/kokkos/CUDACore/ScopedSetDevice.h
+++ b/src/kokkos/CUDACore/ScopedSetDevice.h
@@ -1,0 +1,30 @@
+#ifndef HeterogeneousCore_CUDAUtilities_ScopedSetDevice_h
+#define HeterogeneousCore_CUDAUtilities_ScopedSetDevice_h
+
+#include "CUDACore/cudaCheck.h"
+
+#include <cuda_runtime.h>
+
+namespace cms {
+  namespace cuda {
+    class ScopedSetDevice {
+    public:
+      explicit ScopedSetDevice(int newDevice) {
+        cudaCheck(cudaGetDevice(&prevDevice_));
+        cudaCheck(cudaSetDevice(newDevice));
+      }
+
+      ~ScopedSetDevice() {
+        // Intentionally don't check the return value to avoid
+        // exceptions to be thrown. If this call fails, the process is
+        // doomed anyway.
+        cudaSetDevice(prevDevice_);
+      }
+
+    private:
+      int prevDevice_;
+    };
+  }  // namespace cuda
+}  // namespace cms
+
+#endif

--- a/src/kokkos/CUDACore/SharedEventPtr.h
+++ b/src/kokkos/CUDACore/SharedEventPtr.h
@@ -1,0 +1,18 @@
+#ifndef HeterogeneousCore_CUDAUtilities_SharedEventPtr_h
+#define HeterogeneousCore_CUDAUtilities_SharedEventPtr_h
+
+#include <memory>
+#include <type_traits>
+
+#include <cuda_runtime.h>
+
+namespace cms {
+  namespace cuda {
+    // cudaEvent_t itself is a typedef for a pointer, for the use with
+    // edm::ReusableObjectHolder the pointed-to type is more interesting
+    // to avoid extra layer of indirection
+    using SharedEventPtr = std::shared_ptr<std::remove_pointer_t<cudaEvent_t>>;
+  }  // namespace cuda
+}  // namespace cms
+
+#endif

--- a/src/kokkos/CUDACore/SharedStreamPtr.h
+++ b/src/kokkos/CUDACore/SharedStreamPtr.h
@@ -1,0 +1,18 @@
+#ifndef HeterogeneousCore_CUDAUtilities_SharedStreamPtr_h
+#define HeterogeneousCore_CUDAUtilities_SharedStreamPtr_h
+
+#include <memory>
+#include <type_traits>
+
+#include <cuda_runtime.h>
+
+namespace cms {
+  namespace cuda {
+    // cudaStream_t itself is a typedef for a pointer, for the use with
+    // edm::ReusableObjectHolder the pointed-to type is more interesting
+    // to avoid extra layer of indirection
+    using SharedStreamPtr = std::shared_ptr<std::remove_pointer_t<cudaStream_t>>;
+  }  // namespace cuda
+}  // namespace cms
+
+#endif

--- a/src/kokkos/CUDACore/StreamCache.cc
+++ b/src/kokkos/CUDACore/StreamCache.cc
@@ -1,0 +1,43 @@
+#include "CUDACore/StreamCache.h"
+#include "CUDACore/cudaCheck.h"
+#include "CUDACore/currentDevice.h"
+#include "CUDACore/deviceCount.h"
+#include "CUDACore/ScopedSetDevice.h"
+
+namespace cms::cuda {
+  void StreamCache::Deleter::operator()(cudaStream_t stream) const {
+    if (device_ != -1) {
+      ScopedSetDevice deviceGuard{device_};
+      cudaCheck(cudaStreamDestroy(stream));
+    }
+  }
+
+  // StreamCache should be constructed by the first call to
+  // getStreamCache() only if we have CUDA devices present
+  StreamCache::StreamCache() : cache_(deviceCount()) {}
+
+  SharedStreamPtr StreamCache::get() {
+    const auto dev = currentDevice();
+    return cache_[dev].makeOrGet([dev]() {
+      cudaStream_t stream;
+      cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+      return std::unique_ptr<BareStream, Deleter>(stream, Deleter{dev});
+    });
+  }
+
+  void StreamCache::clear() {
+    // Reset the contents of the caches, but leave an
+    // edm::ReusableObjectHolder alive for each device. This is needed
+    // mostly for the unit tests, where the function-static
+    // StreamCache lives through multiple tests (and go through
+    // multiple shutdowns of the framework).
+    cache_.clear();
+    cache_.resize(deviceCount());
+  }
+
+  StreamCache& getStreamCache() {
+    // the public interface is thread safe
+    static StreamCache cache;
+    return cache;
+  }
+}  // namespace cms::cuda

--- a/src/kokkos/CUDACore/StreamCache.h
+++ b/src/kokkos/CUDACore/StreamCache.h
@@ -1,0 +1,50 @@
+#ifndef HeterogeneousCore_CUDAUtilities_StreamCache_h
+#define HeterogeneousCore_CUDAUtilities_StreamCache_h
+
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "Framework/ReusableObjectHolder.h"
+#include "CUDACore/SharedStreamPtr.h"
+
+class CUDAService;
+
+namespace cms {
+  namespace cuda {
+    class StreamCache {
+    public:
+      using BareStream = SharedStreamPtr::element_type;
+
+      StreamCache();
+
+      // Gets a (cached) CUDA stream for the current device. The stream
+      // will be returned to the cache by the shared_ptr destructor.
+      // This function is thread safe
+      SharedStreamPtr get();
+
+    private:
+      friend class ::CUDAService;
+      // not thread safe, intended to be called only from CUDAService destructor
+      void clear();
+
+      class Deleter {
+      public:
+        Deleter() = default;
+        Deleter(int d) : device_{d} {}
+        void operator()(cudaStream_t stream) const;
+
+      private:
+        int device_ = -1;
+      };
+
+      std::vector<edm::ReusableObjectHolder<BareStream, Deleter>> cache_;
+    };
+
+    // Gets the global instance of a StreamCache
+    // This function is thread safe
+    StreamCache& getStreamCache();
+  }  // namespace cuda
+}  // namespace cms
+
+#endif

--- a/src/kokkos/CUDACore/cudaCheck.h
+++ b/src/kokkos/CUDACore/cudaCheck.h
@@ -1,0 +1,61 @@
+#ifndef HeterogeneousCore_CUDAUtilities_cudaCheck_h
+#define HeterogeneousCore_CUDAUtilities_cudaCheck_h
+
+// C++ standard headers
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+// CUDA headers
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+namespace cms {
+  namespace cuda {
+
+    [[noreturn]] inline void abortOnCudaError(const char* file,
+                                              int line,
+                                              const char* cmd,
+                                              const char* error,
+                                              const char* message,
+                                              const char* description = nullptr) {
+      std::ostringstream out;
+      out << "\n";
+      out << file << ", line " << line << ":\n";
+      out << "cudaCheck(" << cmd << ");\n";
+      out << error << ": " << message << "\n";
+      if (description)
+        out << description << "\n";
+      throw std::runtime_error(out.str());
+    }
+
+    inline bool cudaCheck_(
+        const char* file, int line, const char* cmd, CUresult result, const char* description = nullptr) {
+      if (result == CUDA_SUCCESS)
+        return true;
+
+      const char* error;
+      const char* message;
+      cuGetErrorName(result, &error);
+      cuGetErrorString(result, &message);
+      abortOnCudaError(file, line, cmd, error, message, description);
+      return false;
+    }
+
+    inline bool cudaCheck_(
+        const char* file, int line, const char* cmd, cudaError_t result, const char* description = nullptr) {
+      if (result == cudaSuccess)
+        return true;
+
+      const char* error = cudaGetErrorName(result);
+      const char* message = cudaGetErrorString(result);
+      abortOnCudaError(file, line, cmd, error, message, description);
+      return false;
+    }
+
+  }  // namespace cuda
+}  // namespace cms
+
+#define cudaCheck(ARG, ...) (cms::cuda::cudaCheck_(__FILE__, __LINE__, #ARG, (ARG), ##__VA_ARGS__))
+
+#endif  // HeterogeneousCore_CUDAUtilities_cudaCheck_h

--- a/src/kokkos/CUDACore/currentDevice.h
+++ b/src/kokkos/CUDACore/currentDevice.h
@@ -1,0 +1,18 @@
+#ifndef HeterogenousCore_CUDAUtilities_currentDevice_h
+#define HeterogenousCore_CUDAUtilities_currentDevice_h
+
+#include "CUDACore/cudaCheck.h"
+
+#include <cuda_runtime.h>
+
+namespace cms {
+  namespace cuda {
+    inline int currentDevice() {
+      int dev;
+      cudaCheck(cudaGetDevice(&dev));
+      return dev;
+    }
+  }  // namespace cuda
+}  // namespace cms
+
+#endif

--- a/src/kokkos/CUDACore/deviceCount.h
+++ b/src/kokkos/CUDACore/deviceCount.h
@@ -1,0 +1,18 @@
+#ifndef HeterogenousCore_CUDAUtilities_deviceCount_h
+#define HeterogenousCore_CUDAUtilities_deviceCount_h
+
+#include "CUDACore/cudaCheck.h"
+
+#include <cuda_runtime.h>
+
+namespace cms {
+  namespace cuda {
+    inline int deviceCount() {
+      int ndevices;
+      cudaCheck(cudaGetDeviceCount(&ndevices));
+      return ndevices;
+    }
+  }  // namespace cuda
+}  // namespace cms
+
+#endif

--- a/src/kokkos/CUDACore/eventWorkHasCompleted.h
+++ b/src/kokkos/CUDACore/eventWorkHasCompleted.h
@@ -1,0 +1,32 @@
+#ifndef HeterogeneousCore_CUDAUtilities_eventWorkHasCompleted_h
+#define HeterogeneousCore_CUDAUtilities_eventWorkHasCompleted_h
+
+#include "CUDACore/cudaCheck.h"
+
+#include <cuda_runtime.h>
+
+namespace cms {
+  namespace cuda {
+    /**
+   * Returns true if the work captured by the event (=queued to the
+   * CUDA stream at the point of cudaEventRecord()) has completed.
+   *
+   * Returns false if any captured work is incomplete.
+   *
+   * In case of errors, throws an exception.
+   */
+    inline bool eventWorkHasCompleted(cudaEvent_t event) {
+      const auto ret = cudaEventQuery(event);
+      if (ret == cudaSuccess) {
+        return true;
+      } else if (ret == cudaErrorNotReady) {
+        return false;
+      }
+      // leave error case handling to cudaCheck
+      cudaCheck(ret);
+      return false;  // to keep compiler happy
+    }
+  }  // namespace cuda
+}  // namespace cms
+
+#endif

--- a/src/kokkos/Framework/ReusableObjectHolder.h
+++ b/src/kokkos/Framework/ReusableObjectHolder.h
@@ -1,0 +1,167 @@
+#ifndef FWCore_Utilities_ReusableObjectHolder_h
+#define FWCore_Utilities_ReusableObjectHolder_h
+
+// -*- C++ -*-
+//
+// Package:     FWCore/Utilities
+// Class  :     ReusableObjectHolder
+//
+/**\class edm::ReusableObjectHolder ReusableObjectHolder "ReusableObjectHolder.h"
+ 
+ Description: Thread safe way to do create and reuse a group of the same object type.
+ 
+ Usage:
+ This class can be used to safely reuse a series of objects created on demand. The reuse
+ of the objects is safe even across different threads since one can safely call all member
+ functions of this class on the same instance of this class from multiple threads.
+
+ This class manages the cache of reusable objects and therefore an instance of this
+ class must live as long as you want the cache to live.
+ 
+ The primary way of using the class it to call makeOrGetAndClear
+ An example use would be
+ \code
+ auto objectToUse = holder.makeOrGetAndClear(
+                             []() { return new MyObject(10); }, //makes new one
+                             [](MyObject* old) {old->reset(); } //resets old one
+                    );
+ \endcode
+ 
+ If you always want to set the values you can use makeOrGet
+ \code
+ auto objectToUse = holder.makeOrGet(
+                         []() { return new MyObject(); });
+ objectToUse->setValue(3);
+ \endcode
+ 
+ NOTE: If you hold onto the std::shared_ptr<> until another call to the ReusableObjectHolder,
+ make sure to release the shared_ptr before the call. That way the object you were just
+ using can go back into the cache and be reused for the call you are going to make.
+ An example
+ \code
+  std::shared_ptr<MyObject> obj;
+  while(someCondition()) {
+    //release object so it can re-enter the cache
+    obj.release();
+    obj = holder.makeOrGet([]{ return new MyObject();} );
+    obj->setValue(someNewValue());
+    useTheObject(obj);
+  }
+ \endcode
+ 
+ The above example is very contrived, since the better way to do the above is
+ \code
+ while(someCondition()) {
+   auto obj = holder.makeOrGet([]{ return new MyObject();} );
+   obj->setValue(someNewValue());
+   useTheObject(obj);
+   //obj goes out of scope and returns the object to the cache
+ }
+ \endcode
+
+ When a custom deleter is used, the deleter type must be the same to
+ all objects. The deleter is allowed to have state that depends on the
+ object. The deleter object is passed along the std::unique_ptr, and
+ is internally kept along the object. The deleter object must be copyable.
+ */
+//
+// Original Author:  Chris Jones
+//         Created:  Fri, 31 July 2014 14:29:41 GMT
+//
+
+#include <memory>
+#include <cassert>
+#include <atomic>
+#include "tbb/task.h"
+#include "tbb/concurrent_queue.h"
+
+namespace edm {
+  template <class T, class Deleter = std::default_delete<T>>
+  class ReusableObjectHolder {
+  public:
+    using deleter_type = Deleter;
+
+    ReusableObjectHolder() : m_outstandingObjects(0) {}
+    ReusableObjectHolder(ReusableObjectHolder&& iOther)
+        : m_availableQueue(std::move(iOther.m_availableQueue)), m_outstandingObjects(0) {
+      assert(0 == iOther.m_outstandingObjects);
+    }
+    ~ReusableObjectHolder() {
+      assert(0 == m_outstandingObjects);
+      std::unique_ptr<T, Deleter> item;
+      while (m_availableQueue.try_pop(item)) {
+        item.reset();
+      }
+    }
+
+    ///Adds the item to the cache.
+    /// Use this function if you know ahead of time
+    /// how many cached items you will need.
+    void add(std::unique_ptr<T, Deleter> iItem) {
+      if (nullptr != iItem) {
+        m_availableQueue.push(std::move(iItem));
+      }
+    }
+
+    ///Tries to get an already created object,
+    /// if none are available, returns an empty shared_ptr.
+    /// Use this function in conjunction with add()
+    std::shared_ptr<T> tryToGet() {
+      std::unique_ptr<T, Deleter> item;
+      m_availableQueue.try_pop(item);
+      if (nullptr == item) {
+        return std::shared_ptr<T>{};
+      }
+      //instead of deleting, hand back to queue
+      auto pHolder = this;
+      auto deleter = item.get_deleter();
+      ++m_outstandingObjects;
+      return std::shared_ptr<T>{item.release(), [pHolder, deleter](T* iItem) {
+                                  pHolder->addBack(std::unique_ptr<T, Deleter>{iItem, deleter});
+                                }};
+    }
+
+    ///If there isn't an object already available, creates a new one using iFunc
+    template <typename F>
+    std::shared_ptr<T> makeOrGet(F iFunc) {
+      std::shared_ptr<T> returnValue;
+      while (!(returnValue = tryToGet())) {
+        add(makeUnique(iFunc()));
+      }
+      return returnValue;
+    }
+
+    ///If there is an object already available, passes the object to iClearFunc and then
+    /// returns the object.
+    ///If there is not an object already available, creates a new one using iMakeFunc
+    template <typename FM, typename FC>
+    std::shared_ptr<T> makeOrGetAndClear(FM iMakeFunc, FC iClearFunc) {
+      std::shared_ptr<T> returnValue;
+      while (!(returnValue = tryToGet())) {
+        add(makeUnique(iMakeFunc()));
+      }
+      iClearFunc(returnValue.get());
+      return returnValue;
+    }
+
+  private:
+    std::unique_ptr<T> makeUnique(T* ptr) {
+      static_assert(std::is_same<Deleter, std::default_delete<T>>::value,
+                    "Generating functions returning raw pointers are supported only with std::default_delete<T>");
+      return std::unique_ptr<T>{ptr};
+    }
+
+    std::unique_ptr<T, Deleter> makeUnique(std::unique_ptr<T, Deleter> ptr) { return ptr; }
+
+    void addBack(std::unique_ptr<T, Deleter> iItem) {
+      m_availableQueue.push(std::move(iItem));
+      --m_outstandingObjects;
+    }
+
+    tbb::concurrent_queue<std::unique_ptr<T, Deleter>> m_availableQueue;
+    std::atomic<size_t> m_outstandingObjects;
+  };
+
+}  // namespace edm
+
+#endif /* end of include guard: FWCore_Utilities_ReusableObjectHolder_h */

--- a/src/kokkos/KokkosCore/ContextState.h
+++ b/src/kokkos/KokkosCore/ContextState.h
@@ -1,0 +1,45 @@
+#ifndef KokkosCore_ContextState_h
+#define KokkosCore_ContextState_h
+
+#include "KokkosCore/ProductBase.h"
+
+namespace cms {
+  namespace kokkos {
+    template <typename T>
+    class ScopedContextAcquire;
+    template <typename T>
+    class SCopedContextProduce;
+
+    /**
+     * The purpose of this class is to deliver the device and CUDA stream
+     * information from ExternalWork's acquire() to producer() via a
+     * member/StreamCache variable.
+     */
+    template <typename ExecSpace>
+    class ContextState {
+    public:
+      ContextState() = default;
+      ~ContextState() = default;
+
+      ContextState(const ContextState&) = delete;
+      ContextState& operator=(const ContextState&) = delete;
+      ContextState(ContextState&&) = delete;
+      ContextState& operator=(ContextState&& other) = delete;
+
+    private:
+      friend class ScopedContextAcquire<ExecSpace>;
+      friend class ScopedContextProduce<ExecSpace>;
+
+      void set(std::unique_ptr<impl::ExecSpaceSpecific<ExecSpace>> specific) { specific_ = std::move(specific); }
+
+      std::unique_ptr<impl::ExecSpaceSpecific<ExecSpace>> release() { return std::move(specific_); }
+
+      //void throwIfStream() const;
+      //void throwIfNoStream() const;
+
+      std::unique_ptr<impl::ExecSpaceSpecific<ExecSpace>> specific_;
+    };
+  }  // namespace kokkos
+}  // namespace cms
+
+#endif

--- a/src/kokkos/KokkosCore/ExecSpaceCache.h
+++ b/src/kokkos/KokkosCore/ExecSpaceCache.h
@@ -1,0 +1,89 @@
+#ifndef KokkosCore_ExecSpaceCache_h
+#define KokkosCore_ExecSpaceCache_h
+
+#include <memory>
+
+#include <Kokkos_Core.hpp>
+
+#include "Framework/ReusableObjectHolder.h"
+
+namespace cms {
+  namespace kokkos {
+    template <typename ExecSpace>
+    class ExecSpaceWrapper {
+    public:
+      ExecSpaceWrapper() = default;
+
+      ExecSpace const& space() const { return space_; }
+
+    private:
+      ExecSpace space_;
+    };
+
+    template <typename ExecSpace>
+    class ExecSpaceCache {
+    public:
+      using CacheType = edm::ReusableObjectHolder<ExecSpaceWrapper<ExecSpace>>;
+
+      ExecSpaceCache() : cache_{std::make_unique<CacheType>()} {}
+
+      // Gets a (cached) execution space object. The object will be
+      // returned to the cache by the shared_ptr destructor.  This
+      // function is thread safe
+      std::shared_ptr<ExecSpaceWrapper<ExecSpace>> get() {
+        return cache_->makeOrGet([]() { return std::make_unique<ExecSpaceWrapper<ExecSpace>>(); });
+      }
+
+      // Need to be able to clear before the destruction of globals
+      // because the execution space objects need to be destructed
+      // before the destruction of Kokkos runtime. In addition, these
+      // objects need to be destructed before the
+      // cms::cuda::StreamCache is destroyed.
+      void clear() { cache_.reset(); }
+
+    private:
+      std::unique_ptr<CacheType> cache_;
+    };
+
+    // Gets the global instance of a ExecSpaceCache
+    // This function is thread safe
+    template <typename ExecSpace>
+    ExecSpaceCache<ExecSpace>& getExecSpaceCache() {
+      // the public interface is thread safe
+      static ExecSpaceCache<ExecSpace> cache;
+      return cache;
+    }
+  }  // namespace kokkos
+}  // namespace cms
+
+#ifdef KOKKOS_ENABLE_CUDA
+#include "CUDACore/StreamCache.h"
+namespace cms {
+  namespace kokkos {
+    template <>
+    class ExecSpaceWrapper<Kokkos::Cuda> {
+    public:
+      ExecSpaceWrapper(Kokkos::Cuda space, cms::cuda::SharedStreamPtr stream)
+          : space_(std::move(space)), stream_(std::move(stream)) {}
+
+      Kokkos::Cuda const& space() const { return space_; }
+      cudaStream_t stream() const { return stream_.get(); }
+
+    private:
+      Kokkos::Cuda space_;
+      cms::cuda::SharedStreamPtr stream_;
+    };
+
+    template <>
+    inline std::shared_ptr<ExecSpaceWrapper<Kokkos::Cuda>> ExecSpaceCache<Kokkos::Cuda>::get() {
+      return cache_->makeOrGet([]() {
+        auto streamPtr = cms::cuda::getStreamCache().get();
+        return std::make_unique<ExecSpaceWrapper<Kokkos::Cuda>>(Kokkos::Cuda(streamPtr.get()), std::move(streamPtr));
+      });
+    }
+  }  // namespace kokkos
+}  // namespace cms
+
+#endif
+
+#endif

--- a/src/kokkos/KokkosCore/Product.h
+++ b/src/kokkos/KokkosCore/Product.h
@@ -1,0 +1,49 @@
+#ifndef KokkosCore_Product_h
+#define KokkosCore_Product_h
+
+#include "KokkosCore/ProductBase.h"
+
+namespace edm {
+  template <typename T>
+  class Wrapper;
+}
+
+namespace cms {
+  namespace kokkos {
+    namespace impl {
+      template <typename ExecSpace>
+      class ScopedContextGetterBase;
+    }
+    template <typename ExecSpace>
+    class ScopedContextProduce;
+
+    template <typename T>
+    class Product : public ProductBase {
+    public:
+      Product() = default;
+
+      Product(const Product&) = delete;
+      Product& operator=(const Product&) = delete;
+      Product(Product&&) = default;
+      Product& operator=(Product&&) = default;
+
+    private:
+      template <typename ExecSpace>
+      friend class impl::ScopedContextGetterBase;
+      template <typename ExecSpace>
+      friend class ScopedContextProduce;
+      friend class edm::Wrapper<Product<T>>;
+
+      explicit Product(std::unique_ptr<impl::ExecSpaceSpecificBase> spaceSpecific, T data)
+          : ProductBase(std::move(spaceSpecific)), data_(std::move(data)) {}
+
+      template <typename... Args>
+      explicit Product(std::unique_ptr<impl::ExecSpaceSpecificBase> spaceSpecific, Args&&... args)
+          : ProductBase(std::move(spaceSpecific)), data_(std::forward<Args>(args)...) {}
+
+      T data_;
+    };
+  }  // namespace kokkos
+}  // namespace cms
+
+#endif

--- a/src/kokkos/KokkosCore/ProductBase.h
+++ b/src/kokkos/KokkosCore/ProductBase.h
@@ -1,0 +1,128 @@
+#ifndef KokkosCore_ProductBase_h
+#define KokkosCore_ProductBase_h
+
+#include <exception>
+#include <memory>
+#include <string>
+
+#include <Kokkos_Core.hpp>
+
+#ifdef KOKKOS_ENABLE_CUDA
+#include "CUDACore/EventCache.h"
+#include "CUDACore/SharedEventPtr.h"
+#include "CUDACore/SharedStreamPtr.h"
+#include "CUDACore/StreamCache.h"
+#endif
+#include "Framework/WaitingTaskHolder.h"
+#include "Framework/WaitingTaskWithArenaHolder.h"
+
+namespace cms {
+  namespace kokkos {
+    namespace impl {
+      class ExecSpaceSpecificBase {
+      public:
+        ExecSpaceSpecificBase() = default;
+        virtual ~ExecSpaceSpecificBase();
+      };
+
+      template <typename ExecSpace>
+      class ExecSpaceSpecific : public ExecSpaceSpecificBase {
+      public:
+        ExecSpaceSpecific() = default;
+        ~ExecSpaceSpecific() override = default;
+
+        std::unique_ptr<ExecSpaceSpecific> cloneShareStream() const {
+          return std::make_unique<ExecSpaceSpecific>(*this);
+        }
+
+        std::unique_ptr<ExecSpaceSpecific> cloneShareAll() const { return std::make_unique<ExecSpaceSpecific>(*this); }
+
+        void recordEvent() {}
+        void enqueueCallback(edm::WaitingTaskWithArenaHolder withArenaHolder) {
+          space_.fence();
+          auto holder = withArenaHolder.makeWaitingTaskHolderAndRelease();
+          holder.doneWaiting(nullptr);
+        }
+        void synchronizeWith(ExecSpaceSpecific const& other) const { other.execSpace().fence(); }
+
+        ExecSpace const& execSpace() const { return space_; }
+
+      private:
+        ExecSpace space_;
+      };
+
+#ifdef KOKKOS_ENABLE_CUDA
+      template <>
+      class ExecSpaceSpecific<Kokkos::Cuda> : public ExecSpaceSpecificBase {
+      public:
+        ExecSpaceSpecific() : ExecSpaceSpecific(cms::cuda::getStreamCache().get()) {}
+        explicit ExecSpaceSpecific(cms::cuda::SharedStreamPtr stream)
+            : ExecSpaceSpecific(stream, cms::cuda::getEventCache().get()) {}
+        explicit ExecSpaceSpecific(cms::cuda::SharedStreamPtr stream, cms::cuda::SharedEventPtr event)
+            : space_(stream.get()), stream_(std::move(stream)), event_(std::move(event)) {}
+
+        ~ExecSpaceSpecific() override = default;
+
+        std::unique_ptr<ExecSpaceSpecific> cloneShareStream() const {
+          return std::make_unique<ExecSpaceSpecific>(stream_);
+        }
+
+        std::unique_ptr<ExecSpaceSpecific> cloneShareAll() const {
+          return std::make_unique<ExecSpaceSpecific>(stream_, event_);
+        }
+
+        void recordEvent() {
+          // Intentionally not checking the return value to avoid throwing
+          // exceptions. If this call would fail, we should get failures
+          // elsewhere as well.
+          cudaEventRecord(event_.get(), stream_.get());
+        }
+
+        void enqueueCallback(edm::WaitingTaskWithArenaHolder holder);
+
+        void synchronizeWith(ExecSpaceSpecific const& other);
+
+        int device() const { return space_.cuda_device(); }
+        Kokkos::Cuda const& execSpace() const { return space_; }
+
+      private:
+        bool isAvailable() const;
+
+        Kokkos::Cuda space_;
+        cms::cuda::SharedStreamPtr stream_;
+        cms::cuda::SharedEventPtr event_;
+      };
+#endif
+    }  // namespace impl
+
+    class ProductBase {
+    public:
+      ProductBase() = default;
+      explicit ProductBase(std::unique_ptr<impl::ExecSpaceSpecificBase> spaceSpecific)
+          : execSpaceSpecific_(std::move(spaceSpecific)) {}
+      ~ProductBase() = default;
+
+      ProductBase(const ProductBase&) = delete;
+      ProductBase& operator=(const ProductBase&) = delete;
+      ProductBase(ProductBase&&) = default;
+      ProductBase& operator=(ProductBase&&) = default;
+
+      bool isValid() const { return execSpaceSpecific_.get() != nullptr; }
+
+      template <typename ExecSpace>
+      impl::ExecSpaceSpecific<ExecSpace> const& execSpaceSpecific() const {
+        auto const& sp = *execSpaceSpecific_;
+        if (typeid(sp) != typeid(impl::ExecSpaceSpecific<ExecSpace>)) {
+          throw std::runtime_error(std::string("Incompatible Execution space: has ") + typeid(sp).name() + ", but " +
+                                   typeid(impl::ExecSpaceSpecific<ExecSpace>).name() + " was asked for");
+        }
+        return static_cast<impl::ExecSpaceSpecific<ExecSpace> const&>(sp);
+      }
+
+    private:
+      std::unique_ptr<impl::ExecSpaceSpecificBase> execSpaceSpecific_;
+    };
+  }  // namespace kokkos
+}  // namespace cms
+
+#endif

--- a/src/kokkos/KokkosCore/ScopedContext.h
+++ b/src/kokkos/KokkosCore/ScopedContext.h
@@ -1,0 +1,76 @@
+#ifndef KokkosCore_ScopedContext_h
+#define KokkosCore_ScopedContext_h
+
+#include "KokkosCore/Product.h"
+#include "Framework/Event.h"
+#include "Framework/EDGetToken.h"
+#include "Framework/EDPutToken.h"
+
+namespace cms {
+  namespace kokkos {
+    namespace impl {
+      template <typename ExecSpace>
+      class ScopedContextGetterBase {
+      public:
+        ExecSpace const& execSpace() const { return execSpaceSpecific_->execSpace(); }
+
+        template <typename T>
+        const T& get(const Product<T>& data) {
+          execSpaceSpecific_->synchronizeWith(data.template execSpaceSpecific<ExecSpace>());
+          return data.data_;
+        }
+
+        template <typename T>
+        const T& get(const edm::Event& iEvent, edm::EDGetTokenT<Product<T>> token) {
+          return get(iEvent.get(token));
+        }
+
+      protected:
+        ScopedContextGetterBase() : execSpaceSpecific_(std::make_unique<impl::ExecSpaceSpecific<ExecSpace>>()) {}
+
+        explicit ScopedContextGetterBase(const ProductBase& data)
+            : execSpaceSpecific_(data.execSpaceSpecific<ExecSpace>().cloneShareStream()) {}
+
+        ExecSpaceSpecific<ExecSpace>& execSpaceSpecific() { return *execSpaceSpecific_; }
+
+      private:
+        std::unique_ptr<ExecSpaceSpecific<ExecSpace>> execSpaceSpecific_;
+      };
+    }  // namespace impl
+
+    template <typename ExecSpace>
+    class ScopedContextAcquire : public impl::ScopedContextGetterBase<ExecSpace> {
+    public:
+      explicit ScopedContextAcquire(edm::WaitingTaskWithArenaHolder holder) : waitingTaskHolder_(std::move(holder)) {}
+      explicit ScopedContextAcquire(const ProductBase& data, edm::WaitingTaskWithArenaHolder holder)
+          : impl::ScopedContextGetterBase<ExecSpace>(data), waitingTaskHolder_(std::move(holder)) {}
+
+      ~ScopedContextAcquire() { this->execSpaceSpecific().enqueueCallback(std::move(waitingTaskHolder_)); }
+
+    private:
+      edm::WaitingTaskWithArenaHolder waitingTaskHolder_;
+    };
+
+    template <typename ExecSpace>
+    class ScopedContextProduce : public impl::ScopedContextGetterBase<ExecSpace> {
+    public:
+      ScopedContextProduce() = default;
+      explicit ScopedContextProduce(const ProductBase& data) : impl::ScopedContextGetterBase<ExecSpace>(data) {}
+
+      ~ScopedContextProduce() { this->execSpaceSpecific().recordEvent(); }
+
+      template <typename T>
+      std::unique_ptr<Product<T>> wrap(T data) {
+        // make_unique doesn't work because of private constructor
+        return std::unique_ptr<Product<T>>(new Product<T>(this->execSpaceSpecific().cloneShareAll(), std::move(data)));
+      }
+
+      template <typename T, typename... Args>
+      auto emplace(edm::Event& iEvent, edm::EDPutTokenT<T> token, Args&&... args) {
+        return iEvent.emplace(token, this->execSpaceSpecific().cloneShareAll(), std::forward<Args>(args)...);
+      }
+    };
+  }  // namespace kokkos
+}  // namespace cms
+
+#endif

--- a/src/kokkos/KokkosCore/ScopedContext.h
+++ b/src/kokkos/KokkosCore/ScopedContext.h
@@ -30,7 +30,7 @@ namespace cms {
         ScopedContextGetterBase() : execSpaceSpecific_(std::make_unique<impl::ExecSpaceSpecific<ExecSpace>>()) {}
 
         explicit ScopedContextGetterBase(const ProductBase& data)
-            : execSpaceSpecific_(data.execSpaceSpecific<ExecSpace>().cloneShareStream()) {}
+            : execSpaceSpecific_(data.execSpaceSpecific<ExecSpace>().cloneShareExecSpace()) {}
 
         explicit ScopedContextGetterBase(std::unique_ptr<ExecSpaceSpecific<ExecSpace>> specific)
             : execSpaceSpecific_(std::move(specific)) {}

--- a/src/kokkos/KokkosCore/kokkoshost/ProductBase.cc
+++ b/src/kokkos/KokkosCore/kokkoshost/ProductBase.cc
@@ -1,0 +1,75 @@
+#include "KokkosCore/ProductBase.h"
+
+#ifdef KOKKOS_ENABLE_CUDA
+#include "CUDACore/cudaCheck.h"
+#include "CUDACore/eventWorkHasCompleted.h"
+
+namespace {
+  struct CallbackData {
+    edm::WaitingTaskWithArenaHolder holder;
+    int device;
+  };
+
+  void CUDART_CB cudaScopedContextCallback(cudaStream_t streamId, cudaError_t status, void* data) {
+    std::unique_ptr<CallbackData> guard{reinterpret_cast<CallbackData*>(data)};
+    edm::WaitingTaskWithArenaHolder& waitingTaskHolder = guard->holder;
+    int device = guard->device;
+    if (status == cudaSuccess) {
+      //std::cout << " GPU kernel finished (in callback) device " << device << " CUDA stream "
+      //          << streamId << std::endl;
+      waitingTaskHolder.doneWaiting(nullptr);
+    } else {
+      // wrap the exception in a try-catch block to let GDB "catch throw" break on it
+      try {
+        auto error = cudaGetErrorName(status);
+        auto message = cudaGetErrorString(status);
+        throw std::runtime_error("Callback of CUDA stream " +
+                                 std::to_string(reinterpret_cast<unsigned long>(streamId)) + " in device " +
+                                 std::to_string(device) + " error " + std::string(error) + ": " + std::string(message));
+      } catch (std::exception&) {
+        waitingTaskHolder.doneWaiting(std::current_exception());
+      }
+    }
+  }
+}  // namespace
+#endif
+
+namespace cms {
+  namespace kokkos {
+    namespace impl {
+      ExecSpaceSpecificBase::~ExecSpaceSpecificBase() = default;
+
+#ifdef KOKKOS_ENABLE_CUDA
+      void ExecSpaceSpecific<Kokkos::Cuda>::enqueueCallback(edm::WaitingTaskWithArenaHolder holder) {
+        cudaCheck(cudaStreamAddCallback(
+            stream_.get(), cudaScopedContextCallback, new CallbackData{std::move(holder), device()}, 0));
+      }
+
+      void ExecSpaceSpecific<Kokkos::Cuda>::synchronizeWith(ExecSpaceSpecific const& other) {
+        if (device() != other.device()) {
+          // Eventually replace with prefetch to current device (assuming unified memory works)
+          // If we won't go to unified memory, need to figure out something else...
+          throw std::runtime_error("Handling data from multiple devices is not yet supported");
+        }
+
+        if (other.stream_.get() != stream_.get()) {
+          // Different streams, need to synchronize
+          if (not other.isAvailable()) {
+            // Event not yet occurred, so need to add synchronization
+            // here. Sychronization is done by making the CUDA stream to
+            // wait for an event, so all subsequent work in the stream
+            // will run only after the event has "occurred" (i.e. data
+            // product became available).
+            cudaCheck(cudaStreamWaitEvent(stream_.get(), other.event_.get(), 0),
+                      "Failed to make a stream to wait for an event");
+          }
+        }
+      }
+
+      bool ExecSpaceSpecific<Kokkos::Cuda>::isAvailable() const {
+        return cms::cuda::eventWorkHasCompleted(event_.get());
+      }
+#endif
+    }  // namespace impl
+  }    // namespace kokkos
+}  // namespace cms

--- a/src/kokkos/KokkosCore/kokkoshost/kokkosConfigCommon.cc
+++ b/src/kokkos/KokkosCore/kokkoshost/kokkosConfigCommon.cc
@@ -1,6 +1,11 @@
 #include "KokkosCore/kokkosConfigCommon.h"
+#include "KokkosCore/ExecSpaceCache.h"
 
 #include <Kokkos_Core.hpp>
+
+#ifdef KOKKOS_ENABLE_CUDA
+#include "CUDACore/StreamCache.h"
+#endif
 
 namespace kokkos_common {
   class InitializeScopeGuard::Impl {
@@ -31,7 +36,12 @@ namespace kokkos_common {
       Kokkos::Impl::post_initialize(args);
     }
 
-    ~Impl() { Kokkos::finalize(); }
+    ~Impl() {
+#ifdef KOKKOS_ENABLE_CUDA
+      cms::kokkos::getExecSpaceCache<Kokkos::Cuda>().clear();
+#endif
+      Kokkos::finalize();
+    }
   };
 
   InitializeScopeGuard::InitializeScopeGuard(std::vector<Backend> const& backends, int numberOfInnerThreads) {

--- a/src/kokkos/Makefile.deps
+++ b/src/kokkos/Makefile.deps
@@ -11,3 +11,12 @@ PixelVertexFinding_DEPENDS := Framework KokkosCore KokkosDataFormats DataFormats
 SiPixelClusterizer_DEPENDS := Framework KokkosCore KokkosDataFormats DataFormats CondFormats
 SiPixelRecHits_DEPENDS := Framework KokkosCore KokkosDataFormats DataFormats CondFormats
 Validation_DEPENDS := Framework KokkosCore KokkosDataFormats DataFormats
+ifeq ($(KOKKOS_DEVICE_PARALLEL),CUDA)
+  BeamSpotProducer_DEPENDS += CUDACore
+  KokkosCore_DEPENDS += CUDACore
+  PixelTriplets_DEPENDS += CUDACore
+  PixelVertexFinding_DEPENDS += CUDACore
+  SiPixelClusterizer_DEPENDS += CUDACore
+  SiPixelRecHits_DEPENDS += CUDACore
+  Validation_DEPENDS += CUDACore
+endif

--- a/src/kokkos/Makefile.deps
+++ b/src/kokkos/Makefile.deps
@@ -5,6 +5,7 @@ else ifeq ($(KOKKOS_DEVICE_PARALLEL),HIP)
   kokkos_EXTERNAL_DEPENDS += HIP
 endif
 BeamSpotProducer_DEPENDS := Framework KokkosCore KokkosDataFormats DataFormats
+KokkosCore_DEPENDS := Framework
 PixelTriplets_DEPENDS := Framework KokkosCore KokkosDataFormats
 PixelVertexFinding_DEPENDS := Framework KokkosCore KokkosDataFormats DataFormats CondFormats
 SiPixelClusterizer_DEPENDS := Framework KokkosCore KokkosDataFormats DataFormats CondFormats

--- a/src/kokkos/plugin-PixelVertexFinding/kokkos/PixelVertexSoAFromKokkos.cc
+++ b/src/kokkos/plugin-PixelVertexFinding/kokkos/PixelVertexSoAFromKokkos.cc
@@ -1,4 +1,6 @@
 #include "KokkosCore/kokkosConfig.h"
+#include "KokkosCore/Product.h"
+#include "KokkosCore/ScopedContext.h"
 #include "DataFormats/ZVertexSoA.h"
 #include "Framework/EventSetup.h"
 #include "Framework/Event.h"
@@ -7,55 +9,44 @@
 #include "Framework/RunningAverage.h"
 
 namespace KOKKOS_NAMESPACE {
-#ifdef TODO
   class PixelVertexSoAFromKokkos : public edm::EDProducerExternalWork {
-#else
-  class PixelVertexSoAFromKokkos : public edm::EDProducer {
-#endif
   public:
     explicit PixelVertexSoAFromKokkos(edm::ProductRegistry& reg);
     ~PixelVertexSoAFromKokkos() override = default;
 
   private:
-#ifdef TODO
     void acquire(edm::Event const& iEvent,
                  edm::EventSetup const& iSetup,
                  edm::WaitingTaskWithArenaHolder waitingTaskHolder) override;
-#endif
     void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) override;
 
     using VerticesExecSpace = Kokkos::View<ZVertexSoA, KokkosExecSpace>;
     using VerticesHostSpace = VerticesExecSpace::HostMirror;
 
-    edm::EDGetTokenT<VerticesExecSpace> tokenKokkos_;
+    edm::EDGetTokenT<cms::kokkos::Product<VerticesExecSpace>> tokenKokkos_;
     edm::EDPutTokenT<VerticesHostSpace> tokenSOA_;
-#ifdef TODO
-    cms::cuda::host::unique_ptr<ZVertexSoA> m_soa;
-#endif
+
+    VerticesHostSpace m_soa;
   };
 
   PixelVertexSoAFromKokkos::PixelVertexSoAFromKokkos(edm::ProductRegistry& reg)
-      : tokenKokkos_(reg.consumes<VerticesExecSpace>()), tokenSOA_(reg.produces<VerticesHostSpace>()) {}
+      : tokenKokkos_(reg.consumes<cms::kokkos::Product<VerticesExecSpace>>()),
+        tokenSOA_(reg.produces<VerticesHostSpace>()) {}
 
-#ifdef TODO
   void PixelVertexSoAFromKokkos::acquire(edm::Event const& iEvent,
                                          edm::EventSetup const& iSetup,
                                          edm::WaitingTaskWithArenaHolder waitingTaskHolder) {
     auto const& inputDataWrapped = iEvent.get(tokenKokkos_);
-    cms::cuda::ScopedContextAcquire ctx{inputDataWrapped, std::move(waitingTaskHolder)};
+    cms::kokkos::ScopedContextAcquire<KokkosExecSpace> ctx{inputDataWrapped, std::move(waitingTaskHolder)};
     auto const& inputData = ctx.get(inputDataWrapped);
 
-    m_soa = inputData.toHostAsync(ctx.stream());
+    m_soa = VerticesHostSpace("vertices");
+    Kokkos::deep_copy(ctx.execSpace(), m_soa, inputData);
   }
-#endif
 
   void PixelVertexSoAFromKokkos::produce(edm::Event& iEvent, edm::EventSetup const& iSetup) {
-    auto const& inputData = iEvent.get(tokenKokkos_);
-    VerticesHostSpace outputData("vertices");
-    Kokkos::deep_copy(KokkosExecSpace(), outputData, inputData);
-    KokkosExecSpace().fence();
     // No copies....
-    iEvent.emplace(tokenSOA_, std::move(outputData));
+    iEvent.emplace(tokenSOA_, std::move(m_soa));
   }
 }  // namespace KOKKOS_NAMESPACE
 

--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/SiPixelRawToClusterGPUKernel.cc
@@ -578,8 +578,8 @@ namespace KOKKOS_NAMESPACE {
 
       digis_d = SiPixelDigisKokkos<KokkosExecSpace>(pixelgpudetails::MAX_FED_WORDS);
       if (includeErrors) {
-        digiErrors_d = SiPixelDigiErrorsKokkos<KokkosExecSpace>(
-            pixelgpudetails::MAX_FED_WORDS, std::move(errors), KokkosExecSpace());
+        digiErrors_d =
+            SiPixelDigiErrorsKokkos<KokkosExecSpace>(pixelgpudetails::MAX_FED_WORDS, std::move(errors), execSpace);
       }
       clusters_d = SiPixelClustersKokkos<KokkosExecSpace>(::gpuClustering::MaxNumModules);
 

--- a/src/kokkos/plugin-SiPixelRecHits/kokkos/SiPixelRecHitKokkos.cc
+++ b/src/kokkos/plugin-SiPixelRecHits/kokkos/SiPixelRecHitKokkos.cc
@@ -11,6 +11,8 @@
 #include "PixelRecHits.h"  // TODO : spit product from kernel
 
 #include "KokkosCore/kokkosConfig.h"
+#include "KokkosCore/Product.h"
+#include "KokkosCore/ScopedContext.h"
 
 namespace KOKKOS_NAMESPACE {
   class SiPixelRecHitKokkos : public edm::EDProducer {
@@ -22,34 +24,37 @@ namespace KOKKOS_NAMESPACE {
     void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
     // The mess with inputs will be cleaned up when migrating to the new framework
-    edm::EDGetTokenT<BeamSpotKokkos<KokkosExecSpace>> tBeamSpot;
-    edm::EDGetTokenT<SiPixelClustersKokkos<KokkosExecSpace>> token_;
-    edm::EDGetTokenT<SiPixelDigisKokkos<KokkosExecSpace>> tokenDigi_;
+    edm::EDGetTokenT<cms::kokkos::Product<BeamSpotKokkos<KokkosExecSpace>>> tBeamSpot;
+    edm::EDGetTokenT<cms::kokkos::Product<SiPixelClustersKokkos<KokkosExecSpace>>> token_;
+    edm::EDGetTokenT<cms::kokkos::Product<SiPixelDigisKokkos<KokkosExecSpace>>> tokenDigi_;
 
-    edm::EDPutTokenT<TrackingRecHit2DKokkos<KokkosExecSpace>> tokenHit_;
+    edm::EDPutTokenT<cms::kokkos::Product<TrackingRecHit2DKokkos<KokkosExecSpace>>> tokenHit_;
 
     pixelgpudetails::PixelRecHitGPUKernel gpuAlgo_;
   };
 
   SiPixelRecHitKokkos::SiPixelRecHitKokkos(edm::ProductRegistry& reg)
-      : tBeamSpot(reg.consumes<BeamSpotKokkos<KokkosExecSpace>>()),
-        token_(reg.consumes<SiPixelClustersKokkos<KokkosExecSpace>>()),
-        tokenDigi_(reg.consumes<SiPixelDigisKokkos<KokkosExecSpace>>()),
-        tokenHit_(reg.produces<TrackingRecHit2DKokkos<KokkosExecSpace>>()) {}
+      : tBeamSpot(reg.consumes<cms::kokkos::Product<BeamSpotKokkos<KokkosExecSpace>>>()),
+        token_(reg.consumes<cms::kokkos::Product<SiPixelClustersKokkos<KokkosExecSpace>>>()),
+        tokenDigi_(reg.consumes<cms::kokkos::Product<SiPixelDigisKokkos<KokkosExecSpace>>>()),
+        tokenHit_(reg.produces<cms::kokkos::Product<TrackingRecHit2DKokkos<KokkosExecSpace>>>()) {}
 
   void SiPixelRecHitKokkos::produce(edm::Event& iEvent, const edm::EventSetup& es) {
     auto const& fcpe = es.get<PixelCPEFast<KokkosExecSpace>>();
 
-    auto const& bs = iEvent.get(tBeamSpot);
-    auto const& clusters = iEvent.get(token_);
-    auto const& digis = iEvent.get(tokenDigi_);
+    auto const& pclusters = iEvent.get(token_);
+    cms::kokkos::ScopedContextProduce<KokkosExecSpace> ctx{pclusters};
+
+    auto const& bs = ctx.get(iEvent, tBeamSpot);
+    auto const& clusters = ctx.get(pclusters);
+    auto const& digis = ctx.get(iEvent, tokenDigi_);
 
     auto nHits = clusters.nClusters();
     if (nHits >= TrackingRecHit2DSOAView::maxHits()) {
       std::cout << "Clusters/Hits Overflow " << nHits << " >= " << TrackingRecHit2DSOAView::maxHits() << std::endl;
     }
 
-    iEvent.emplace(tokenHit_, gpuAlgo_.makeHitsAsync(digis, clusters, bs, fcpe.params(), KokkosExecSpace()));
+    ctx.emplace(iEvent, tokenHit_, gpuAlgo_.makeHitsAsync(digis, clusters, bs, fcpe.params(), ctx.execSpace()));
   }
 }  // namespace KOKKOS_NAMESPACE
 


### PR DESCRIPTION
Introduces caching of the Execution Space objects in addition to what is in `kokkostest` (in principle should be "backported" there). The Execution Space objects are "heavy", and should be treated similarly to CUDA streams. With the caching the performance drop on a "one concurrent event" case is about 1-2 %.

With the Kokkos 3.4.1 only the CUDA backend works (as in runs and passes `--validation`) with multiple concurrent events and CPU threads. With Kokkos `develop` branch (i.e. their next version) also Serial backend works technically, but the performance is poor because of a "global lock". The performance of concurrent calls to Serial backend is expected to be improved in future versions of Kokkos. The performance of Kokkos-CUDA version is also bad, but because of continuous memory allocations and frees. The next step to improve performance is to use the caching allocator.

The Threads backend explicitly does not work from multiple calling CPU threads so I didn't even try, and the (Kokkos-)HIP version is still in progress in general so I didn't try that either.