### PR TITLE
[alpaka] Rename accelerator-dependent types

### DIFF
--- a/src/alpaka/AlpakaCore/HistoContainer.h
+++ b/src/alpaka/AlpakaCore/HistoContainer.h
@@ -70,20 +70,20 @@ namespace cms {
       const int num_items = Histo::totbins();
 
       const unsigned int nthreads = 1024;
-      const Vec1 threadsPerBlockOrElementsPerThread(nthreads);
+      const Vec1D threadsPerBlockOrElementsPerThread(nthreads);
       const unsigned int nblocks = (num_items + nthreads - 1) / nthreads;
-      const Vec1 blocksPerGrid(nblocks);
+      const Vec1D blocksPerGrid(nblocks);
 
-      const WorkDiv1 &workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
+      const WorkDiv1D &workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+                      alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
                           workDiv, multiBlockPrefixScanFirstStep<uint32_t>(), poff, poff, num_items));
 
-      const WorkDiv1 &workDivWith1Block =
-          cms::alpakatools::make_workdiv(Vec1::all(1), threadsPerBlockOrElementsPerThread);
+      const WorkDiv1D &workDivWith1Block =
+          cms::alpakatools::make_workdiv(Vec1D::all(1), threadsPerBlockOrElementsPerThread);
       alpaka::enqueue(
           queue,
-          alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+          alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
               workDivWith1Block, multiBlockPrefixScanSecondStep<uint32_t>(), poff, poff, num_items, nblocks));
     }
 
@@ -99,18 +99,18 @@ namespace cms {
       launchZero(h, queue);
 
       const unsigned int nblocks = (totSize + nthreads - 1) / nthreads;
-      const Vec1 blocksPerGrid(nblocks);
-      const Vec1 threadsPerBlockOrElementsPerThread(nthreads);
-      const WorkDiv1 &workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
+      const Vec1D blocksPerGrid(nblocks);
+      const Vec1D threadsPerBlockOrElementsPerThread(nthreads);
+      const WorkDiv1D &workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
 
       alpaka::enqueue(
           queue,
-          alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(workDiv, countFromVector(), h, nh, v, offsets));
+          alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(workDiv, countFromVector(), h, nh, v, offsets));
       launchFinalize(h, queue);
 
       alpaka::enqueue(
           queue,
-          alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(workDiv, fillFromVector(), h, nh, v, offsets));
+          alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(workDiv, fillFromVector(), h, nh, v, offsets));
     }
 
     struct finalizeBulk {

--- a/src/alpaka/AlpakaCore/alpaka/alpakaDevAcc.cc
+++ b/src/alpaka/AlpakaCore/alpaka/alpakaDevAcc.cc
@@ -1,5 +1,5 @@
 #include "AlpakaCore/alpakaDevAcc.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  const DevAcc2 device = alpaka::getDevByIdx<PltfAcc2>(0u);
+  const Device device = alpaka::getDevByIdx<Platform>(0u);
 }

--- a/src/alpaka/AlpakaCore/alpakaConfigAcc.h
+++ b/src/alpaka/AlpakaCore/alpakaConfigAcc.h
@@ -7,8 +7,8 @@
 #define ALPAKA_ACC_GPU_CUDA_ASYNC_BACKEND
 namespace alpaka_cuda_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::AccGpuCudaRt<Dim1, Extent>;
-  using Acc2 = alpaka::AccGpuCudaRt<Dim2, Extent>;
+  using Acc1D = alpaka::AccGpuCudaRt<Dim1D, Extent>;
+  using Acc2D = alpaka::AccGpuCudaRt<Dim2D, Extent>;
   using Queue = alpaka::QueueCudaRtNonBlocking;
 }  // namespace alpaka_cuda_async
 
