### PR TITLE
Add --runForMinutes to all programs, and several updates to scanning script

### DIFF
--- a/run-many.py
+++ b/run-many.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import time
+import socket
+import argparse
+import importlib
+import subprocess
+import collections
+
+scan = importlib.import_module("run-scan")
+
+RunningProgram = collections.namedtuple("RunningProgram", ["program", "index", "handle"])
+
+class Program:
+    def __init__(self, description):
+        s = description.split(":")
+        self._program = s[0]
+        self._options = ["threads","streams","numa","cores","cudaDevices"]
+        valid = set(self._options)
+        for o in s[1:]:
+            (name, value) = o.split("=")
+            if name not in valid:
+                raise Exception("Unsupported option '{}'".format(name))
+            setattr(self, "_"+name, value)
+            valid.remove(name)
+        for o in valid:
+            setattr(self, "_"+o, None)
+        if self._threads is None:
+            self._threads = 1
+        if self._streams is None:
+            self._streams = self._threads
+        self._cudaDevices = self._cudaDevices.split(",") if self._cudaDevices is not None else []
+
+    def program(self):
+        return self._program
+
+    def programShort(self):
+        return os.path.basename(self._program)
+
+    def cudaDevices(self):
+        return self._cudaDevices
+
+    def makeCommandMessage(self, processUntil):
+        command = [self._program] + processUntil + ["--numberOfThreads", str(self._threads), "--numberOfStreams", str(self._streams)]
+        msg = "Program {} threads {} streams {}".format(self.programShort(), self._threads, self._streams)
+        if self._numa is not None:
+            command = ["numactl", "--cpunodebind={}".format(self._numa), "--membind={}".format(self._numa)] + command
+            msg += " NUMA node {}".format(self._numa)
+        if self._cores is not None:
+            command = ["taskset", "-c", self._cores]
+            msg += " cores {}".format(self._cores)
+        if len(self._cudaDevices) > 0:
+            msg += " CUDA devices {}".format(",".join(self._cudaDevices))
+        return (command, msg)
+
+    def makeEnv(self, logfile):
+        if len(self._cudaDevices) == 0:
+            return os.environ
+        visibleDevices = ",".join(self._cudaDevices)
+        logfile.write("export CUDA_DEVICE_ORDER=PCI_BUS_ID\n")
+        logfile.write("export CUDA_VISIBLE_DEVICES="+visibleDevices+"\n")
+        logfile.flush()
+        env = dict(os.environ, CUDA_VISIBLE_DEVICES=visibleDevices)
+        return env
+
+    def addMetadata(self, d):
+        d["program"] = self.programShort()
+        d["threads"] = self._threads
+        d["streams"] = self._streams
+        if self._numa is not None:
+            d["numa"] = self._numa
+        if self._cores is not None:
+            d["cores"] = self._cores
+        if self._cudaDevices is not None:
+            d["cudaDevices"] = self._cudaDevices
+            
+    def __str__(self):
+        ret = self._program+": "
+        for o in self._options:
+            v = getattr(self, "_"+o)
+            if v is not None:
+                ret += o+"="+v+" "
+        return ret
+
+class Monitor:
+    def __init__(self, opts, programs, cudaDevices=[]):
+        self._intervalSeconds = opts.monitorSeconds
+        self._monitorMemory = opts.monitorMemory
+        self._monitorCuda = opts.monitorCuda
+        self._allPrograms = programs
+
+        self._timeStamp = []
+        self._dataMemory = [[] for p in programs]
+        self._dataCuda = {x: [] for x in cudaDevices}
+        self._dataCudaProcs = [{x: [] for x in p.cudaDevices()} for p in programs]
+
+    def setIntervalSeconds(self, interval):
+        self._intervalSeconds = interval
+
+    def intervalSeconds(self):
+        return self._intervalSeconds
+
+    def snapshot(self, programs=[]):
+        if self._intervalSeconds is None:
+            return
+        self._timeStamp.append(time.strftime("%y-%m-%d %H:%M:%S"))
+
+        if self._monitorMemory:
+            update = [dict(rss=0)]*len(self._dataMemory)
+            for rp in programs:
+                update[rp.index]["rss"] = scan.processRss(rp.handle.pid)
+            for i, u in enumerate(update):
+                self._dataMemory[i].append(u)
+
+        if self._monitorCuda:
+            for dev in self._dataCuda.keys():
+                self._dataCuda[dev].append(scan.cudaDeviceStatus(dev)._asdict())
+            update = [{x: dict(proc_mem_use=0) for x in p.cudaDevices()} for p in self._allPrograms]
+            for rp in programs:
+                for dev in rp.program.cudaDevices():
+                    update[rp.index][dev]["proc_mem_use"] = scan.cudaDeviceProcessMemory(dev, rp.handle.pid)
+            for i, u in enumerate(update):
+                for dev, val in u.items():
+                    self._dataCudaProcs[i][dev].append(val)
+
+    def toArrays(self):
+        data = {}
+        if self._intervalSeconds is not None:
+            data["time"] = self._timeStamp
+            if self._monitorMemory:
+                data["host"] = self._dataMemory
+            if self._monitorCuda:
+                data["cuda"] = dict(
+                    device = self._dataCuda,
+                    processes = self._dataCudaProcs,
+                )
+        return data
+
+def runMany(programs, processUntil, opts, logfilenamebase, monitor):
+    logfiles = []
+    for i in range(0, len(programs)):
+        logfiles.append(open(logfilenamebase.format(i), "w"))
+
+    running_programs = []
+    for i, (prog, logfile) in enumerate(zip(programs, logfiles)):
+        (command, msg) = prog.makeCommandMessage(processUntil)
+        msg = str(i) + " "+ msg + " minutes {}".format(opts.runForMinutes)
+        scan.printMessage(msg)
+        logfile.write(" ".join(command))
+        logfile.write("\n----\n")
+        logfile.flush()
+        if opts.dryRun:
+            print(" ".join(command))
+            continue
+
+        env = prog.makeEnv(logfile)
+        p = subprocess.Popen(command, stdout=logfile, stderr=subprocess.STDOUT, universal_newlines=True, env=env)
+        running_programs.append(RunningProgram(prog, i, p))
+    monitor.snapshot(running_programs)
+    finished_programs = []
+    def terminate_programs():
+        for p in running_programs:
+            try:
+                p.handle.terminate()
+            except OSError:
+                pass
+            p.handle.wait()
+
+    while len(running_programs) > 0:
+        try:
+            running_programs[0].handle.wait(timeout=monitor.intervalSeconds())
+            rp = running_programs[0]
+            del running_programs[0]
+            finished_programs.append(rp)
+            scan.printMessage("Program {} finished".format(rp.index))
+            if rp.handle.returncode != 0:
+                print(" got return code {}, aborting test".format(rp.handle.returncode))
+                msg += "Program {} {} got return code {}, see output in log file {}, terminating the remaining programs.\n".format(rp.index, rp.program.program(), rp.handle.returncode, logfilenamebase.format(rp.index))
+                terminate_programs()
+        except subprocess.TimeoutExpired:
+            monitor.snapshot(running_programs)
+        except KeyboardInterrupt:
+            terminate_programs()
+    monitor.snapshot(running_programs)
+    msg = ""
+    for i, p in enumerate(running_programs):
+        if p.returncode != 0:
+            msg += "Program {} {} got return code %d, see output in log file %s\n".format(i, programs[i].program(), logfilenamebase.format(i))
+    if len(msg) > 0:
+        raise Exception(msg)
+
+    for l in logfiles:
+        l.close()
+
+    ret = []
+    for i in range(len(programs)):
+        with open(logfilenamebase.format(i)) as logfile:
+            ret.append(scan.throughput(logfile))
+    return ret
+
+            
+
+def main(opts):
+    programs = []
+    cudaDevicesInPrograms = set()
+    for x in opts.programs.split(";"):
+        num = 1
+        if x[0] == "[": 
+            s = x[1:].split("]")
+            num = int(s[0])
+            x = s[1]
+        for i in range(0, num):
+            p = Program(x)
+            programs.append(p)
+            cudaDevicesInPrograms.update(p.cudaDevices())
+    cudaDevicesInPrograms = list(cudaDevicesInPrograms)
+
+    cudaDevicesAvailable = scan.listCudaDevices()
+    print("Found {} devices".format(len(cudaDevicesAvailable)))
+    for i, d in cudaDevicesAvailable.items():
+        print(" {} {} driver {}".format(i, d.name, d.driver_version))
+    for d in cudaDevicesInPrograms:
+        if d not in cudaDevicesAvailable:
+            raise Exception("Some program asked device {} but there is no device with that id".format(d))
+
+    data = dict(
+        args=" ".join(opts.args),
+        results=[]
+    )
+    outputJson = opts.output+".json"
+    if os.path.exists(outputJson):
+        if opts.append:
+            with open(outputJson) as inp:
+                data = json.load(inp)
+        elif not opts.overwrite:
+            return
+
+    hostname = socket.gethostname()
+
+    if opts.runForMinutes < 0:
+        raise Exception("currently --runForMinutes is required")
+    mins = opts.runForMinutes
+
+    tryAgain = opts.tryAgain
+    while tryAgain > 0:
+        try:
+            monitor = Monitor(opts, programs, cudaDevices=cudaDevicesInPrograms)
+            measurements = runMany(programs, ["--runForMinutes", str(mins)], opts, opts.output+"_log_{}.txt", monitor=monitor)
+            break
+        except Exception as e:
+            tryAgain -= 1
+            if tryAgain == 0:
+                raise
+                print("Got exception (see below), trying again ({} times left)".format(tryAgain))
+                print("--------------------")
+                print(str(e))
+                print("--------------------")
+
+    d = dict(
+        hostname=hostname,
+        throughput=sum([m.throughput for m in measurements]),
+        programs=[]
+    )
+    scan.printMessage("Total throughput {} events/s".format(d["throughput"]))
+    for i, (p, m) in enumerate(zip(programs, measurements)):
+        dp = dict(
+            events=m.events,
+            time=m.time,
+            throughput=m.throughput
+        )
+        p.addMetadata(dp)
+        d["programs"].append(dp)
+    if monitor.intervalSeconds() is not None:
+        d["monitor"]=monitor.toArrays()
+    if len(cudaDevicesInPrograms) > 0:
+        d["cudaDevices"] = {
+            x: dict(name=cudaDevicesAvailable[x].name, driver_version=cudaDevicesAvailable[x].driver_version) for x in cudaDevicesInPrograms
+        }
+    data["results"].append(d)
+    
+    with open(outputJson, "w") as out:
+        json.dump(data, out, indent=2)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="""Run given test programs.
+
+Note that this program does not honor CUDA_VISIBLE_DEVICES, use cudaDevices instead.
+
+Measuring combined throughput of multiple programs
+[M]<program>:threads=N:streams=N:numa=N:cores=<list>:cudaDevices=<list>;<program>:...
+
+  <program>   (Path to) the program to run
+  threads     Number host threads (default: 1)
+  streams     Number of streams (concurrent events) (default: same as threads)
+  numa        NUMA node, uses 'numactl' (default: not set)
+  cores       List of CPU cores to pin, uses 'taskset' (default: not set)
+  cudaDevices List of CUDA devices to use (default: not set)
+  M copies
+""", formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("programs", type=str,
+                        help="Declaration of many programs to run (for syntax see above).")
+
+    scan.addCommonArguments(parser)
+    opts = scan.parseCommonArguments(parser)
+
+    main(opts)

