### PR TITLE
Fix AtomicPairCounter test for Kokkos/HIP

### DIFF
--- a/src/kokkos/KokkosCore/AtomicPairCounter.h
+++ b/src/kokkos/KokkosCore/AtomicPairCounter.h
@@ -11,7 +11,7 @@ namespace cms {
     public:
       using c_type = unsigned long long int;
 
-      KOKKOS_INLINE_FUNCTION AtomicPairCounter() {}
+      KOKKOS_INLINE_FUNCTION AtomicPairCounter() { counter.ac = 0; }
       KOKKOS_INLINE_FUNCTION AtomicPairCounter(c_type i) { counter.ac = i; }
 
       KOKKOS_INLINE_FUNCTION AtomicPairCounter& operator=(c_type i) {


### PR DESCRIPTION
When running Kokkos with the HIP backend there is an assertion failure in `assert (c.m < n);` in the first loop ("update") in `src/kokos/test/kokkos/AtomicPairCounter_t.cc`.

The failure seems to be because the `counters` member is not initialized in the default constructor.   This was pretty clear from printing out values of `c.m` before the counter update.

The straight HIP port calls `hipMemset` to initialize the object to zero after allocation, so the problem does not occur there.