@@ -23,8 +23,8 @@ namespace alpaka_cuda_async {
 #define ALPAKA_ACC_CPU_B_SEQ_T_SEQ_SYNC_BACKEND
 namespace alpaka_serial_sync {
   using namespace alpaka_common;
-  using Acc1 = alpaka::AccCpuSerial<Dim1, Extent>;
-  using Acc2 = alpaka::AccCpuSerial<Dim2, Extent>;
+  using Acc1D = alpaka::AccCpuSerial<Dim1D, Extent>;
+  using Acc2D = alpaka::AccCpuSerial<Dim2D, Extent>;
   using Queue = alpaka::QueueCpuBlocking;
 }  // namespace alpaka_serial_sync
 
@@ -39,8 +39,8 @@ namespace alpaka_serial_sync {
 #define ALPAKA_ACC_CPU_B_TBB_T_SEQ_ASYNC_BACKEND
 namespace alpaka_tbb_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::AccCpuTbbBlocks<Dim1, Extent>;
-  using Acc2 = alpaka::AccCpuTbbBlocks<Dim2, Extent>;
+  using Acc1D = alpaka::AccCpuTbbBlocks<Dim1D, Extent>;
+  using Acc2D = alpaka::AccCpuTbbBlocks<Dim2D, Extent>;
   using Queue = alpaka::QueueCpuNonBlocking;
 }  // namespace alpaka_tbb_async
 
@@ -55,8 +55,8 @@ namespace alpaka_tbb_async {
 #define ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ASYNC_BACKEND
 namespace alpaka_omp2_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::AccCpuOmp2Blocks<Dim1, Extent>;
-  using Acc2 = alpaka::AccCpuOmp2Blocks<Dim2, Extent>;
+  using Acc1D = alpaka::AccCpuOmp2Blocks<Dim1D, Extent>;
+  using Acc2D = alpaka::AccCpuOmp2Blocks<Dim2D, Extent>;
   using Queue = alpaka::QueueCpuNonBlocking;
 }  // namespace alpaka_omp2_async
 
@@ -71,8 +71,8 @@ namespace alpaka_omp2_async {
 #define ALPAKA_ACC_CPU_BT_OMP4_ASYNC_BACKEND
 namespace alpaka_omp4_async {
   using namespace alpaka_common;
-  using Acc1 = alpaka::AccCpuOmp4<Dim1, Extent>;
-  using Acc2 = alpaka::AccCpuOmp4<Dim2, Extent>;
+  using Acc1D = alpaka::AccCpuOmp4<Dim1D, Extent>;
+  using Acc2D = alpaka::AccCpuOmp4<Dim2D, Extent>;
   using Queue = alpaka::QueueCpuNonBlocking;
 }  // namespace alpaka_omp4_async
 
@@ -84,25 +84,23 @@ namespace alpaka_omp4_async {
 #endif  // ALPAKA_ACC_CPU_BT_OMP4_ASYNC_BACKEND
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  using DevAcc1 = alpaka::Dev<Acc1>;
-  using DevAcc2 = alpaka::Dev<Acc2>;
-  using PltfAcc1 = alpaka::Pltf<DevAcc1>;
-  using PltfAcc2 = alpaka::Pltf<DevAcc2>;
+  using Device = alpaka::Dev<Acc1D>;      // these are independent from the dimensionality
+  using Platform = alpaka::Pltf<Device>;  //
 
   template <class TData>
-  using AlpakaAccBuf1 = alpaka::Buf<Acc1, TData, Dim1, Idx>;
+  using AlpakaAccBuf1D = alpaka::Buf<Acc1D, TData, Dim1D, Idx>;
 
   template <class TData>
-  using AlpakaAccBuf2 = alpaka::Buf<Acc2, TData, Dim2, Idx>;
+  using AlpakaAccBuf2D = alpaka::Buf<Acc2D, TData, Dim2D, Idx>;
 
   template <typename TData>
-  using AlpakaDeviceBuf = AlpakaAccBuf1<TData>;
+  using AlpakaDeviceBuf = AlpakaAccBuf1D<TData>;
 
   template <typename TData>
-  using AlpakaDeviceView = alpaka::ViewPlainPtr<DevAcc1, TData, Dim1, Idx>;
+  using AlpakaDeviceView = alpaka::ViewPlainPtr<Device, TData, Dim1D, Idx>;
 
   template <typename TData>
-  using AlpakaDeviceSubView = alpaka::ViewSubView<DevAcc1, TData, Dim1, Idx>;
+  using AlpakaDeviceSubView = alpaka::ViewSubView<Device, TData, Dim1D, Idx>;
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
 #endif  // alpakaConfigAcc_h_

--- a/src/alpaka/AlpakaCore/alpakaConfigCommon.h
+++ b/src/alpaka/AlpakaCore/alpakaConfigCommon.h
@@ -10,24 +10,24 @@ namespace alpaka_common {
   using DevHost = alpaka::DevCpu;
   using PltfHost = alpaka::Pltf<DevHost>;
 
-  using Dim1 = alpaka::DimInt<1u>;
-  using Dim2 = alpaka::DimInt<2u>;
+  using Dim1D = alpaka::DimInt<1u>;
+  using Dim2D = alpaka::DimInt<2u>;
 
   template <typename TDim>
   using Vec = alpaka::Vec<TDim, Idx>;
-  using Vec1 = Vec<Dim1>;
-  using Vec2 = Vec<Dim2>;
+  using Vec1D = Vec<Dim1D>;
+  using Vec2D = Vec<Dim2D>;
 
   template <typename TDim>
   using WorkDiv = alpaka::WorkDivMembers<TDim, Idx>;
-  using WorkDiv1 = WorkDiv<Dim1>;
-  using WorkDiv2 = WorkDiv<Dim2>;
+  using WorkDiv1D = WorkDiv<Dim1D>;
+  using WorkDiv2D = WorkDiv<Dim2D>;
 
   template <typename TData>
-  using AlpakaHostBuf = alpaka::Buf<DevHost, TData, Dim1, Idx>;
+  using AlpakaHostBuf = alpaka::Buf<DevHost, TData, Dim1D, Idx>;
 
   template <typename TData>
-  using AlpakaHostView = alpaka::ViewPlainPtr<DevHost, TData, Dim1, Idx>;
+  using AlpakaHostView = alpaka::ViewPlainPtr<DevHost, TData, Dim1D, Idx>;
 }  // namespace alpaka_common
 
 // trick to force expanding ALPAKA_ACCELERATOR_NAMESPACE before stringification inside DEFINE_FWK_MODULE

--- a/src/alpaka/AlpakaCore/alpakaDevAcc.h
+++ b/src/alpaka/AlpakaCore/alpakaDevAcc.h
@@ -4,7 +4,7 @@
 #include "AlpakaCore/alpakaConfigAcc.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  extern const DevAcc1 device;
+  extern const Device device;
 }
 
 #endif  // ALPAKADEVICEACC_H

--- a/src/alpaka/AlpakaCore/alpakaMemoryHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaMemoryHelper.h
@@ -16,7 +16,7 @@ namespace cms {
 
     template <typename TData>
     auto createHostView(TData* data, const Extent& extent) {
-      return alpaka::ViewPlainPtr<DevHost, TData, Dim1, Idx>(data, host, extent);
+      return alpaka::ViewPlainPtr<DevHost, TData, Dim1D, Idx>(data, host, extent);
     }
 
     template <typename TData>
@@ -26,13 +26,13 @@ namespace cms {
 
     template <typename TData>
     auto createDeviceView(const TData* data, const Extent& extent) {
-      return alpaka::ViewPlainPtr<ALPAKA_ACCELERATOR_NAMESPACE::DevAcc1, const TData, Dim1, Idx>(
+      return alpaka::ViewPlainPtr<ALPAKA_ACCELERATOR_NAMESPACE::Device, const TData, Dim1D, Idx>(
           data, ALPAKA_ACCELERATOR_NAMESPACE::device, extent);
     }
 
     template <typename TData>
     auto createDeviceView(TData* data, const Extent& extent) {
-      return alpaka::ViewPlainPtr<ALPAKA_ACCELERATOR_NAMESPACE::DevAcc1, TData, Dim1, Idx>(
+      return alpaka::ViewPlainPtr<ALPAKA_ACCELERATOR_NAMESPACE::Device, TData, Dim1D, Idx>(
           data, ALPAKA_ACCELERATOR_NAMESPACE::device, extent);
     }
 

--- a/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDivHelper.h
@@ -69,7 +69,7 @@ namespace cms {
                                                                              const Idx elementIdxShift,
                                                                              const unsigned int dimIndex = 0u) {
       // Check dimension
-      //static_assert(alpaka::Dim<TAcc>::value == Dim1::value,
+      //static_assert(alpaka::Dim<TAcc>::value == Dim1D::value,
       //              "Accelerator and maxNumberOfElements need to have same dimension.");
       auto [firstElementIdxLocal, endElementIdxLocal] = element_index_range_in_block(acc, elementIdxShift, dimIndex);
 

--- a/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
@@ -12,9 +12,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     const auto blockSize = 64;
     const auto numberOfBlocks = (maxNumberOfConcurrentFits_ + blockSize - 1) / blockSize;
-    const WorkDiv1 workDivTriplets = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
-    const WorkDiv1 workDivQuadsPenta =
-        cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks / 4), Vec1::all(blockSize));
+    const WorkDiv1D workDivTriplets = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
+    const WorkDiv1D workDivQuadsPenta =
+        cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks / 4), Vec1D::all(blockSize));
 
     //  Fit internals
     auto hitsGPU_ = cms::alpakatools::allocDeviceBuf<double>(maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix3xNd<4>) /
@@ -29,105 +29,105 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
       // fit triplets
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDivTriplets,
-                                                     kernelBLFastFit<3>(),
-                                                     tuples_d,
-                                                     tupleMultiplicity_d,
-                                                     hv,
-                                                     alpaka::getPtrNative(hitsGPU_),
-                                                     alpaka::getPtrNative(hits_geGPU_),
-                                                     alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                     3,
-                                                     offset));
+                      alpaka::createTaskKernel<Acc1D>(workDivTriplets,
+                                                      kernelBLFastFit<3>(),
+                                                      tuples_d,
+                                                      tupleMultiplicity_d,
+                                                      hv,
+                                                      alpaka::getPtrNative(hitsGPU_),
+                                                      alpaka::getPtrNative(hits_geGPU_),
+                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      3,
+                                                      offset));
 
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDivTriplets,
-                                                     kernelBLFit<3>(),
-                                                     tupleMultiplicity_d,
-                                                     bField_,
-                                                     outputSoa_d,
-                                                     alpaka::getPtrNative(hitsGPU_),
-                                                     alpaka::getPtrNative(hits_geGPU_),
-                                                     alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                     3,
-                                                     offset));
+                      alpaka::createTaskKernel<Acc1D>(workDivTriplets,
+                                                      kernelBLFit<3>(),
+                                                      tupleMultiplicity_d,
+                                                      bField_,
+                                                      outputSoa_d,
+                                                      alpaka::getPtrNative(hitsGPU_),
+                                                      alpaka::getPtrNative(hits_geGPU_),
+                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      3,
+                                                      offset));
 
       // fit quads
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                     kernelBLFastFit<4>(),
-                                                     tuples_d,
-                                                     tupleMultiplicity_d,
-                                                     hv,
-                                                     alpaka::getPtrNative(hitsGPU_),
-                                                     alpaka::getPtrNative(hits_geGPU_),
-                                                     alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                     4,
-                                                     offset));
+                      alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                      kernelBLFastFit<4>(),
+                                                      tuples_d,
+                                                      tupleMultiplicity_d,
+                                                      hv,
+                                                      alpaka::getPtrNative(hitsGPU_),
+                                                      alpaka::getPtrNative(hits_geGPU_),
+                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      4,
+                                                      offset));
 
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                     kernelBLFit<4>(),
-                                                     tupleMultiplicity_d,
-                                                     bField_,
-                                                     outputSoa_d,
-                                                     alpaka::getPtrNative(hitsGPU_),
-                                                     alpaka::getPtrNative(hits_geGPU_),
-                                                     alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                     4,
-                                                     offset));
+                      alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                      kernelBLFit<4>(),
+                                                      tupleMultiplicity_d,
+                                                      bField_,
+                                                      outputSoa_d,
+                                                      alpaka::getPtrNative(hitsGPU_),
+                                                      alpaka::getPtrNative(hits_geGPU_),
+                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      4,
+                                                      offset));
 
       if (fit5as4_) {
         // fit penta (only first 4)
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                       kernelBLFastFit<4>(),
-                                                       tuples_d,
-                                                       tupleMultiplicity_d,
-                                                       hv,
-                                                       alpaka::getPtrNative(hitsGPU_),
-                                                       alpaka::getPtrNative(hits_geGPU_),
-                                                       alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                       5,
-                                                       offset));
+                        alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                        kernelBLFastFit<4>(),
+                                                        tuples_d,
+                                                        tupleMultiplicity_d,
+                                                        hv,
+                                                        alpaka::getPtrNative(hitsGPU_),
+                                                        alpaka::getPtrNative(hits_geGPU_),
+                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        5,
+                                                        offset));
 
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                       kernelBLFit<4>(),
-                                                       tupleMultiplicity_d,
-                                                       bField_,
-                                                       outputSoa_d,
-                                                       alpaka::getPtrNative(hitsGPU_),
-                                                       alpaka::getPtrNative(hits_geGPU_),
-                                                       alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                       5,
-                                                       offset));
+                        alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                        kernelBLFit<4>(),
+                                                        tupleMultiplicity_d,
+                                                        bField_,
+                                                        outputSoa_d,
+                                                        alpaka::getPtrNative(hitsGPU_),
+                                                        alpaka::getPtrNative(hits_geGPU_),
+                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        5,
+                                                        offset));
         alpaka::wait(queue);
       } else {
         // fit penta (all 5)
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                       kernelBLFastFit<5>(),
-                                                       tuples_d,
-                                                       tupleMultiplicity_d,
-                                                       hv,
-                                                       alpaka::getPtrNative(hitsGPU_),
-                                                       alpaka::getPtrNative(hits_geGPU_),
-                                                       alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                       5,
-                                                       offset));
+                        alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                        kernelBLFastFit<5>(),
+                                                        tuples_d,
+                                                        tupleMultiplicity_d,
+                                                        hv,
+                                                        alpaka::getPtrNative(hitsGPU_),
+                                                        alpaka::getPtrNative(hits_geGPU_),
+                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        5,
+                                                        offset));
 
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                       kernelBLFit<5>(),
-                                                       tupleMultiplicity_d,
-                                                       bField_,
-                                                       outputSoa_d,
-                                                       alpaka::getPtrNative(hitsGPU_),
-                                                       alpaka::getPtrNative(hits_geGPU_),
-                                                       alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                       5,
-                                                       offset));
+                        alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                        kernelBLFit<5>(),
+                                                        tupleMultiplicity_d,
+                                                        bField_,
+                                                        outputSoa_d,
+                                                        alpaka::getPtrNative(hitsGPU_),
+                                                        alpaka::getPtrNative(hits_geGPU_),
+                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        5,
+                                                        offset));
         alpaka::wait(queue);
       }
 

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.cc
@@ -9,10 +9,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // NB: MPORTANT: This could be tuned to benefit from innermost loop.
     const auto blockSize = 128;
     const auto numberOfBlocks = (HitContainer::capacity() + blockSize - 1) / blockSize;
-    const WorkDiv1 fillHitDetWorkDiv = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+    const WorkDiv1D fillHitDetWorkDiv =
+        cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
     alpaka::enqueue(
         queue,
-        alpaka::createTaskKernel<Acc1>(
+        alpaka::createTaskKernel<Acc1D>(
             fillHitDetWorkDiv, kernel_fillHitDetIndices(), &tracks_d->hitIndices, hv, &tracks_d->detIndices));
     alpaka::wait(queue);
   }