--- a/run-scan.py
+++ b/run-scan.py
@@ -6,6 +6,7 @@ import json
 import time
 import socket
 import argparse
+import statistics
 import subprocess
 import collections
 import multiprocessing
@@ -372,9 +373,12 @@ def main(opts):
                     backgroundJob.wait()
 
         thr = 0
+        stdev = 0
         if len(throughputs) > 0:
-            thr = sum(throughputs)/len(throughputs)
-        printMessage("Number of streams %d threads %d, average throughput %f" % (nstr, nth, thr))
+            thr = statistics.mean(throughputs)
+            if len(throughputs) > 1:
+                stdev = statistics.stdev(throughputs)
+        printMessage("Number of streams {} threads {}, average throughput {} stdev {}".format(nstr, nth, thr, stdev))
         print()
         if stop:
             print("Reached max wall time of %d s, stopping scan" % opts.stopAfterWallTime)

--- a/run-scan.py
+++ b/run-scan.py
@@ -7,6 +7,7 @@ import time
 import socket
 import argparse
 import subprocess
+import collections
 import multiprocessing
 
 # Number of events for each application
@@ -25,6 +26,7 @@ background_events_per_thread = 30*3600*8
 
 result_re = re.compile("Processed (?P<events>\d+) events in (?P<time>\S+) seconds, throughput (?P<throughput>\S+) events/s")
 
+Measurement = collections.namedtuple("Measurement", ["events", "time", "throughput"])
 
 def printMessage(*args):
     print(time.strftime("%y-%m-%d %H:%M:%S"), *args)
@@ -34,7 +36,7 @@ def throughput(output):
         m = result_re.search(line)
         if m:
             printMessage(line.rstrip())
-            return (float(m.group("throughput")), float(m.group("time")))
+            return Measurement(int(m.group("events")), float(m.group("time")), float(m.group("throughput")))
 
     raise Exception("Did not find throughput from the log")
 
@@ -44,12 +46,12 @@ def partition_cores(cores, nth):
 
     return (cores[0:nth], cores[nth:])
 
-def run(nev, nstr, cores_main, opts, logfilename):
+def _run(processUntil, nstr, cores_main, opts, logfilename):
     nth = len(cores_main)
     with open(logfilename, "w") as logfile:
         taskset = []
         nvprof = []
-        command = [opts.program, "--maxEvents", str(nev), "--numberOfStreams", str(nstr), "--numberOfThreads", str(nth)] + opts.args
+        command = [opts.program] + processUntil + ["--numberOfStreams", str(nstr), "--numberOfThreads", str(nth)] + opts.args
         if opts.taskset:
             taskset = ["taskset", "-c", ",".join(cores_main)]
 
