### PR TITLE
Remove find_ntuplets recursion in HIP port

### DIFF
--- a/src/hip/plugin-PixelTriplets/CAHitNtupletGeneratorKernelsImpl.h
+++ b/src/hip/plugin-PixelTriplets/CAHitNtupletGeneratorKernelsImpl.h
@@ -288,7 +288,8 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
     if (doit) {
       GPUCACell::TmpTuple stack;
       stack.reset();
-      thisCell.find_ntuplets<6>(hh, cells, *cellTracks, *foundNtuplets, *apc, quality, stack, minHitsPerNtuplet, pid < 3);
+      thisCell.find_ntuplets<6>(
+          hh, cells, *cellTracks, *foundNtuplets, *apc, quality, stack, minHitsPerNtuplet, pid < 3);
       assert(stack.empty());
       // printf("in %d found quadruplets: %d\n", cellIndex, apc->get());
     }

--- a/src/hip/plugin-PixelTriplets/GPUCACell.h
+++ b/src/hip/plugin-PixelTriplets/GPUCACell.h
@@ -300,7 +300,7 @@ public:
       if (cells[otherCell].theDoubletId < 0)
         continue;  // killed by earlyFishbone
       last = false;
-      cells[otherCell].find_ntuplets<DEPTH-1>(
+      cells[otherCell].find_ntuplets<DEPTH - 1>(
           hh, cells, cellTracks, foundNtuplets, apc, quality, tmpNtuplet, minHitsPerNtuplet, startAt0);
     }
     if (last) {  // if long enough save...
@@ -348,14 +348,14 @@ private:
 
 template <>
 __device__ inline void GPUCACell::find_ntuplets<0>(Hits const& hh,
-                                   GPUCACell* __restrict__ cells,
-                                   CellTracksVector& cellTracks,
-                                   HitContainer& foundNtuplets,
-                                   cms::hip::AtomicPairCounter& apc,
-                                   Quality* __restrict__ quality,
-                                   TmpTuple& tmpNtuplet,
-                                   const unsigned int minHitsPerNtuplet,
-                                   bool startAt0) const {
+                                                   GPUCACell* __restrict__ cells,
+                                                   CellTracksVector& cellTracks,
+                                                   HitContainer& foundNtuplets,
+                                                   cms::hip::AtomicPairCounter& apc,
+                                                   Quality* __restrict__ quality,
+                                                   TmpTuple& tmpNtuplet,
+                                                   const unsigned int minHitsPerNtuplet,
+                                                   bool startAt0) const {
   printf("ERROR: GPUCACell::find_ntuplets reached full depth!\n");
   assert(false);
 }


### PR DESCRIPTION
Use templates to perform a compile-time unrolling of the find_ntuplets recursion.

Ported from here: https://github.com/cms-sw/cmssw/pull/35473

This PR is for the HIP port.