@@ -44,11 +45,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     numberOfBlocks = (3 * m_params.maxNumberOfDoublets_ / 4 + blockSize - 1) / blockSize;
     ALPAKA_ASSERT_OFFLOAD(numberOfBlocks < 65536);
     ALPAKA_ASSERT_OFFLOAD(blockSize > 0 && 0 == blockSize % 16);
-    const Vec2 blks(numberOfBlocks, 1u);
-    const Vec2 thrs(blockSize, stride);
-    const WorkDiv2 kernelConnectWorkDiv = cms::alpakatools::make_workdiv(blks, thrs);
+    const Vec2D blks(numberOfBlocks, 1u);
+    const Vec2D thrs(blockSize, stride);
+    const WorkDiv2D kernelConnectWorkDiv = cms::alpakatools::make_workdiv(blks, thrs);
     alpaka::enqueue(queue,
-                    alpaka::createTaskKernel<Acc2>(
+                    alpaka::createTaskKernel<Acc2D>(
                         kernelConnectWorkDiv,
                         kernel_connect(),
                         alpaka::getPtrNative(device_hitTuple_apc_),
@@ -70,44 +71,44 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       const uint32_t stride = 16;
       const uint32_t blockSize = nthTot / stride;
       const uint32_t numberOfBlocks = (nhits + blockSize - 1) / blockSize;
-      const Vec2 blks(numberOfBlocks, 1u);
-      const Vec2 thrs(blockSize, stride);
-      const WorkDiv2 fishboneWorkDiv = cms::alpakatools::make_workdiv(blks, thrs);
+      const Vec2D blks(numberOfBlocks, 1u);
+      const Vec2D thrs(blockSize, stride);
+      const WorkDiv2D fishboneWorkDiv = cms::alpakatools::make_workdiv(blks, thrs);
 
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc2>(fishboneWorkDiv,
-                                                     gpuPixelDoublets::fishbone(),
-                                                     hh.view(),
-                                                     alpaka::getPtrNative(device_theCells_),
-                                                     alpaka::getPtrNative(device_nCells_),
-                                                     alpaka::getPtrNative(device_isOuterHitOfCell_),
-                                                     nhits,
-                                                     false));
+                      alpaka::createTaskKernel<Acc2D>(fishboneWorkDiv,
+                                                      gpuPixelDoublets::fishbone(),
+                                                      hh.view(),
+                                                      alpaka::getPtrNative(device_theCells_),
+                                                      alpaka::getPtrNative(device_nCells_),
+                                                      alpaka::getPtrNative(device_isOuterHitOfCell_),
+                                                      nhits,
+                                                      false));
       alpaka::wait(queue);
     }
 
     blockSize = 64;
     numberOfBlocks = (3 * m_params.maxNumberOfDoublets_ / 4 + blockSize - 1) / blockSize;
-    WorkDiv1 workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+    WorkDiv1D workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
     alpaka::enqueue(queue,
-                    alpaka::createTaskKernel<Acc1>(workDiv1D,
-                                                   kernel_find_ntuplets(),
-                                                   hh.view(),
-                                                   alpaka::getPtrNative(device_theCells_),
-                                                   alpaka::getPtrNative(device_nCells_),
-                                                   alpaka::getPtrNative(device_theCellTracks_),
-                                                   tuples_d,
-                                                   alpaka::getPtrNative(device_hitTuple_apc_),
-                                                   quality_d,
-                                                   m_params.minHitsPerNtuplet_));
+                    alpaka::createTaskKernel<Acc1D>(workDiv1D,
+                                                    kernel_find_ntuplets(),
+                                                    hh.view(),
+                                                    alpaka::getPtrNative(device_theCells_),
+                                                    alpaka::getPtrNative(device_nCells_),
+                                                    alpaka::getPtrNative(device_theCellTracks_),
+                                                    tuples_d,
+                                                    alpaka::getPtrNative(device_hitTuple_apc_),
+                                                    quality_d,
+                                                    m_params.minHitsPerNtuplet_));
 
     if (m_params.doStats_) {
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDiv1D,
-                                                     kernel_mark_used(),
-                                                     hh.view(),
-                                                     alpaka::getPtrNative(device_theCells_),
-                                                     alpaka::getPtrNative(device_nCells_)));
+                      alpaka::createTaskKernel<Acc1D>(workDiv1D,
+                                                      kernel_mark_used(),
+                                                      hh.view(),
+                                                      alpaka::getPtrNative(device_theCells_),
+                                                      alpaka::getPtrNative(device_nCells_)));
     }
 
 #ifdef GPU_DEBUG
@@ -116,39 +117,39 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     blockSize = 128;
     numberOfBlocks = (HitContainer::totbins() + blockSize - 1) / blockSize;
-    workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+    workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
     alpaka::enqueue(
         queue,
-        alpaka::createTaskKernel<Acc1>(
+        alpaka::createTaskKernel<Acc1D>(
             workDiv1D, cms::alpakatools::finalizeBulk(), alpaka::getPtrNative(device_hitTuple_apc_), tuples_d));
 
     // remove duplicates (tracks that share a doublet)
     numberOfBlocks = (3 * m_params.maxNumberOfDoublets_ / 4 + blockSize - 1) / blockSize;
-    workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+    workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
     alpaka::enqueue(queue,
-                    alpaka::createTaskKernel<Acc1>(workDiv1D,
-                                                   kernel_earlyDuplicateRemover(),
-                                                   alpaka::getPtrNative(device_theCells_),
-                                                   alpaka::getPtrNative(device_nCells_),
-                                                   tuples_d,
-                                                   quality_d));
+                    alpaka::createTaskKernel<Acc1D>(workDiv1D,
+                                                    kernel_earlyDuplicateRemover(),
+                                                    alpaka::getPtrNative(device_theCells_),
+                                                    alpaka::getPtrNative(device_nCells_),
+                                                    tuples_d,
+                                                    quality_d));
 
     blockSize = 128;
     numberOfBlocks = (3 * CAConstants::maxTuples() / 4 + blockSize - 1) / blockSize;
-    workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+    workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
     alpaka::enqueue(queue,
-                    alpaka::createTaskKernel<Acc1>(workDiv1D,
-                                                   kernel_countMultiplicity(),
-                                                   tuples_d,
-                                                   quality_d,
-                                                   alpaka::getPtrNative(device_tupleMultiplicity_)));
+                    alpaka::createTaskKernel<Acc1D>(workDiv1D,
+                                                    kernel_countMultiplicity(),
+                                                    tuples_d,
+                                                    quality_d,
+                                                    alpaka::getPtrNative(device_tupleMultiplicity_)));
 
     cms::alpakatools::launchFinalize(alpaka::getPtrNative(device_tupleMultiplicity_), queue);
 
-    workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+    workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
     alpaka::enqueue(
         queue,
-        alpaka::createTaskKernel<Acc1>(
+        alpaka::createTaskKernel<Acc1D>(
             workDiv1D, kernel_fillMultiplicity(), tuples_d, quality_d, alpaka::getPtrNative(device_tupleMultiplicity_)));
 
     if (nhits > 1 && m_params.lateFishbone_) {
@@ -157,38 +158,38 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       const uint32_t blockSize = nthTot / stride;
       const uint32_t numberOfBlocks = (nhits + blockSize - 1) / blockSize;
 
-      const Vec2 blks(numberOfBlocks, 1u);
-      const Vec2 thrs(blockSize, stride);
-      const WorkDiv2 workDiv2D = cms::alpakatools::make_workdiv(blks, thrs);
+      const Vec2D blks(numberOfBlocks, 1u);
+      const Vec2D thrs(blockSize, stride);
+      const WorkDiv2D workDiv2D = cms::alpakatools::make_workdiv(blks, thrs);
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc2>(workDiv2D,
-                                                     gpuPixelDoublets::fishbone(),
-                                                     hh.view(),
-                                                     alpaka::getPtrNative(device_theCells_),
-                                                     alpaka::getPtrNative(device_nCells_),
-                                                     alpaka::getPtrNative(device_isOuterHitOfCell_),
-                                                     nhits,
-                                                     true));
+                      alpaka::createTaskKernel<Acc2D>(workDiv2D,
+                                                      gpuPixelDoublets::fishbone(),
+                                                      hh.view(),
+                                                      alpaka::getPtrNative(device_theCells_),
+                                                      alpaka::getPtrNative(device_nCells_),
+                                                      alpaka::getPtrNative(device_isOuterHitOfCell_),
+                                                      nhits,
+                                                      true));
       alpaka::wait(queue);
     }
 
     if (m_params.doStats_) {
       numberOfBlocks = (std::max(nhits, m_params.maxNumberOfDoublets_) + blockSize - 1) / blockSize;
-      workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+      workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDiv1D,
-                                                     kernel_checkOverflows(),
-                                                     tuples_d,
-                                                     alpaka::getPtrNative(device_tupleMultiplicity_),
-                                                     alpaka::getPtrNative(device_hitTuple_apc_),
-                                                     alpaka::getPtrNative(device_theCells_),
-                                                     alpaka::getPtrNative(device_nCells_),
-                                                     alpaka::getPtrNative(device_theCellNeighbors_),
-                                                     alpaka::getPtrNative(device_theCellTracks_),
-                                                     alpaka::getPtrNative(device_isOuterHitOfCell_),
-                                                     nhits,
-                                                     m_params.maxNumberOfDoublets_,
-                                                     alpaka::getPtrNative(counters_)));
+                      alpaka::createTaskKernel<Acc1D>(workDiv1D,
+                                                      kernel_checkOverflows(),
+                                                      tuples_d,
+                                                      alpaka::getPtrNative(device_tupleMultiplicity_),
+                                                      alpaka::getPtrNative(device_hitTuple_apc_),
+                                                      alpaka::getPtrNative(device_theCells_),
+                                                      alpaka::getPtrNative(device_nCells_),
+                                                      alpaka::getPtrNative(device_theCellNeighbors_),
+                                                      alpaka::getPtrNative(device_theCellTracks_),
+                                                      alpaka::getPtrNative(device_isOuterHitOfCell_),
+                                                      nhits,
+                                                      m_params.maxNumberOfDoublets_,
+                                                      alpaka::getPtrNative(counters_)));
       alpaka::wait(queue);
     }
 #ifdef GPU_DEBUG