@@ -72,6 +74,12 @@ def run(nev, nstr, cores_main, opts, logfilename):
             raise Exception("Got return code %d, see output in the log file %s" % (p.returncode, logfilename))
     with open(logfilename) as logfile:
         return throughput(logfile)
+
+def runEvents(nev, *args, **kwargs):
+    return _run(["--maxEvents", str(nev)], *args, **kwargs)
+
+def runMinutes(mins, *args, **kwargs):
+    return _run(["--runForMinutes", str(mins)], *args, **kwargs)
 
 def launchBackground(opts, cores_bkg, logfile):
     if opts.fill <= 0:
@@ -118,7 +126,7 @@ def main(opts):
         n_streams_threads = [(s, t) for t in nthreads for s in opts.numStreams]
 
     nev_per_stream = opts.eventsPerStream
-    if nev_per_stream is None:
+    if nev_per_stream is None and opts.runForMinutes < 0:
         tmp = n_blocks_per_stream.get(os.path.basename(opts.program), None)
         if tmp is None:
             raise Exception("No default number of event blocks for program %s, and --eventsPerStream was not given" % opts.program)
@@ -154,15 +162,23 @@ def main(opts):
         if (nstr, nth) in alreadyExists:
             continue
 
-        if opts.maxStreamsToAddEvents > 0 and nstr > opts.maxStreamsToAddEvents:
-            nev = nev_per_stream * opts.maxStreamsToAddEvents
-        else:
-            nev = nev_per_stream*nstr
         (cores_main, cores_bkg) = partition_cores(cores, nth)
+
+        mins = -1
+        nev = -1
+        if opts.runForMinutes >= 0:
+            mins = opts.runForMinutes
+            run = lambda postfix: runMinutes(mins, nstr, cores_main, opts, opts.output+postfix)
+        else:
+            if opts.maxStreamsToAddEvents > 0 and nstr > opts.maxStreamsToAddEvents:
+                nev = nev_per_stream * opts.maxStreamsToAddEvents
+            else:
+                nev = nev_per_stream*nstr
+            run = lambda postfix: runEvents(nev, nstr, cores_main, opts, opts.output+postfix)
 
         if opts.warmup:
           printMessage("Warming up")
-          run(nev, nstr, cores_main, opts, opts.output+"_warmup.txt")
+          run("_warmup.txt")
           print()
           opts.warmup = False
 
@@ -175,7 +191,11 @@ def main(opts):
                 printMessage(msg)
 
             try:
-                msg = "Number of streams {} threads {} events {}".format(nstr, nth, nev)
+                msg = "Number of streams {} threads {}".format(nstr, nth)
+                if nev >= 0:
+                    msg += " events {}".format(nev)
+                else:
+                    msg += " minutes {}".format(mins)
                 if opts.taskset:
                     msg += ", running on cores " + ",".join(cores_main)
                 printMessage(msg)
@@ -184,7 +204,7 @@ def main(opts):
                     tryAgain = opts.tryAgain
                     while tryAgain > 0:
                         try:
-                            (th, wtime) = run(nev, nstr, cores_main, opts, opts.output+"_log_nstr{}_nth{}_n{}.txt".format(nstr, nth, i))
+                            measurement = run("_log_nstr{}_nth{}_n{}.txt".format(nstr, nth, i))
                             break
                         except Exception as e:
                             tryAgain -= 1
@@ -205,18 +225,18 @@ def main(opts):
 
             if opts.dryRun:
                 continue
-            throughputs.append(th)
+            throughputs.append(measurement.throughput)
             data["results"].append(dict(
                 hostname=hostname,
                 threads=nth,
                 streams=nstr,
-                events=nev,
-                throughput=th,
+                events=measurement.events,
+                throughput=measurement.throughput,
             ))
             # Save results after each test
             with open(outputJson, "w") as out:
                 json.dump(data, out, indent=2)
-            if opts.stopAfterWallTime > 0 and wtime > opts.stopAfterWallTime:
+            if opts.stopAfterWallTime > 0 and measurement.time > opts.stopAfterWallTime:
                 stop = True
                 break
 
@@ -234,36 +254,47 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run a scan of a given test program")
     parser.add_argument("program", type=str,
                         help="Path to the test program to run")
