### PR TITLE
Fix namespace in hip port

### DIFF
--- a/src/hip/CUDACore/ESProduct.h
+++ b/src/hip/CUDACore/ESProduct.h
@@ -20,7 +20,7 @@ namespace cms {
     public:
       ESProduct() : gpuDataPerDevice_(deviceCount()) {
         if (not gpuDataPerDevice_.empty()) {
-          cms::cuda::ScopedSetDevice scopedDevice;
+          cms::hip::ScopedSetDevice scopedDevice;
           for (size_t i = 0; i < gpuDataPerDevice_.size(); ++i) {
             scopedDevice.set(i);
             gpuDataPerDevice_[i].m_event = getEventCache().get();


### PR DESCRIPTION
Code introduced in 9f46b5695a7055577078f63702992a40b15056d8 added a call to ScopedSetDevice that should be in the cms::hip namespace in the hip port.