@@ -216,16 +217,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       int threadsPerBlock = 128;
       // at least one block!
       int blocks = (std::max(1U, nhits) + threadsPerBlock - 1) / threadsPerBlock;
-      const WorkDiv1 workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(blocks), Vec1::all(threadsPerBlock));
+      const WorkDiv1D workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(blocks), Vec1D::all(threadsPerBlock));
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDiv1D,
-                                                     gpuPixelDoublets::initDoublets(),
-                                                     alpaka::getPtrNative(device_isOuterHitOfCell_),
-                                                     nhits,
-                                                     alpaka::getPtrNative(device_theCellNeighbors_),
-                                                     alpaka::getPtrNative(device_theCellNeighborsContainer_),
-                                                     alpaka::getPtrNative(device_theCellTracks_),
-                                                     alpaka::getPtrNative(device_theCellTracksContainer_)));
+                      alpaka::createTaskKernel<Acc1D>(workDiv1D,
+                                                      gpuPixelDoublets::initDoublets(),
+                                                      alpaka::getPtrNative(device_isOuterHitOfCell_),
+                                                      nhits,
+                                                      alpaka::getPtrNative(device_theCellNeighbors_),
+                                                      alpaka::getPtrNative(device_theCellNeighborsContainer_),
+                                                      alpaka::getPtrNative(device_theCellTracks_),
+                                                      alpaka::getPtrNative(device_theCellTracksContainer_)));
       alpaka::wait(queue);
     }
 
@@ -248,24 +249,24 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const uint32_t stride = 4;
     const uint32_t threadsPerBlock = gpuPixelDoublets::getDoubletsFromHistoMaxBlockSize / stride;
     const uint32_t blocks = (4 * nhits + threadsPerBlock - 1) / threadsPerBlock;
-    const Vec2 blks(blocks, 1u);
-    const Vec2 thrs(threadsPerBlock, stride);
-    const WorkDiv2 workDiv2D = cms::alpakatools::make_workdiv(blks, thrs);
+    const Vec2D blks(blocks, 1u);
+    const Vec2D thrs(threadsPerBlock, stride);
+    const WorkDiv2D workDiv2D = cms::alpakatools::make_workdiv(blks, thrs);
     alpaka::enqueue(queue,
-                    alpaka::createTaskKernel<Acc2>(workDiv2D,
-                                                   gpuPixelDoublets::getDoubletsFromHisto(),
-                                                   alpaka::getPtrNative(device_theCells_),
-                                                   alpaka::getPtrNative(device_nCells_),
-                                                   alpaka::getPtrNative(device_theCellNeighbors_),
-                                                   alpaka::getPtrNative(device_theCellTracks_),
-                                                   hh.view(),
-                                                   alpaka::getPtrNative(device_isOuterHitOfCell_),
-                                                   nActualPairs,
-                                                   m_params.idealConditions_,
-                                                   m_params.doClusterCut_,
-                                                   m_params.doZ0Cut_,
-                                                   m_params.doPtCut_,
-                                                   m_params.maxNumberOfDoublets_));
+                    alpaka::createTaskKernel<Acc2D>(workDiv2D,
+                                                    gpuPixelDoublets::getDoubletsFromHisto(),
+                                                    alpaka::getPtrNative(device_theCells_),
+                                                    alpaka::getPtrNative(device_nCells_),
+                                                    alpaka::getPtrNative(device_theCellNeighbors_),
+                                                    alpaka::getPtrNative(device_theCellTracks_),
+                                                    hh.view(),
+                                                    alpaka::getPtrNative(device_isOuterHitOfCell_),
+                                                    nActualPairs,
+                                                    m_params.idealConditions_,
+                                                    m_params.doClusterCut_,
+                                                    m_params.doZ0Cut_,
+                                                    m_params.doPtCut_,
+                                                    m_params.maxNumberOfDoublets_));
     alpaka::wait(queue);
 
 #ifdef GPU_DEBUG
@@ -282,82 +283,82 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     // classify tracks based on kinematics
     auto numberOfBlocks = (3 * CAConstants::maxNumberOfQuadruplets() / 4 + blockSize - 1) / blockSize;
-    WorkDiv1 workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+    WorkDiv1D workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
     alpaka::enqueue(queue,
-                    alpaka::createTaskKernel<Acc1>(
+                    alpaka::createTaskKernel<Acc1D>(
                         workDiv1D, kernel_classifyTracks(), tuples_d, tracks_d, m_params.cuts_, quality_d));
 
     if (m_params.lateFishbone_) {
       // apply fishbone cleaning to good tracks
       numberOfBlocks = (3 * m_params.maxNumberOfDoublets_ / 4 + blockSize - 1) / blockSize;
-      workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+      workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDiv1D,
-                                                     kernel_fishboneCleaner(),
-                                                     alpaka::getPtrNative(device_theCells_),
-                                                     alpaka::getPtrNative(device_nCells_),
-                                                     quality_d));
+                      alpaka::createTaskKernel<Acc1D>(workDiv1D,
+                                                      kernel_fishboneCleaner(),
+                                                      alpaka::getPtrNative(device_theCells_),
+                                                      alpaka::getPtrNative(device_nCells_),
+                                                      quality_d));
       alpaka::wait(queue);
     }
 
     // remove duplicates (tracks that share a doublet)
     numberOfBlocks = (3 * m_params.maxNumberOfDoublets_ / 4 + blockSize - 1) / blockSize;
-    workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+    workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
     alpaka::enqueue(queue,
-                    alpaka::createTaskKernel<Acc1>(workDiv1D,
-                                                   kernel_fastDuplicateRemover(),
-                                                   alpaka::getPtrNative(device_theCells_),
-                                                   alpaka::getPtrNative(device_nCells_),
-                                                   tuples_d,
-                                                   tracks_d));
+                    alpaka::createTaskKernel<Acc1D>(workDiv1D,
+                                                    kernel_fastDuplicateRemover(),
+                                                    alpaka::getPtrNative(device_theCells_),
+                                                    alpaka::getPtrNative(device_nCells_),
+                                                    tuples_d,
+                                                    tracks_d));
 
     if (m_params.minHitsPerNtuplet_ < 4 || m_params.doStats_) {
       // fill hit->track "map"
       numberOfBlocks = (3 * CAConstants::maxNumberOfQuadruplets() / 4 + blockSize - 1) / blockSize;
-      workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+      workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
       alpaka::enqueue(
           queue,
-          alpaka::createTaskKernel<Acc1>(
+          alpaka::createTaskKernel<Acc1D>(
               workDiv1D, kernel_countHitInTracks(), tuples_d, quality_d, alpaka::getPtrNative(device_hitToTuple_)));
 
       cms::alpakatools::launchFinalize(alpaka::getPtrNative(device_hitToTuple_), queue);
 
-      workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+      workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
       alpaka::enqueue(
           queue,
-          alpaka::createTaskKernel<Acc1>(
+          alpaka::createTaskKernel<Acc1D>(
               workDiv1D, kernel_fillHitInTracks(), tuples_d, quality_d, alpaka::getPtrNative(device_hitToTuple_)));
       alpaka::wait(queue);
     }
     if (m_params.minHitsPerNtuplet_ < 4) {
       // remove duplicates (tracks that share a hit)
       numberOfBlocks = (HitToTuple::capacity() + blockSize - 1) / blockSize;
-      workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+      workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDiv1D,
-                                                     kernel_tripletCleaner(),
-                                                     hh.view(),
-                                                     tuples_d,
-                                                     tracks_d,
-                                                     quality_d,
-                                                     alpaka::getPtrNative(device_hitToTuple_)));
+                      alpaka::createTaskKernel<Acc1D>(workDiv1D,
+                                                      kernel_tripletCleaner(),
+                                                      hh.view(),
+                                                      tuples_d,
+                                                      tracks_d,
+                                                      quality_d,
+                                                      alpaka::getPtrNative(device_hitToTuple_)));
       alpaka::wait(queue);
     }
 
     if (m_params.doStats_) {
       // counters (add flag???)
       numberOfBlocks = (HitToTuple::capacity() + blockSize - 1) / blockSize;
-      workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+      workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDiv1D,
-                                                     kernel_doStatsForHitInTracks(),
-                                                     alpaka::getPtrNative(device_hitToTuple_),
-                                                     alpaka::getPtrNative(counters_)));
+                      alpaka::createTaskKernel<Acc1D>(workDiv1D,
+                                                      kernel_doStatsForHitInTracks(),
+                                                      alpaka::getPtrNative(device_hitToTuple_),
+                                                      alpaka::getPtrNative(counters_)));
 
       numberOfBlocks = (3 * CAConstants::maxNumberOfQuadruplets() / 4 + blockSize - 1) / blockSize;
-      workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
+      workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(
+                      alpaka::createTaskKernel<Acc1D>(
                           workDiv1D, kernel_doStatsForTracks(), tuples_d, quality_d, alpaka::getPtrNative(counters_)));
       alpaka::wait(queue);
     }
@@ -368,24 +369,24 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #ifdef DUMP_GPU_TK_TUPLES
     static std::atomic<int> iev(0);
     ++iev;