-    parser.add_argument("-o", "--output", type=str, default="result",
-                        help="Prefix of output JSON and log files. If the output JSON file exists, it will be updated (see also --overwrite) (default: 'result')")
-    parser.add_argument("--overwrite", action="store_true",
-                        help="Overwrite the output JSON instead of updating it")
-    parser.add_argument("--append", action="store_true",
-                        help="Append new (stream, threads) results insteads of ignoring already existing point")
-    parser.add_argument("--taskset", action="store_true",
-                        help="Use taskset to explicitly set the cores where to run on")
-    parser.add_argument("--tasksetCores", type=str, default="",
-                        help="Comma-separated list of cores to be used for taskset in that order. Default (empty) is to use range(0, N(cores))")
-    parser.add_argument("--fill", type=int, default=-1,
-                        help="Launch serial program in the background so that this many threads are always running. If given, this will also become the upper limit for the number of threads instead of the number of cores of the machine. (default: -1 to disable")
-    parser.add_argument("--bkgNice", type=int, default=None,
-                        help="If given, use this 'nice' level for the background program")
-    parser.add_argument("--minThreads", type=int, default=1,
-                        help="Minimum number of threads to use in the scan (default: 1)")
-    parser.add_argument("--maxThreads", type=int, default=-1,
-                        help="Maximum number of threads to use in the scan (default: -1 for the number of cores)")
-    parser.add_argument("--numThreads", type=str, default="",
-                        help="Comma separated list of numbers of threads to use in the scan (default: empty for all)")
-    parser.add_argument("--numStreams", type=str, default="",
-                        help="Comma separated list of numbers of streams to use in the scan (default: empty for always the same as the number of threads). If both number of threads and number of streams have more than 1 element, a 2D scan is done with all the combinations")
-    parser.add_argument("--eventsPerStream", type=int, default=None,
-                        help="Number of events to be used per EDM stream (default: 400*4kev for cuda, others also hardcoded in the top of the script file)")
-    parser.add_argument("--maxStreamsToAddEvents", type=int, default=-1,
-                        help="Maximum number of streams to add events (default: -1 for no limit")
-    parser.add_argument("--stopAfterWallTime", type=int, default=-1,
-                        help="Stop running after the wall time of the job reaches this many in seconds (default: -1 for no limit)")
-    parser.add_argument("--repeat", type=int, default=1,
-                        help="Repeat each point this many times (default: 1)")
+
+    output_group = parser.add_argument_group("JSON output arguments")
+    output_group.add_argument("-o", "--output", type=str, default="result",
+                              help="Prefix of output JSON and log files. If the output JSON file exists, it will be updated (see also --overwrite) (default: 'result')")
+    output_group.add_argument("--overwrite", action="store_true",
+                              help="Overwrite the output JSON instead of updating it")
+    output_group.add_argument("--append", action="store_true",
+                              help="Append new (stream, threads) results insteads of ignoring already existing point")
+
+    scan_group = parser.add_argument_group("Scan arguments")
+    scan_group.add_argument("--repeat", type=int, default=1,
+                            help="Repeat each point this many times (default: 1)")
+    scan_group.add_argument("--minThreads", type=int, default=1,
+                            help="Minimum number of threads to use in the scan (default: 1)")
+    scan_group.add_argument("--maxThreads", type=int, default=-1,
+                            help="Maximum number of threads to use in the scan (default: -1 for the number of cores)")
+    scan_group.add_argument("--numThreads", type=str, default="",
+                            help="Comma separated list of numbers of threads to use in the scan (default: empty for all)")
+    scan_group.add_argument("--numStreams", type=str, default="",
+                            help="Comma separated list of numbers of streams to use in the scan (default: empty for always the same as the number of threads). If both number of threads and number of streams have more than 1 element, a 2D scan is done with all the combinations")
+    scan_group.add_argument("--stopAfterWallTime", type=int, default=-1,
+                            help="Stop running after the wall time of the job reaches this many in seconds (default: -1 for no limit)")
+
+    nevents_group = parser.add_argument_group("Setting number of events arguments")
+    nevents_group.add_argument("--eventsPerStream", type=int, default=None,
+                               help="Number of events to be used per EDM stream (default: 400*4kev for cuda, others also hardcoded in the top of the script file)")
+    nevents_group.add_argument("--maxStreamsToAddEvents", type=int, default=-1,
+                               help="Maximum number of streams to add events (default: -1 for no limit")
+    nevents_group.add_argument("--runForMinutes", type=int, default=-1,
+                               help="Process the set of events until this many minutes has elapsed. Conflicts with --eventsPerStream and --maxStreamsToAddEvents. (default -1 for disabled)")
+
+    fill_group = parser.add_argument_group("Node filling and pinning arguments")
+    fill_group.add_argument("--taskset", action="store_true",
+                            help="Use taskset to explicitly set the cores where to run on")
+    fill_group.add_argument("--tasksetCores", type=str, default="",
+                            help="Comma-separated list of cores to be used for taskset in that order. Default (empty) is to use range(0, N(cores))")
+    fill_group.add_argument("--fill", type=int, default=-1,
+                            help="Launch serial program in the background so that this many threads are always running. If given, this will also become the upper limit for the number of threads instead of the number of cores of the machine. (default: -1 to disable")
+    fill_group.add_argument("--bkgNice", type=int, default=None,
+                            help="If given, use this 'nice' level for the background program")
+
     parser.add_argument("--tryAgain", type=int, default=1,
                         help="In case of failure on a point, try again at most this many times (default: 1)")
     parser.add_argument("--warmup", action="store_true",
@@ -286,5 +317,10 @@ if __name__ == "__main__":
         opts.tasksetCores = opts.tasksetCores.split(",")
     if len(opts.tasksetCores) > 0 and opts.fill != -1 and len(opts.tasksetCores) != opts.fill:
         parser.error("When both --tasksetCores and --fill are given, --fill must match to the number of elements in --tasksetCores. No got --fill {} and {} elements in --tasksetCores {}".format(opts.fill, len(opts.tasksetCores)))
+    if opts.runForMinutes >= 0:
+        if opts.eventsPerStream is not None:
+            parser.error("--runForMinutes and --eventsPerStream can not be used together")
+        if opts.maxStreamsToAddEvents >= 0:
+            parser.error("--runForMinutes and --maxStreamsToAddEvents can not be used together")
 
     main(opts)

--- a/run-scan.py
+++ b/run-scan.py
@@ -12,6 +12,7 @@ import multiprocessing
 
 # Make CUDA_VISIBLE_DEVICES order match to nvidia-smi
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 # Number of events for each application
 n_events_unit = 1000

--- a/src/alpaka/bin/EventProcessor.cc
+++ b/src/alpaka/bin/EventProcessor.cc
@@ -7,12 +7,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -26,6 +27,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();

--- a/src/alpaka/bin/EventProcessor.h
+++ b/src/alpaka/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/alpaka/bin/Source.cc
+++ b/src/alpaka/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/alpaka/bin/Source.h
+++ b/src/alpaka/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/alpaka/bin/main.cc
+++ b/src/alpaka/bin/main.cc
@@ -25,6 +25,8 @@ namespace {
         << " --numberOfThreads   Number of threads to use (default 1)\n"
         << " --numberOfStreams   Number of concurrent events (default 0=numberOfThreads)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
+        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
+           "(default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
@@ -43,6 +45,7 @@ int main(int argc, char** argv) {
   int numberOfThreads = 1;
   int numberOfStreams = 0;
   int maxEvents = -1;
+  int runForMinutes = -1;
   std::filesystem::path datadir;
   bool transfer = false;
   bool validation = false;
@@ -67,6 +70,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
+    } else if (*i == "--runForMinutes") {
+      ++i;
+      runForMinutes = std::stoi(*i);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;
@@ -85,6 +91,10 @@ int main(int argc, char** argv) {
       print_help(args.front());
       return EXIT_FAILURE;
     }
+  }
+  if (maxEvents >= 0 and runForMinutes >= 0) {
+    std::cout << "Got both --maxEvents and --runForMinutes, please give only one of them" << std::endl;
+    return EXIT_FAILURE;
   }
   if (numberOfStreams == 0) {
     numberOfStreams = numberOfThreads;
@@ -150,11 +160,15 @@ int main(int argc, char** argv) {
     }
   }
   edm::EventProcessor processor(
-      maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
-  maxEvents = processor.maxEvents();
+      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
 
-  std::cout << "Processing " << maxEvents << " events, of which " << numberOfStreams << " concurrently, with "
-            << numberOfThreads << " threads." << std::endl;
+  if (runForMinutes < 0) {
+    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
+              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+  } else {
+    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
+              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+  }
 
   // Run work
   auto start = std::chrono::high_resolution_clock::now();
@@ -193,6 +207,7 @@ int main(int argc, char** argv) {
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;
+  maxEvents = processor.processedEvents();
   std::cout << "Processed " << maxEvents << " events in " << std::scientific << time << " seconds, throughput "
             << std::defaultfloat << (maxEvents / time) << " events/s." << std::endl;
   return EXIT_SUCCESS;

--- a/src/alpakatest/bin/EventProcessor.cc
+++ b/src/alpakatest/bin/EventProcessor.cc
@@ -7,12 +7,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -26,6 +27,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();

--- a/src/alpakatest/bin/EventProcessor.h
+++ b/src/alpakatest/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/alpakatest/bin/Source.cc
+++ b/src/alpakatest/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/alpakatest/bin/Source.h
+++ b/src/alpakatest/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/cuda/bin/EventProcessor.cc
+++ b/src/cuda/bin/EventProcessor.cc
@@ -7,12 +7,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -26,6 +27,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();

--- a/src/cuda/bin/EventProcessor.h
+++ b/src/cuda/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/cuda/bin/Source.cc
+++ b/src/cuda/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/cuda/bin/Source.h
+++ b/src/cuda/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/cuda/bin/main.cc
+++ b/src/cuda/bin/main.cc
@@ -24,6 +24,8 @@ namespace {
         << " --numberOfThreads   Number of threads to use (default 1)\n"
         << " --numberOfStreams   Number of concurrent events (default 0=numberOfThreads)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
+        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
+           "(default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
@@ -39,6 +41,7 @@ int main(int argc, char** argv) {
   int numberOfThreads = 1;
   int numberOfStreams = 0;
   int maxEvents = -1;
+  int runForMinutes = -1;
   std::filesystem::path datadir;
   bool transfer = false;
   bool validation = false;
@@ -57,6 +60,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
+    } else if (*i == "--runForMinutes") {
+      ++i;
+      runForMinutes = std::stoi(*i);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;
@@ -75,6 +81,10 @@ int main(int argc, char** argv) {
       print_help(args.front());
       return EXIT_FAILURE;
     }
+  }
+  if (maxEvents >= 0 and runForMinutes >= 0) {
+    std::cout << "Got both --maxEvents and --runForMinutes, please give only one of them" << std::endl;
+    return EXIT_FAILURE;
   }
   if (numberOfStreams == 0) {
     numberOfStreams = numberOfThreads;
@@ -130,11 +140,15 @@ int main(int argc, char** argv) {
     }
   }
   edm::EventProcessor processor(
-      maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
-  maxEvents = processor.maxEvents();
+      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
 
-  std::cout << "Processing " << maxEvents << " events, of which " << numberOfStreams << " concurrently, with "
-            << numberOfThreads << " threads." << std::endl;
+  if (runForMinutes < 0) {
+    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
+              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+  } else {
+    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
+              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+  }
 
   // Initialize tasks scheduler (thread pool)
   tbb::task_scheduler_init tsi(numberOfThreads);
@@ -176,6 +190,7 @@ int main(int argc, char** argv) {
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;
+  maxEvents = processor.processedEvents();
   std::cout << "Processed " << maxEvents << " events in " << std::scientific << time << " seconds, throughput "
             << std::defaultfloat << (maxEvents / time) << " events/s." << std::endl;
   return EXIT_SUCCESS;

--- a/src/cudacompat/bin/EventProcessor.cc
+++ b/src/cudacompat/bin/EventProcessor.cc
@@ -7,12 +7,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -26,6 +27,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();

--- a/src/cudacompat/bin/EventProcessor.h
+++ b/src/cudacompat/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/cudacompat/bin/Source.cc
+++ b/src/cudacompat/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/cudacompat/bin/Source.h
+++ b/src/cudacompat/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/cudadev/bin/EventProcessor.cc
+++ b/src/cudadev/bin/EventProcessor.cc
@@ -7,12 +7,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -26,6 +27,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();

--- a/src/cudadev/bin/EventProcessor.h
+++ b/src/cudadev/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/cudadev/bin/Source.cc
+++ b/src/cudadev/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/cudadev/bin/Source.h
+++ b/src/cudadev/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,31 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(int maxEvents,
+                    int runForMinutes,
+                    ProductRegistry& reg,
+                    std::filesystem::path const& datadir,
+                    bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/cudadev/bin/main.cc
+++ b/src/cudadev/bin/main.cc
@@ -24,6 +24,8 @@ namespace {
         << " --numberOfThreads   Number of threads to use (default 1)\n"
         << " --numberOfStreams   Number of concurrent events (default 0=numberOfThreads)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
+        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
+           "(default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
@@ -39,6 +41,7 @@ int main(int argc, char** argv) {
   int numberOfThreads = 1;
   int numberOfStreams = 0;
   int maxEvents = -1;
+  int runForMinutes = -1;
   std::filesystem::path datadir;
   bool transfer = false;
   bool validation = false;
@@ -57,6 +60,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
+    } else if (*i == "--runForMinutes") {
+      ++i;
+      runForMinutes = std::stoi(*i);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;
@@ -75,6 +81,10 @@ int main(int argc, char** argv) {
       print_help(args.front());
       return EXIT_FAILURE;
     }
+  }
+  if (maxEvents >= 0 and runForMinutes >= 0) {
+    std::cout << "Got both --maxEvents and --runForMinutes, please give only one of them" << std::endl;
+    return EXIT_FAILURE;
   }
   if (numberOfStreams == 0) {
     numberOfStreams = numberOfThreads;
@@ -130,11 +140,15 @@ int main(int argc, char** argv) {
     }
   }
   edm::EventProcessor processor(
-      maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
-  maxEvents = processor.maxEvents();
+      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
 
-  std::cout << "Processing " << maxEvents << " events, of which " << numberOfStreams << " concurrently, with "
-            << numberOfThreads << " threads." << std::endl;
+  if (runForMinutes < 0) {
+    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
+              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+  } else {
+    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
+              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+  }
 
   // Initialize tasks scheduler (thread pool)
   tbb::task_scheduler_init tsi(numberOfThreads);
@@ -176,6 +190,7 @@ int main(int argc, char** argv) {
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;
+  maxEvents = processor.processedEvents();
   std::cout << "Processed " << maxEvents << " events in " << std::scientific << time << " seconds, throughput "
             << std::defaultfloat << (maxEvents / time) << " events/s." << std::endl;
   return EXIT_SUCCESS;

--- a/src/cudauvm/bin/EventProcessor.cc
+++ b/src/cudauvm/bin/EventProcessor.cc
@@ -7,12 +7,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -26,6 +27,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();

--- a/src/cudauvm/bin/EventProcessor.h
+++ b/src/cudauvm/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/cudauvm/bin/Source.cc
+++ b/src/cudauvm/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/cudauvm/bin/Source.h
+++ b/src/cudauvm/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/cudauvm/bin/main.cc
+++ b/src/cudauvm/bin/main.cc
@@ -23,6 +23,8 @@ namespace {
         << " --numberOfThreads   Number of threads to use (default 1)\n"
         << " --numberOfStreams   Number of concurrent events (default 0=numberOfThreads)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
+        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
+           "(default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
@@ -38,6 +40,7 @@ int main(int argc, char** argv) {
   int numberOfThreads = 1;
   int numberOfStreams = 0;
   int maxEvents = -1;
+  int runForMinutes = -1;
   std::filesystem::path datadir;
   bool transfer = false;
   bool validation = false;
@@ -56,6 +59,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
+    } else if (*i == "--runForMinutes") {
+      ++i;
+      runForMinutes = std::stoi(*i);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;
@@ -74,6 +80,10 @@ int main(int argc, char** argv) {
       print_help(args.front());
       return EXIT_FAILURE;
     }
+  }
+  if (maxEvents >= 0 and runForMinutes >= 0) {
+    std::cout << "Got both --maxEvents and --runForMinutes, please give only one of them" << std::endl;
+    return EXIT_FAILURE;
   }
   if (numberOfStreams == 0) {
     numberOfStreams = numberOfThreads;
@@ -129,11 +139,15 @@ int main(int argc, char** argv) {
     }
   }
   edm::EventProcessor processor(
-      maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
-  maxEvents = processor.maxEvents();
+      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
 
-  std::cout << "Processing " << maxEvents << " events, of which " << numberOfStreams << " concurrently, with "
-            << numberOfThreads << " threads." << std::endl;
+  if (runForMinutes < 0) {
+    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
+              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+  } else {
+    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
+              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+  }
 
   // Initialize tasks scheduler (thread pool)
   tbb::task_scheduler_init tsi(numberOfThreads);
@@ -175,6 +189,7 @@ int main(int argc, char** argv) {
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;
+  maxEvents = processor.processedEvents();
   std::cout << "Processed " << maxEvents << " events in " << std::scientific << time << " seconds, throughput "
             << std::defaultfloat << (maxEvents / time) << " events/s." << std::endl;
   return EXIT_SUCCESS;

--- a/src/fwtest/bin/EventProcessor.cc
+++ b/src/fwtest/bin/EventProcessor.cc
@@ -7,12 +7,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -26,6 +27,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();

--- a/src/fwtest/bin/EventProcessor.h
+++ b/src/fwtest/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/fwtest/bin/Source.cc
+++ b/src/fwtest/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/fwtest/bin/Source.h
+++ b/src/fwtest/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/fwtest/bin/main.cc
+++ b/src/fwtest/bin/main.cc
@@ -20,6 +20,8 @@ namespace {
         << " --numberOfThreads   Number of threads to use (default 1)\n"
         << " --numberOfStreams   Number of concurrent events (default 0=numberOfThreads)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
+        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
+           "(default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
@@ -34,6 +36,7 @@ int main(int argc, char** argv) {
   int numberOfThreads = 1;
   int numberOfStreams = 0;
   int maxEvents = -1;
+  int runForMinutes = -1;
   std::filesystem::path datadir;
   bool transfer = false;
   bool validation = false;
@@ -51,6 +54,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
+    } else if (*i == "--runForMinutes") {
+      ++i;
+      runForMinutes = std::stoi(*i);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;
@@ -66,6 +72,10 @@ int main(int argc, char** argv) {
       print_help(args.front());
       return EXIT_FAILURE;
     }
+  }
+  if (maxEvents >= 0 and runForMinutes >= 0) {
+    std::cout << "Got both --maxEvents and --runForMinutes, please give only one of them" << std::endl;
+    return EXIT_FAILURE;
   }
   if (numberOfStreams == 0) {
     numberOfStreams = numberOfThreads;
@@ -89,11 +99,15 @@ int main(int argc, char** argv) {
     }
   }
   edm::EventProcessor processor(
-      maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
-  maxEvents = processor.maxEvents();
+      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
 
-  std::cout << "Processing " << maxEvents << " events, of which " << numberOfStreams << " concurrently, with "
-            << numberOfThreads << " threads." << std::endl;
+  if (runForMinutes < 0) {
+    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
+              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+  } else {
+    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
+              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+  }
 
   // Initialize tasks scheduler (thread pool)
   tbb::task_scheduler_init tsi(numberOfThreads);
@@ -135,6 +149,7 @@ int main(int argc, char** argv) {
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;
+  maxEvents = processor.processedEvents();
   std::cout << "Processed " << maxEvents << " events in " << std::scientific << time << " seconds, throughput "
             << std::defaultfloat << (maxEvents / time) << " events/s." << std::endl;
   return EXIT_SUCCESS;

--- a/src/hip/bin/EventProcessor.cc
+++ b/src/hip/bin/EventProcessor.cc
@@ -7,12 +7,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -26,6 +27,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();

--- a/src/hip/bin/EventProcessor.h
+++ b/src/hip/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/hip/bin/Source.cc
+++ b/src/hip/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/hip/bin/Source.h
+++ b/src/hip/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/hip/bin/main.cc
+++ b/src/hip/bin/main.cc
@@ -23,6 +23,8 @@ namespace {
         << " --numberOfThreads   Number of threads to use (default 1)\n"
         << " --numberOfStreams   Number of concurrent events (default 0=numberOfThreads)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
+        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
+           "(default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
@@ -38,6 +40,7 @@ int main(int argc, char** argv) {
   int numberOfThreads = 1;
   int numberOfStreams = 0;
   int maxEvents = -1;
+  int runForMinutes = -1;
   std::filesystem::path datadir;
   bool transfer = false;
   bool validation = false;
@@ -56,6 +59,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
+    } else if (*i == "--runForMinutes") {
+      ++i;
+      runForMinutes = std::stoi(*i);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;
@@ -74,6 +80,10 @@ int main(int argc, char** argv) {
       print_help(args.front());
       return EXIT_FAILURE;
     }
+  }
+  if (maxEvents >= 0 and runForMinutes >= 0) {
+    std::cout << "Got both --maxEvents and --runForMinutes, please give only one of them" << std::endl;
+    return EXIT_FAILURE;
   }
   if (numberOfStreams == 0) {
     numberOfStreams = numberOfThreads;
@@ -119,11 +129,15 @@ int main(int argc, char** argv) {
     }
   }
   edm::EventProcessor processor(
-      maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
-  maxEvents = processor.maxEvents();
+      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
 
-  std::cout << "Processing " << maxEvents << " events, of which " << numberOfStreams << " concurrently, with "
-            << numberOfThreads << " threads." << std::endl;
+  if (runForMinutes < 0) {
+    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
+              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+  } else {
+    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
+              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+  }
 
   // Initialize tasks scheduler (thread pool)
   tbb::task_scheduler_init tsi(numberOfThreads);
@@ -165,6 +179,7 @@ int main(int argc, char** argv) {
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;
+  maxEvents = processor.processedEvents();
   std::cout << "Processed " << maxEvents << " events in " << std::scientific << time << " seconds, throughput "
             << std::defaultfloat << (maxEvents / time) << " events/s." << std::endl;
   return EXIT_SUCCESS;

--- a/src/hiptest/bin/EventProcessor.cc
+++ b/src/hiptest/bin/EventProcessor.cc
@@ -7,12 +7,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -26,6 +27,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();

--- a/src/hiptest/bin/EventProcessor.h
+++ b/src/hiptest/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/hiptest/bin/Source.cc
+++ b/src/hiptest/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/hiptest/bin/Source.h
+++ b/src/hiptest/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/hiptest/bin/main.cc
+++ b/src/hiptest/bin/main.cc
@@ -22,6 +22,8 @@ namespace {
         << " --numberOfThreads   Number of threads to use (default 1)\n"
         << " --numberOfStreams   Number of concurrent events (default 0=numberOfThreads)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
+        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
+           "(default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
@@ -36,6 +38,7 @@ int main(int argc, char** argv) {
   int numberOfThreads = 1;
   int numberOfStreams = 0;
   int maxEvents = -1;
+  int runForMinutes = -1;
   std::filesystem::path datadir;
   bool transfer = false;
   bool validation = false;
@@ -53,6 +56,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
+    } else if (*i == "--runForMinutes") {
+      ++i;
+      runForMinutes = std::stoi(*i);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;
@@ -68,6 +74,10 @@ int main(int argc, char** argv) {
       print_help(args.front());
       return EXIT_FAILURE;
     }
+  }
+  if (maxEvents >= 0 and runForMinutes >= 0) {
+    std::cout << "Got both --maxEvents and --runForMinutes, please give only one of them" << std::endl;
+    return EXIT_FAILURE;
   }
   if (numberOfStreams == 0) {
     numberOfStreams = numberOfThreads;
@@ -98,11 +108,15 @@ int main(int argc, char** argv) {
     }
   }
   edm::EventProcessor processor(
-      maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
-  maxEvents = processor.maxEvents();
+      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
 
-  std::cout << "Processing " << maxEvents << " events, of which " << numberOfStreams << " concurrently, with "
-            << numberOfThreads << " threads." << std::endl;
+  if (runForMinutes < 0) {
+    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
+              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+  } else {
+    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
+              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+  }
 
   // Initialize tasks scheduler (thread pool)
   tbb::task_scheduler_init tsi(numberOfThreads);
@@ -144,6 +158,7 @@ int main(int argc, char** argv) {
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;
+  maxEvents = processor.processedEvents();
   std::cout << "Processed " << maxEvents << " events in " << std::scientific << time << " seconds, throughput "
             << std::defaultfloat << (maxEvents / time) << " events/s." << std::endl;
   return EXIT_SUCCESS;

--- a/src/kokkos/bin/EventProcessor.cc
+++ b/src/kokkos/bin/EventProcessor.cc
@@ -11,12 +11,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -30,6 +31,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
 #ifdef KOKKOS_ENABLE_THREADS
     for (auto& s : schedules_) {
       s.runToCompletion();

--- a/src/kokkos/bin/EventProcessor.h
+++ b/src/kokkos/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/kokkos/bin/Source.cc
+++ b/src/kokkos/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/kokkos/bin/Source.h
+++ b/src/kokkos/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/kokkos/bin/main.cc
+++ b/src/kokkos/bin/main.cc
@@ -45,6 +45,8 @@ namespace {
         << " --numberOfThreads       Number of threads to use (default 1)\n"
         << " --numberOfStreams       Number of concurrent events (default 0=numberOfThreads)\n"
         << " --maxEvents             Number of events to process (default -1 for all events in the input file)\n"
+        << " --runForMinutes         Continue processing the set of 1000 events until this many minutes have passed "
+           "(default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data                  Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer              Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --histogram             Produce histograms at the end (implies --transfer)\n"
@@ -61,6 +63,7 @@ int main(int argc, char** argv) {
   int numberOfThreads = 1;
   int numberOfStreams = 0;
   int maxEvents = -1;
+  int runForMinutes = -1;
   std::filesystem::path datadir;
   bool transfer = false;
   bool validation = false;
@@ -92,6 +95,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
+    } else if (*i == "--runForMinutes") {
+      ++i;
+      runForMinutes = std::stoi(*i);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;
@@ -108,6 +114,10 @@ int main(int argc, char** argv) {
       print_help(args.front());
       return EXIT_FAILURE;
     }
+  }
+  if (maxEvents >= 0 and runForMinutes >= 0) {
+    std::cout << "Got both --maxEvents and --runForMinutes, please give only one of them" << std::endl;
+    return EXIT_FAILURE;
   }
   if (numberOfStreams == 0) {
     numberOfStreams = numberOfThreads;
@@ -161,11 +171,15 @@ int main(int argc, char** argv) {
     addModules("kokkos_hip::", Backend::HIP);
   }
   edm::EventProcessor processor(
-      maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
-  maxEvents = processor.maxEvents();
+      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
 
-  std::cout << "Processing " << maxEvents << " events, of which " << numberOfStreams << " concurrently, with "
-            << numberOfThreads << " threads." << std::endl;
+  if (runForMinutes < 0) {
+    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
+              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+  } else {
+    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
+              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+  }
 
   // Initialize tasks scheduler (thread pool)
   tbb::task_scheduler_init tsi(numberOfThreads);
@@ -207,6 +221,7 @@ int main(int argc, char** argv) {
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;
+  maxEvents = processor.processedEvents();
   std::cout << "Processed " << maxEvents << " events in " << std::scientific << time << " seconds, throughput "
             << std::defaultfloat << (maxEvents / time) << " events/s." << std::endl;
   return EXIT_SUCCESS;

--- a/src/kokkostest/bin/EventProcessor.cc
+++ b/src/kokkostest/bin/EventProcessor.cc
@@ -11,12 +11,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -30,6 +31,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
 #ifdef KOKKOS_ENABLE_THREADS
     for (auto& s : schedules_) {
       s.runToCompletion();

--- a/src/kokkostest/bin/EventProcessor.h
+++ b/src/kokkostest/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/kokkostest/bin/Source.cc
+++ b/src/kokkostest/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/kokkostest/bin/Source.h
+++ b/src/kokkostest/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/kokkostest/bin/main.cc
+++ b/src/kokkostest/bin/main.cc
@@ -45,6 +45,8 @@ namespace {
         << " --numberOfThreads       Number of threads to use (default 1)\n"
         << " --numberOfStreams       Number of concurrent events (default 0=numberOfThreads)\n"
         << " --maxEvents             Number of events to process (default -1 for all events in the input file)\n"
+        << " --runForMinutes         Continue processing the set of 1000 events until this many minutes have passed "
+           "(default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data                  Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer              Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --validation            Run (rudimentary) validation at the end (implies --transfer)\n"
@@ -60,6 +62,7 @@ int main(int argc, char** argv) {
   int numberOfThreads = 1;
   int numberOfStreams = 0;
   int maxEvents = -1;
+  int runForMinutes = -1;
   std::filesystem::path datadir;
   bool transfer = false;
   bool validation = false;
@@ -90,6 +93,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
+    } else if (*i == "--runForMinutes") {
+      ++i;
+      runForMinutes = std::stoi(*i);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;
@@ -103,6 +109,10 @@ int main(int argc, char** argv) {
       print_help(args.front());
       return EXIT_FAILURE;
     }
+  }
+  if (maxEvents >= 0 and runForMinutes >= 0) {
+    std::cout << "Got both --maxEvents and --runForMinutes, please give only one of them" << std::endl;
+    return EXIT_FAILURE;
   }
   if (numberOfStreams == 0) {
     numberOfStreams = numberOfThreads;
@@ -144,11 +154,15 @@ int main(int argc, char** argv) {
     }
   }
   edm::EventProcessor processor(
-      maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
-  maxEvents = processor.maxEvents();
+      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
 
-  std::cout << "Processing " << maxEvents << " events, of which " << numberOfStreams << " concurrently, with "
-            << numberOfThreads << " threads." << std::endl;
+  if (runForMinutes < 0) {
+    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
+              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+  } else {
+    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
+              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+  }
 
   // Initialize tasks scheduler (thread pool)
   tbb::task_scheduler_init tsi(numberOfThreads);
@@ -190,6 +204,7 @@ int main(int argc, char** argv) {
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;
+  maxEvents = processor.processedEvents();
   std::cout << "Processed " << maxEvents << " events in " << std::scientific << time << " seconds, throughput "
             << std::defaultfloat << (maxEvents / time) << " events/s." << std::endl;
   return EXIT_SUCCESS;

--- a/src/serial/bin/EventProcessor.cc
+++ b/src/serial/bin/EventProcessor.cc
@@ -7,12 +7,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -26,6 +27,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();

--- a/src/serial/bin/EventProcessor.h
+++ b/src/serial/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/serial/bin/Source.cc
+++ b/src/serial/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/serial/bin/Source.h
+++ b/src/serial/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/serial/bin/main.cc
+++ b/src/serial/bin/main.cc
@@ -21,6 +21,8 @@ namespace {
         << " --numberOfThreads   Number of threads to use (default 1)\n"
         << " --numberOfStreams   Number of concurrent events (default 0=numberOfThreads)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
+        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
+           "(default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --validation        Run (rudimentary) validation at the end\n"
         << " --histogram         Produce histograms at the end\n"
@@ -35,6 +37,7 @@ int main(int argc, char** argv) {
   int numberOfThreads = 1;
   int numberOfStreams = 0;
   int maxEvents = -1;
+  int runForMinutes = -1;
   std::filesystem::path datadir;
   bool validation = false;
   bool histogram = false;
@@ -52,6 +55,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
+    } else if (*i == "--runForMinutes") {
+      ++i;
+      runForMinutes = std::stoi(*i);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;
@@ -66,6 +72,10 @@ int main(int argc, char** argv) {
       print_help(args.front());
       return EXIT_FAILURE;
     }
+  }
+  if (maxEvents >= 0 and runForMinutes >= 0) {
+    std::cout << "Got both --maxEvents and --runForMinutes, please give only one of them" << std::endl;
+    return EXIT_FAILURE;
   }
   if (numberOfStreams == 0) {
     numberOfStreams = numberOfThreads;
@@ -96,11 +106,15 @@ int main(int argc, char** argv) {
     }
   }
   edm::EventProcessor processor(
-      maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
-  maxEvents = processor.maxEvents();
+      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
 
-  std::cout << "Processing " << maxEvents << " events, of which " << numberOfStreams << " concurrently, with "
-            << numberOfThreads << " threads." << std::endl;
+  if (runForMinutes < 0) {
+    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
+              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+  } else {
+    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
+              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+  }
 
   // Initialize tasks scheduler (thread pool)
   tbb::task_scheduler_init tsi(numberOfThreads);
@@ -142,6 +156,7 @@ int main(int argc, char** argv) {
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;
+  maxEvents = processor.processedEvents();
   std::cout << "Processed " << maxEvents << " events in " << std::scientific << time << " seconds, throughput "
             << std::defaultfloat << (maxEvents / time) << " events/s." << std::endl;
   return EXIT_SUCCESS;

--- a/src/sycltest/bin/EventProcessor.cc
+++ b/src/sycltest/bin/EventProcessor.cc
@@ -7,12 +7,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -26,6 +27,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     auto globalWaitTask = make_empty_waiting_task();
     globalWaitTask->increment_ref_count();

--- a/src/sycltest/bin/EventProcessor.h
+++ b/src/sycltest/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/sycltest/bin/Source.cc
+++ b/src/sycltest/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/sycltest/bin/Source.h
+++ b/src/sycltest/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/sycltest/bin/main.cc
+++ b/src/sycltest/bin/main.cc
@@ -22,6 +22,8 @@ namespace {
         << " --numberOfThreads   Number of threads to use (default 1)\n"
         << " --numberOfStreams   Number of concurrent events (default 0=numberOfThreads)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
+        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
+           "(default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
@@ -36,6 +38,7 @@ int main(int argc, char** argv) try {
   int numberOfThreads = 1;
   int numberOfStreams = 0;
   int maxEvents = -1;
+  int runForMinutes = -1;
   std::filesystem::path datadir;
   bool transfer = false;
   bool validation = false;
@@ -53,6 +56,9 @@ int main(int argc, char** argv) try {
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
+    } else if (*i == "--runForMinutes") {
+      ++i;
+      runForMinutes = std::stoi(*i);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;
@@ -68,6 +74,10 @@ int main(int argc, char** argv) try {
       print_help(args.front());
       return EXIT_FAILURE;
     }
+  }
+  if (maxEvents >= 0 and runForMinutes >= 0) {
+    std::cout << "Got both --maxEvents and --runForMinutes, please give only one of them" << std::endl;
+    return EXIT_FAILURE;
   }
   if (numberOfStreams == 0) {
     numberOfStreams = numberOfThreads;
@@ -94,11 +104,15 @@ int main(int argc, char** argv) try {
     }
   }
   edm::EventProcessor processor(
-      maxEvents, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
-  maxEvents = processor.maxEvents();
+      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
 
-  std::cout << "Processing " << maxEvents << " events, of which " << numberOfStreams << " concurrently, with "
-            << numberOfThreads << " threads." << std::endl;
+  if (runForMinutes < 0) {
+    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
+              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+  } else {
+    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
+              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+  }
 
   // Initialize tasks scheduler (thread pool)
   tbb::task_scheduler_init tsi(numberOfThreads);
@@ -140,6 +154,7 @@ int main(int argc, char** argv) try {
   // Work done, report timing
   auto diff = stop - start;
   auto time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(diff).count()) / 1e6;
+  maxEvents = processor.processedEvents();
   std::cout << "Processed " << maxEvents << " events in " << std::scientific << time << " seconds, throughput "
             << std::defaultfloat << (maxEvents / time) << " events/s." << std::endl;
   return EXIT_SUCCESS;


### PR DESCRIPTION
This PR includes several technical changes on running performance measurements

* Adds `--runForMinutes` argument for all programs. The argument is mutually exclusive with `--maxEvents`, and with it the program repeats the 1k events for at least the given integer number of minutes. The set of 1k events is always processed in full. In my tests so far the cost of the added synchronization is negligible.
* On `run-scan.py`
   * The **script no longer honors `CUDA_VISIBLE_DEVICES`**. Instead, it has a new argument `--cudaDevices` to specify the devices to use. The device indices correspond to those in `nvidia-smi` (whic does not, in general. hold for `CUDA_VISIBLE_DEVICES`)
       * This change was motivated by the monitoring of GPU status (see below), and the fact that the device indices in `CUDA_VISIBLE_DEVICES` are not necessarily consistent with those in `nvidia-smi`
       * The script prints all devices it sees (with the consistent indexing)
       * Information (name and driver version) are stored in the JSON file for those devices that were used in the measurement
   * Support for the --runForMinutes` option
   * Aggregate various arguments into groups to make the help message more clear
   * Add options to monitor the process host RSS and CUDA utilization, temperature, power, clock, and process memory usage
       * The host RSS is read from `/proc/`, and the GPU status with `nvidia-smi`
       * The `--monitorSeconds` argument specifies the sampling interval in seconds
       * In case the job uses multiple GPUs, the status (including the memory usage) is recorded for each GPU separately
   * Fix `--repeat` (resolves #232)
* A new script `run-many.py` to run a single meaurement that is a combination of the throughput of many processes. These processes can be different programs, use different numbers of threads/streams, be pinned to different NUMA nodes or CPU cores, and use different CUDA devices.
   * The script supports some of the arguments of `run-scan.py`, e.g. the monitoring.
   