-    workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(1u), Vec1::all(32u));
+    workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(1u), Vec1D::all(32u));
     alpaka::enqueue(queue,
-                    alpaka::createTaskKernel<Acc1>(workDiv1D,
-                                                   kernel_print_found_ntuplets(),
-                                                   hh.view(),
-                                                   tuples_d,
-                                                   tracks_d,
-                                                   quality_d,
-                                                   alpaka::getPtrNative(device_hitToTuple_),
-                                                   100,
-                                                   iev));
+                    alpaka::createTaskKernel<Acc1D>(workDiv1D,
+                                                    kernel_print_found_ntuplets(),
+                                                    hh.view(),
+                                                    tuples_d,
+                                                    tracks_d,
+                                                    quality_d,
+                                                    alpaka::getPtrNative(device_hitToTuple_),
+                                                    100,
+                                                    iev));
 #endif
   }
 
   void CAHitNtupletGeneratorKernels::printCounters(Queue &queue) {
-    const WorkDiv1 workDiv1D = cms::alpakatools::make_workdiv(Vec1::all(1u), Vec1::all(1u));
-    alpaka::enqueue(queue,
-                    alpaka::createTaskKernel<Acc1>(workDiv1D, kernel_printCounters(), alpaka::getPtrNative(counters_)));
+    const WorkDiv1D workDiv1D = cms::alpakatools::make_workdiv(Vec1D::all(1u), Vec1D::all(1u));
+    alpaka::enqueue(
+        queue, alpaka::createTaskKernel<Acc1D>(workDiv1D, kernel_printCounters(), alpaka::getPtrNative(counters_)));
     alpaka::wait(queue);
   }
 

--- a/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
@@ -12,9 +12,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     const auto blockSize = 64;
     const auto numberOfBlocks = (maxNumberOfConcurrentFits_ + blockSize - 1) / blockSize;
-    const WorkDiv1 workDivTriplets = cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
-    const WorkDiv1 workDivQuadsPenta =
-        cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks / 4), Vec1::all(blockSize));
+    const WorkDiv1D workDivTriplets = cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
+    const WorkDiv1D workDivQuadsPenta =
+        cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks / 4), Vec1D::all(blockSize));
 
     //  Fit internals
     auto hitsGPU_ = cms::alpakatools::allocDeviceBuf<double>(maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix3xNd<4>) /
@@ -35,157 +35,157 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
       // triplets
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDivTriplets,
-                                                     kernelFastFit<3>(),
-                                                     tuples_d,
-                                                     tupleMultiplicity_d,
-                                                     3,
-                                                     hv,
-                                                     alpaka::getPtrNative(hitsGPU_),
-                                                     alpaka::getPtrNative(hits_geGPU_),
-                                                     alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                     offset));
+                      alpaka::createTaskKernel<Acc1D>(workDivTriplets,
+                                                      kernelFastFit<3>(),
+                                                      tuples_d,
+                                                      tupleMultiplicity_d,
+                                                      3,
+                                                      hv,
+                                                      alpaka::getPtrNative(hitsGPU_),
+                                                      alpaka::getPtrNative(hits_geGPU_),
+                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      offset));
 
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDivTriplets,
-                                                     kernelCircleFit<3>(),
-                                                     tupleMultiplicity_d,
-                                                     3,
-                                                     bField_,
-                                                     alpaka::getPtrNative(hitsGPU_),
-                                                     alpaka::getPtrNative(hits_geGPU_),
-                                                     alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                     alpaka::getPtrNative(circle_fit_resultsGPU_),
-                                                     offset));
+                      alpaka::createTaskKernel<Acc1D>(workDivTriplets,
+                                                      kernelCircleFit<3>(),
+                                                      tupleMultiplicity_d,
+                                                      3,
+                                                      bField_,
+                                                      alpaka::getPtrNative(hitsGPU_),
+                                                      alpaka::getPtrNative(hits_geGPU_),
+                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                      offset));
 
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDivTriplets,
-                                                     kernelLineFit<3>(),
-                                                     tupleMultiplicity_d,
-                                                     3,
-                                                     bField_,
-                                                     outputSoa_d,
-                                                     alpaka::getPtrNative(hitsGPU_),
-                                                     alpaka::getPtrNative(hits_geGPU_),
-                                                     alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                     alpaka::getPtrNative(circle_fit_resultsGPU_),
-                                                     offset));
+                      alpaka::createTaskKernel<Acc1D>(workDivTriplets,
+                                                      kernelLineFit<3>(),
+                                                      tupleMultiplicity_d,
+                                                      3,
+                                                      bField_,
+                                                      outputSoa_d,
+                                                      alpaka::getPtrNative(hitsGPU_),
+                                                      alpaka::getPtrNative(hits_geGPU_),
+                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                      offset));
 
       // quads
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                     kernelFastFit<4>(),
-                                                     tuples_d,
-                                                     tupleMultiplicity_d,
-                                                     4,
-                                                     hv,
-                                                     alpaka::getPtrNative(hitsGPU_),
-                                                     alpaka::getPtrNative(hits_geGPU_),
-                                                     alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                     offset));
+                      alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                      kernelFastFit<4>(),
+                                                      tuples_d,
+                                                      tupleMultiplicity_d,
+                                                      4,
+                                                      hv,
+                                                      alpaka::getPtrNative(hitsGPU_),
+                                                      alpaka::getPtrNative(hits_geGPU_),
+                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      offset));
 
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                     kernelCircleFit<4>(),
-                                                     tupleMultiplicity_d,
-                                                     4,
-                                                     bField_,
-                                                     alpaka::getPtrNative(hitsGPU_),
-                                                     alpaka::getPtrNative(hits_geGPU_),
-                                                     alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                     alpaka::getPtrNative(circle_fit_resultsGPU_),
-                                                     offset));
+                      alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                      kernelCircleFit<4>(),
+                                                      tupleMultiplicity_d,
+                                                      4,
+                                                      bField_,
+                                                      alpaka::getPtrNative(hitsGPU_),
+                                                      alpaka::getPtrNative(hits_geGPU_),
+                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                      offset));
 
       alpaka::enqueue(queue,
-                      alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                     kernelLineFit<4>(),
-                                                     tupleMultiplicity_d,
-                                                     4,
-                                                     bField_,
-                                                     outputSoa_d,
-                                                     alpaka::getPtrNative(hitsGPU_),
-                                                     alpaka::getPtrNative(hits_geGPU_),
-                                                     alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                     alpaka::getPtrNative(circle_fit_resultsGPU_),
-                                                     offset));
+                      alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                      kernelLineFit<4>(),
+                                                      tupleMultiplicity_d,
+                                                      4,
+                                                      bField_,
+                                                      outputSoa_d,
+                                                      alpaka::getPtrNative(hitsGPU_),
+                                                      alpaka::getPtrNative(hits_geGPU_),
+                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                      offset));
 
       if (fit5as4_) {
         // penta
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                       kernelFastFit<4>(),
-                                                       tuples_d,
-                                                       tupleMultiplicity_d,
-                                                       5,
-                                                       hv,
-                                                       alpaka::getPtrNative(hitsGPU_),
-                                                       alpaka::getPtrNative(hits_geGPU_),
-                                                       alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                       offset));
+                        alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                        kernelFastFit<4>(),
+                                                        tuples_d,
+                                                        tupleMultiplicity_d,
+                                                        5,
+                                                        hv,
+                                                        alpaka::getPtrNative(hitsGPU_),
+                                                        alpaka::getPtrNative(hits_geGPU_),
+                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        offset));
 
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                       kernelCircleFit<4>(),
-                                                       tupleMultiplicity_d,
-                                                       5,
-                                                       bField_,
-                                                       alpaka::getPtrNative(hitsGPU_),
-                                                       alpaka::getPtrNative(hits_geGPU_),
-                                                       alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                       alpaka::getPtrNative(circle_fit_resultsGPU_),
-                                                       offset));
+                        alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                        kernelCircleFit<4>(),
+                                                        tupleMultiplicity_d,
+                                                        5,
+                                                        bField_,
+                                                        alpaka::getPtrNative(hitsGPU_),
+                                                        alpaka::getPtrNative(hits_geGPU_),
+                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                        offset));
 
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                       kernelLineFit<4>(),
-                                                       tupleMultiplicity_d,
-                                                       5,
-                                                       bField_,
-                                                       outputSoa_d,
-                                                       alpaka::getPtrNative(hitsGPU_),
-                                                       alpaka::getPtrNative(hits_geGPU_),
-                                                       alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                       alpaka::getPtrNative(circle_fit_resultsGPU_),
-                                                       offset));
+                        alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                        kernelLineFit<4>(),
+                                                        tupleMultiplicity_d,
+                                                        5,
+                                                        bField_,
+                                                        outputSoa_d,
+                                                        alpaka::getPtrNative(hitsGPU_),
+                                                        alpaka::getPtrNative(hits_geGPU_),
+                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                        offset));
         alpaka::wait(queue);
       } else {
         // penta all 5
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                       kernelFastFit<5>(),
-                                                       tuples_d,
-                                                       tupleMultiplicity_d,
-                                                       5,
-                                                       hv,
-                                                       alpaka::getPtrNative(hitsGPU_),
-                                                       alpaka::getPtrNative(hits_geGPU_),
-                                                       alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                       offset));
+                        alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                        kernelFastFit<5>(),
+                                                        tuples_d,
+                                                        tupleMultiplicity_d,
+                                                        5,
+                                                        hv,
+                                                        alpaka::getPtrNative(hitsGPU_),
+                                                        alpaka::getPtrNative(hits_geGPU_),
+                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        offset));
 
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                       kernelCircleFit<5>(),
-                                                       tupleMultiplicity_d,
-                                                       5,
-                                                       bField_,
-                                                       alpaka::getPtrNative(hitsGPU_),
-                                                       alpaka::getPtrNative(hits_geGPU_),
-                                                       alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                       alpaka::getPtrNative(circle_fit_resultsGPU_),
-                                                       offset));
+                        alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                        kernelCircleFit<5>(),
+                                                        tupleMultiplicity_d,
+                                                        5,
+                                                        bField_,
+                                                        alpaka::getPtrNative(hitsGPU_),
+                                                        alpaka::getPtrNative(hits_geGPU_),
+                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                        offset));
 
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(workDivQuadsPenta,
-                                                       kernelLineFit<5>(),
-                                                       tupleMultiplicity_d,
-                                                       5,
-                                                       bField_,
-                                                       outputSoa_d,
-                                                       alpaka::getPtrNative(hitsGPU_),
-                                                       alpaka::getPtrNative(hits_geGPU_),
-                                                       alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                       alpaka::getPtrNative(circle_fit_resultsGPU_),
-                                                       offset));
+                        alpaka::createTaskKernel<Acc1D>(workDivQuadsPenta,
+                                                        kernelLineFit<5>(),
+                                                        tupleMultiplicity_d,
+                                                        5,
+                                                        bField_,
+                                                        outputSoa_d,
+                                                        alpaka::getPtrNative(hitsGPU_),
+                                                        alpaka::getPtrNative(hits_geGPU_),
+                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                        offset));
         alpaka::wait(queue);
       }
     }

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuSortByPt2.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuSortByPt2.h
@@ -55,7 +55,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
       auto& sws = alpaka::declareSharedVar<uint16_t[1024], __COUNTER__>(acc);
       // sort using only 16 bits
-      cms::alpakatools::radixSort<Acc1, float, 2>(acc, ptv2, sortInd, sws, nvFinal);
+      cms::alpakatools::radixSort<Acc1D, float, 2>(acc, ptv2, sortInd, sws, nvFinal);
 #else
       for (uint16_t i = 0; i < nvFinal; ++i)
         sortInd[i] = i;

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
@@ -122,29 +122,29 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       const uint32_t blockSize = 128;
       const uint32_t numberOfBlocks = (TkSoA::stride() + blockSize - 1) / blockSize;
-      const WorkDiv1 loadTracksWorkDiv =
-          cms::alpakatools::make_workdiv(Vec1::all(numberOfBlocks), Vec1::all(blockSize));
-      alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1>(loadTracksWorkDiv, loadTracks(), tksoa, soa, ws_d, ptMin));
+      const WorkDiv1D loadTracksWorkDiv =
+          cms::alpakatools::make_workdiv(Vec1D::all(numberOfBlocks), Vec1D::all(blockSize));
+      alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(loadTracksWorkDiv, loadTracks(), tksoa, soa, ws_d, ptMin));
 
-      const WorkDiv1 finderSorterWorkDiv = cms::alpakatools::make_workdiv(Vec1::all(1), Vec1::all(1024 - 256));
-      const WorkDiv1 splitterFitterWorkDiv = cms::alpakatools::make_workdiv(Vec1::all(1024), Vec1::all(128));
+      const WorkDiv1D finderSorterWorkDiv = cms::alpakatools::make_workdiv(Vec1D::all(1), Vec1D::all(1024 - 256));
+      const WorkDiv1D splitterFitterWorkDiv = cms::alpakatools::make_workdiv(Vec1D::all(1024), Vec1D::all(128));
 
       if (oneKernel_) {
         // implemented only for density clustesrs
 #ifndef THREE_KERNELS
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(
+                        alpaka::createTaskKernel<Acc1D>(
                             finderSorterWorkDiv, vertexFinderOneKernel(), soa, ws_d, minT, eps, errmax, chi2max));
 
 #else
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(
+                        alpaka::createTaskKernel<Acc1D>(
                             finderSorterWorkDiv, vertexFinderKernel1(), soa, ws_d, minT, eps, errmax, chi2max));
         // one block per vertex...
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(splitterFitterWorkDiv, splitVerticesKernel(), soa, ws_d, 9.f));
+                        alpaka::createTaskKernel<Acc1D>(splitterFitterWorkDiv, splitVerticesKernel(), soa, ws_d, 9.f));
 
-        alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1>(finderSorterWorkDiv, vertexFinderKernel2(), soa, ws_d));
+        alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(finderSorterWorkDiv, vertexFinderKernel2(), soa, ws_d));
 #endif
 
       } else {  // five kernels
@@ -152,28 +152,28 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         if (useDensity_) {
           alpaka::enqueue(
               queue,
-              alpaka::createTaskKernel<Acc1>(
+              alpaka::createTaskKernel<Acc1D>(
                   finderSorterWorkDiv, clusterTracksByDensityKernel(), soa, ws_d, minT, eps, errmax, chi2max));
         } else if (useDBSCAN_) {
           alpaka::enqueue(queue,
-                          alpaka::createTaskKernel<Acc1>(
+                          alpaka::createTaskKernel<Acc1D>(
                               finderSorterWorkDiv, clusterTracksDBSCAN(), soa, ws_d, minT, eps, errmax, chi2max));
         } else if (useIterative_) {
           alpaka::enqueue(queue,
-                          alpaka::createTaskKernel<Acc1>(
+                          alpaka::createTaskKernel<Acc1D>(
                               finderSorterWorkDiv, clusterTracksIterative(), soa, ws_d, minT, eps, errmax, chi2max));
         }
 
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(finderSorterWorkDiv, fitVerticesKernel(), soa, ws_d, 50.));
+                        alpaka::createTaskKernel<Acc1D>(finderSorterWorkDiv, fitVerticesKernel(), soa, ws_d, 50.));
         // one block per vertex...
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(splitterFitterWorkDiv, splitVerticesKernel(), soa, ws_d, 9.f));
+                        alpaka::createTaskKernel<Acc1D>(splitterFitterWorkDiv, splitVerticesKernel(), soa, ws_d, 9.f));
 
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(finderSorterWorkDiv, fitVerticesKernel(), soa, ws_d, 5000.));
+                        alpaka::createTaskKernel<Acc1D>(finderSorterWorkDiv, fitVerticesKernel(), soa, ws_d, 5000.));
 
-        alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1>(finderSorterWorkDiv, sortByPt2Kernel(), soa, ws_d));
+        alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(finderSorterWorkDiv, sortByPt2Kernel(), soa, ws_d));
       }
 
       alpaka::wait(queue);

--- a/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelRecHits.cc
+++ b/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelRecHits.cc
@@ -35,8 +35,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       const int threadsPerBlockOrElementsPerThread = 128;
       const int blocks = digis_d.nModules();  // active modules (with digis)
-      const WorkDiv1& getHitsWorkDiv =
-          cms::alpakatools::make_workdiv(Vec1::all(blocks), Vec1::all(threadsPerBlockOrElementsPerThread));
+      const WorkDiv1D& getHitsWorkDiv =
+          cms::alpakatools::make_workdiv(Vec1D::all(blocks), Vec1D::all(threadsPerBlockOrElementsPerThread));
 
 #ifdef GPU_DEBUG
       std::cout << "launching getHits kernel for " << blocks << " blocks" << std::endl;
@@ -46,14 +46,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       if (blocks) {  // protect from empty events
         alpaka::enqueue(queue,
-                        alpaka::createTaskKernel<Acc1>(getHitsWorkDiv,
-                                                       gpuPixelRecHits::getHits(),
-                                                       cpeParams,
-                                                       bs_d.data(),
-                                                       digis_d.view(),
-                                                       digis_d.nDigis(),
-                                                       clusters_d.view(),
-                                                       hits_d.view()));
+                        alpaka::createTaskKernel<Acc1D>(getHitsWorkDiv,
+                                                        gpuPixelRecHits::getHits(),
+                                                        cpeParams,
+                                                        bs_d.data(),
+                                                        digis_d.view(),
+                                                        digis_d.nDigis(),
+                                                        clusters_d.view(),
+                                                        hits_d.view()));
       }
 
 #ifdef GPU_DEBUG
@@ -62,10 +62,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       // assuming full warp of threads is better than a smaller number...
       if (nHits) {
-        const WorkDiv1& oneBlockWorkDiv = cms::alpakatools::make_workdiv(Vec1::all(1u), Vec1::all(32u));
+        const WorkDiv1D& oneBlockWorkDiv = cms::alpakatools::make_workdiv(Vec1D::all(1u), Vec1D::all(32u));
         alpaka::enqueue(
             queue,
-            alpaka::createTaskKernel<Acc1>(
+            alpaka::createTaskKernel<Acc1D>(
                 oneBlockWorkDiv, setHitsLayerStart(), clusters_d.clusModuleStart(), cpeParams, hits_d.hitsLayerStart()));
       }
 

--- a/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
+++ b/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
@@ -60,11 +60,11 @@ struct verify {
 
 int main() {
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
-  const DevAcc1 device(alpaka::getDevByIdx<PltfAcc1>(0u));
+  const Device device(alpaka::getDevByIdx<Platform>(0u));
   Queue queue(device);
 
   constexpr uint32_t C = 1;
-  const Vec1 sizeC(C);
+  const Vec1D sizeC(C);
   auto c_dbuf = alpaka::allocBuf<cms::alpakatools::AtomicPairCounter, Idx>(device, sizeC);
   alpaka::memset(queue, c_dbuf, 0, sizeC);
 
@@ -72,46 +72,46 @@ int main() {
 
   constexpr uint32_t N = 20000;
   constexpr uint32_t M = N * 6;
-  const Vec1 sizeN(N);
-  const Vec1 sizeM(M);
+  const Vec1D sizeN(N);
+  const Vec1D sizeM(M);
   auto n_dbuf = alpaka::allocBuf<uint32_t, Idx>(device, sizeN);
   auto m_dbuf = alpaka::allocBuf<uint32_t, Idx>(device, sizeM);
 
   constexpr uint32_t NUM_VALUES = 10000;
 
   // Update
-  const Vec1 &blocksPerGrid(Vec1(2000u));
-  const Vec1 &threadsPerBlockOrElementsPerThread(Vec1(512u));
-  const WorkDiv1 &workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
+  const Vec1D &blocksPerGrid(Vec1D(2000u));
+  const Vec1D &threadsPerBlockOrElementsPerThread(Vec1D(512u));
+  const WorkDiv1D &workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<Acc1>(workDiv,
-                                                 update(),
-                                                 alpaka::getPtrNative(c_dbuf),
-                                                 alpaka::getPtrNative(n_dbuf),
-                                                 alpaka::getPtrNative(m_dbuf),
-                                                 NUM_VALUES));
+                  alpaka::createTaskKernel<Acc1D>(workDiv,
+                                                  update(),
+                                                  alpaka::getPtrNative(c_dbuf),
+                                                  alpaka::getPtrNative(n_dbuf),
+                                                  alpaka::getPtrNative(m_dbuf),
+                                                  NUM_VALUES));
 
   // Finalize
-  const Vec1 &blocksPerGridFinalize(Vec1(1u));
-  const Vec1 &threadsPerBlockOrElementsPerThreadFinalize(Vec1(1u));
-  const WorkDiv1 &workDivFinalize =
+  const Vec1D &blocksPerGridFinalize(Vec1D(1u));
+  const Vec1D &threadsPerBlockOrElementsPerThreadFinalize(Vec1D(1u));
+  const WorkDiv1D &workDivFinalize =
       cms::alpakatools::make_workdiv(blocksPerGridFinalize, threadsPerBlockOrElementsPerThreadFinalize);
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<Acc1>(workDivFinalize,
-                                                 finalize(),
-                                                 alpaka::getPtrNative(c_dbuf),
-                                                 alpaka::getPtrNative(n_dbuf),
-                                                 alpaka::getPtrNative(m_dbuf),
-                                                 NUM_VALUES));
+                  alpaka::createTaskKernel<Acc1D>(workDivFinalize,
+                                                  finalize(),
+                                                  alpaka::getPtrNative(c_dbuf),
+                                                  alpaka::getPtrNative(n_dbuf),
+                                                  alpaka::getPtrNative(m_dbuf),
+                                                  NUM_VALUES));
 
   // Verify
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<Acc1>(workDiv,
-                                                 verify(),
-                                                 alpaka::getPtrNative(c_dbuf),
-                                                 alpaka::getPtrNative(n_dbuf),
-                                                 alpaka::getPtrNative(m_dbuf),
-                                                 NUM_VALUES));
+                  alpaka::createTaskKernel<Acc1D>(workDiv,
+                                                  verify(),
+                                                  alpaka::getPtrNative(c_dbuf),
+                                                  alpaka::getPtrNative(n_dbuf),
+                                                  alpaka::getPtrNative(m_dbuf),
+                                                  NUM_VALUES));
 
   auto c_hbuf = alpaka::allocBuf<cms::alpakatools::AtomicPairCounter, Idx>(host, sizeC);
   alpaka::memcpy(queue, c_hbuf, c_dbuf, sizeC);

--- a/src/alpaka/test/alpaka/HistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/HistoContainer_t.cc
@@ -10,7 +10,7 @@
 
 template <typename T>
 void go(const DevHost& host,
-        const ALPAKA_ACCELERATOR_NAMESPACE::DevAcc1& device,
+        const ALPAKA_ACCELERATOR_NAMESPACE::Device& device,
         ALPAKA_ACCELERATOR_NAMESPACE::Queue& queue) {
   std::mt19937 eng;
   std::uniform_int_distribution<T> rgen(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
@@ -163,7 +163,7 @@ void go(const DevHost& host,
 
 int main() {
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
-  const ALPAKA_ACCELERATOR_NAMESPACE::DevAcc1 device(alpaka::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::PltfAcc1>(0u));
+  const ALPAKA_ACCELERATOR_NAMESPACE::Device device(alpaka::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::Platform>(0u));
   ALPAKA_ACCELERATOR_NAMESPACE::Queue queue(device);
 
   go<int16_t>(host, device, queue);

--- a/src/alpaka/test/alpaka/OneHistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/OneHistoContainer_t.cc
@@ -111,7 +111,7 @@ struct mykernel {
 
 template <typename T, int NBINS = 128, int S = 8 * sizeof(T), int DELTA = 1000>
 void go(const DevHost& host,
-        const ALPAKA_ACCELERATOR_NAMESPACE::DevAcc1& device,
+        const ALPAKA_ACCELERATOR_NAMESPACE::Device& device,
         ALPAKA_ACCELERATOR_NAMESPACE::Queue& queue) {
   std::mt19937 eng;
 
@@ -143,11 +143,11 @@ void go(const DevHost& host,
 
     alpaka::memcpy(queue, v_dbuf, v_hbuf, N);
 
-    const Vec1& threadsPerBlockOrElementsPerThread(Vec1::all(256));
-    const Vec1& blocksPerGrid(Vec1::all(1));
-    const WorkDiv1& workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
+    const Vec1D& threadsPerBlockOrElementsPerThread(Vec1D::all(256));
+    const Vec1D& blocksPerGrid(Vec1D::all(1));
+    const WorkDiv1D& workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
     alpaka::enqueue(queue,
-                    alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+                    alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
                         workDiv, mykernel<NBINS, S, DELTA>(), alpaka::getPtrNative(v_dbuf), N));
   }
   alpaka::wait(queue);
@@ -155,7 +155,7 @@ void go(const DevHost& host,
 
 int main() {
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
-  const ALPAKA_ACCELERATOR_NAMESPACE::DevAcc1 device(alpaka::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::PltfAcc1>(0u));
+  const ALPAKA_ACCELERATOR_NAMESPACE::Device device(alpaka::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::Platform>(0u));
   ALPAKA_ACCELERATOR_NAMESPACE::Queue queue(device);
 
   go<int16_t>(host, device, queue);

--- a/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
+++ b/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
@@ -133,7 +133,7 @@ struct verifyBulk {
 
 int main() {
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
-  const ALPAKA_ACCELERATOR_NAMESPACE::DevAcc1 device(alpaka::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::PltfAcc1>(0u));
+  const ALPAKA_ACCELERATOR_NAMESPACE::Device device(alpaka::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::Platform>(0u));
   ALPAKA_ACCELERATOR_NAMESPACE::Queue queue(device);
 
   std::cout << "OneToManyAssoc " << sizeof(Assoc) << ' ' << Assoc::nbins() << ' ' << Assoc::capacity() << std::endl;
@@ -188,25 +188,26 @@ int main() {
   alpaka::memset(queue, a_dbuf, 0, 1u);
 
   const unsigned int nThreads = 256;
-  const Vec1 threadsPerBlockOrElementsPerThread(nThreads);
+  const Vec1D threadsPerBlockOrElementsPerThread(nThreads);
   const unsigned int nBlocks4N = (4 * N + nThreads - 1) / nThreads;
-  const Vec1 blocksPerGrid4N(nBlocks4N);
-  const WorkDiv1& workDiv4N = cms::alpakatools::make_workdiv(blocksPerGrid4N, threadsPerBlockOrElementsPerThread);
+  const Vec1D blocksPerGrid4N(nBlocks4N);
+  const WorkDiv1D& workDiv4N = cms::alpakatools::make_workdiv(blocksPerGrid4N, threadsPerBlockOrElementsPerThread);
 
   launchZero(alpaka::getPtrNative(a_dbuf), queue);
 
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
                       workDiv4N, count(), alpaka::getPtrNative(v_dbuf), alpaka::getPtrNative(a_dbuf), N));
 
   cms::alpakatools::launchFinalize(alpaka::getPtrNative(a_dbuf), queue);
 
-  alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
-                      WorkDiv1{Vec1::all(1u), Vec1::all(1u), Vec1::all(1u)}, verify(), alpaka::getPtrNative(a_dbuf)));
+  alpaka::enqueue(
+      queue,
+      alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
+          WorkDiv1D{Vec1D::all(1u), Vec1D::all(1u), Vec1D::all(1u)}, verify(), alpaka::getPtrNative(a_dbuf)));
 
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
                       workDiv4N, fill(), alpaka::getPtrNative(v_dbuf), alpaka::getPtrNative(a_dbuf), N));
 
   auto la_hbuf = alpaka::allocBuf<Assoc, Idx>(host, 1u);
@@ -236,25 +237,25 @@ int main() {
   alpaka::memset(queue, dc_dbuf, 0, 1u);
 
   const unsigned int nBlocks = (N + nThreads - 1) / nThreads;
-  const Vec1 blocksPerGrid(nBlocks);
-  const WorkDiv1& workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
+  const Vec1D blocksPerGrid(nBlocks);
+  const WorkDiv1D& workDiv = cms::alpakatools::make_workdiv(blocksPerGrid, threadsPerBlockOrElementsPerThread);
 
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(workDiv,
-                                                                               fillBulk(),
-                                                                               alpaka::getPtrNative(dc_dbuf),
-                                                                               alpaka::getPtrNative(v_dbuf),
-                                                                               alpaka::getPtrNative(a_dbuf),
-                                                                               N));
+                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(workDiv,
+                                                                                fillBulk(),
+                                                                                alpaka::getPtrNative(dc_dbuf),
+                                                                                alpaka::getPtrNative(v_dbuf),
+                                                                                alpaka::getPtrNative(a_dbuf),
+                                                                                N));
 
   alpaka::enqueue(
       queue,
-      alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+      alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
           workDiv, cms::alpakatools::finalizeBulk(), alpaka::getPtrNative(dc_dbuf), alpaka::getPtrNative(a_dbuf)));
 
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
-                      WorkDiv1{Vec1::all(1u), Vec1::all(1u), Vec1::all(1u)},
+                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
+                      WorkDiv1D{Vec1D::all(1u), Vec1D::all(1u), Vec1D::all(1u)},
                       verifyBulk(),
                       alpaka::getPtrNative(a_dbuf),
                       alpaka::getPtrNative(dc_dbuf)));
@@ -271,21 +272,21 @@ int main() {
   alpaka::memset(queue, sa_dbuf, 0, 1u);
 
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(workDiv,
-                                                                               fillBulk(),
-                                                                               alpaka::getPtrNative(dc_dbuf),
-                                                                               alpaka::getPtrNative(v_dbuf),
-                                                                               alpaka::getPtrNative(sa_dbuf),
-                                                                               N));
+                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(workDiv,
+                                                                                fillBulk(),
+                                                                                alpaka::getPtrNative(dc_dbuf),
+                                                                                alpaka::getPtrNative(v_dbuf),
+                                                                                alpaka::getPtrNative(sa_dbuf),
+                                                                                N));
 
   alpaka::enqueue(
       queue,
-      alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+      alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
           workDiv, cms::alpakatools::finalizeBulk(), alpaka::getPtrNative(dc_dbuf), alpaka::getPtrNative(sa_dbuf)));
 
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
-                      WorkDiv1{Vec1::all(1u), Vec1::all(1u), Vec1::all(1u)},
+                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
+                      WorkDiv1D{Vec1D::all(1u), Vec1D::all(1u), Vec1D::all(1u)},
                       verifyBulk(),
                       alpaka::getPtrNative(sa_dbuf),
                       alpaka::getPtrNative(dc_dbuf)));
@@ -317,27 +318,27 @@ int main() {
   launchZero(alpaka::getPtrNative(m2_dbuf), queue);
 
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
                       workDiv4N, countMulti(), alpaka::getPtrNative(v_dbuf), alpaka::getPtrNative(m1_dbuf), N));
 
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
                       workDiv4N, countMultiLocal(), alpaka::getPtrNative(v_dbuf), alpaka::getPtrNative(m2_dbuf), N));
 
-  const Vec1 blocksPerGridTotBins(1u);
-  const Vec1 threadsPerBlockOrElementsPerThreadTotBins(Multiplicity::totbins());
-  const WorkDiv1& workDivTotBins =
+  const Vec1D blocksPerGridTotBins(1u);
+  const Vec1D threadsPerBlockOrElementsPerThreadTotBins(Multiplicity::totbins());
+  const WorkDiv1D& workDivTotBins =
       cms::alpakatools::make_workdiv(blocksPerGridTotBins, threadsPerBlockOrElementsPerThreadTotBins);
 
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
                       workDivTotBins, verifyMulti(), alpaka::getPtrNative(m1_dbuf), alpaka::getPtrNative(m2_dbuf)));
 
   cms::alpakatools::launchFinalize(alpaka::getPtrNative(m1_dbuf), queue);
   cms::alpakatools::launchFinalize(alpaka::getPtrNative(m2_dbuf), queue);
 
   alpaka::enqueue(queue,
-                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(
+                  alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(
                       workDivTotBins, verifyMulti(), alpaka::getPtrNative(m1_dbuf), alpaka::getPtrNative(m2_dbuf)));
 
   alpaka::wait(queue);

--- a/src/alpaka/test/alpaka/clustering_t.cc
+++ b/src/alpaka/test/alpaka/clustering_t.cc
@@ -18,7 +18,7 @@
 
 int main(void) {
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
-  const ALPAKA_ACCELERATOR_NAMESPACE::DevAcc1 device(alpaka::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::PltfAcc1>(0u));
+  const ALPAKA_ACCELERATOR_NAMESPACE::Device device(alpaka::getDevByIdx<ALPAKA_ACCELERATOR_NAMESPACE::Platform>(0u));
   ALPAKA_ACCELERATOR_NAMESPACE::Queue queue(device);
 
   constexpr unsigned int numElements = 256 * 2000;
@@ -250,23 +250,23 @@ int main(void) {
     // COUNT MODULES
     const int blocksPerGridCountModules =
         (numElements + threadsPerBlockOrElementsPerThread - 1) / threadsPerBlockOrElementsPerThread;
-    const WorkDiv1& workDivCountModules = cms::alpakatools::make_workdiv(Vec1::all(blocksPerGridCountModules),
-                                                                         Vec1::all(threadsPerBlockOrElementsPerThread));
+    const WorkDiv1D& workDivCountModules = cms::alpakatools::make_workdiv(
+        Vec1D::all(blocksPerGridCountModules), Vec1D::all(threadsPerBlockOrElementsPerThread));
     std::cout << "CUDA countModules kernel launch with " << blocksPerGridCountModules << " blocks of "
               << threadsPerBlockOrElementsPerThread << " threads (GPU) or elements (CPU). \n";
 
     alpaka::enqueue(
         queue,
-        alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(workDivCountModules,
-                                                                     gpuClustering::countModules(),
-                                                                     alpaka::getPtrNative(d_id_buf),
-                                                                     alpaka::getPtrNative(d_moduleStart_buf),
-                                                                     alpaka::getPtrNative(d_clus_buf),
-                                                                     n));
+        alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(workDivCountModules,
+                                                                      gpuClustering::countModules(),
+                                                                      alpaka::getPtrNative(d_id_buf),
+                                                                      alpaka::getPtrNative(d_moduleStart_buf),
+                                                                      alpaka::getPtrNative(d_clus_buf),
+                                                                      n));
 
     // FIND CLUSTER
-    const WorkDiv1& workDivMaxNumModules = cms::alpakatools::make_workdiv(
-        Vec1::all(gpuClustering::MaxNumModules), Vec1::all(threadsPerBlockOrElementsPerThread));
+    const WorkDiv1D& workDivMaxNumModules = cms::alpakatools::make_workdiv(
+        Vec1D::all(gpuClustering::MaxNumModules), Vec1D::all(threadsPerBlockOrElementsPerThread));
     std::cout << "CUDA findModules kernel launch with " << gpuClustering::MaxNumModules << " blocks of "
               << threadsPerBlockOrElementsPerThread << " threads (GPU) or elements (CPU). \n";
 
@@ -274,16 +274,16 @@ int main(void) {
 
     alpaka::enqueue(
         queue,
-        alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(workDivMaxNumModules,
-                                                                     gpuClustering::findClus(),
-                                                                     alpaka::getPtrNative(d_id_buf),
-                                                                     alpaka::getPtrNative(d_x_buf),
-                                                                     alpaka::getPtrNative(d_y_buf),
-                                                                     alpaka::getPtrNative(d_moduleStart_buf),
-                                                                     alpaka::getPtrNative(d_clusInModule_buf),
-                                                                     alpaka::getPtrNative(d_moduleId_buf),
-                                                                     alpaka::getPtrNative(d_clus_buf),
-                                                                     n));
+        alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(workDivMaxNumModules,
+                                                                      gpuClustering::findClus(),
+                                                                      alpaka::getPtrNative(d_id_buf),
+                                                                      alpaka::getPtrNative(d_x_buf),
+                                                                      alpaka::getPtrNative(d_y_buf),
+                                                                      alpaka::getPtrNative(d_moduleStart_buf),
+                                                                      alpaka::getPtrNative(d_clusInModule_buf),
+                                                                      alpaka::getPtrNative(d_moduleId_buf),
+                                                                      alpaka::getPtrNative(d_clus_buf),
+                                                                      n));
     alpaka::memcpy(queue, h_nModules_buf, d_moduleStart_buf, 1u);
 
     auto h_nclus_buf = alpaka::allocBuf<uint32_t, Idx>(host, gpuClustering::MaxNumModules);
@@ -309,15 +309,15 @@ int main(void) {
     // CLUSTER CHARGE CUT
     alpaka::enqueue(
         queue,
-        alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1>(workDivMaxNumModules,
-                                                                     gpuClustering::clusterChargeCut(),
-                                                                     alpaka::getPtrNative(d_id_buf),
-                                                                     alpaka::getPtrNative(d_adc_buf),
-                                                                     alpaka::getPtrNative(d_moduleStart_buf),
-                                                                     alpaka::getPtrNative(d_clusInModule_buf),
-                                                                     alpaka::getPtrNative(d_moduleId_buf),
-                                                                     alpaka::getPtrNative(d_clus_buf),
-                                                                     n));
+        alpaka::createTaskKernel<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D>(workDivMaxNumModules,
+                                                                      gpuClustering::clusterChargeCut(),
+                                                                      alpaka::getPtrNative(d_id_buf),
+                                                                      alpaka::getPtrNative(d_adc_buf),
+                                                                      alpaka::getPtrNative(d_moduleStart_buf),
+                                                                      alpaka::getPtrNative(d_clusInModule_buf),
+                                                                      alpaka::getPtrNative(d_moduleId_buf),
+                                                                      alpaka::getPtrNative(d_clus_buf),
+                                                                      n));
     alpaka::memcpy(queue, h_id_buf, d_id_buf, n);
     alpaka::memcpy(queue, h_clus_buf, d_clus_buf, n);
     alpaka::memcpy(queue, h_nclus_buf, d_clusInModule_buf, gpuClustering::MaxNumModules);


### PR DESCRIPTION
Rename types that are dependent on the accelerator dimensionality to make it more explicit, *e.g.* `Acc1` to `Acc1D`, *etc.*
Rename types that are not dependent on the accelerator dimensionality to remove that from the name, *e.g.* `DevAcc1` to `Device`, *etc.*