### PR TITLE
[alpaka] Replace ALPAKA_ASSERT_OFFLOAD with assert in places that should not depend on Alpaka

### DIFF
--- a/src/alpaka/DataFormats/SiPixelDigisSoA.cc
+++ b/src/alpaka/DataFormats/SiPixelDigisSoA.cc
@@ -1,7 +1,6 @@
 #include "DataFormats/SiPixelDigisSoA.h"
 
 #include <cassert>
-#include <alpaka/alpaka.hpp>
 
 SiPixelDigisSoA::SiPixelDigisSoA(
     size_t nDigis, const uint32_t *pdigi, const uint32_t *rawIdArr, const uint16_t *adc, const int32_t *clus)
@@ -9,5 +8,5 @@ SiPixelDigisSoA::SiPixelDigisSoA(
       rawIdArr_(rawIdArr, rawIdArr + nDigis),
       adc_(adc, adc + nDigis),
       clus_(clus, clus + nDigis) {
-  ALPAKA_ASSERT_OFFLOAD(pdigi_.size() == nDigis);
+  assert(pdigi_.size() == nDigis);
 }

--- a/src/alpaka/Framework/ReusableObjectHolder.h
+++ b/src/alpaka/Framework/ReusableObjectHolder.h
@@ -76,8 +76,6 @@
 #include <tbb/task.h>
 #include <tbb/concurrent_queue.h>
 
-#include <alpaka/alpaka.hpp>
-
 namespace edm {
   template <class T, class Deleter = std::default_delete<T>>
   class ReusableObjectHolder {
@@ -87,10 +85,10 @@ namespace edm {
     ReusableObjectHolder() : m_outstandingObjects(0) {}
     ReusableObjectHolder(ReusableObjectHolder&& iOther)
         : m_availableQueue(std::move(iOther.m_availableQueue)), m_outstandingObjects(0) {
-      ALPAKA_ASSERT_OFFLOAD(0 == iOther.m_outstandingObjects);
+      assert(0 == iOther.m_outstandingObjects);
     }
     ~ReusableObjectHolder() {
-      ALPAKA_ASSERT_OFFLOAD(0 == m_outstandingObjects);
+      assert(0 == m_outstandingObjects);
       std::unique_ptr<T, Deleter> item;
       while (m_availableQueue.try_pop(item)) {
         item.reset();

--- a/src/alpaka/Framework/WaitingTaskList.cc
+++ b/src/alpaka/Framework/WaitingTaskList.cc
@@ -16,8 +16,6 @@
 
 #include <tbb/task.h>
 
-#include <alpaka/alpaka.hpp>
-
 // user include files
 #include "WaitingTaskList.h"
 #include "hardware_pause.h"
@@ -53,7 +51,7 @@ void WaitingTaskList::reset() {
   m_exceptionPtr = std::exception_ptr{};
   unsigned int nSeenTasks = m_lastAssignedCacheIndex;
   m_lastAssignedCacheIndex = 0;
-  ALPAKA_ASSERT_OFFLOAD(m_head == nullptr);
+  assert(m_head == nullptr);
   if (nSeenTasks > m_nodeCacheSize) {
     //need to expand so next time we don't have to do any
     // memory requests

--- a/src/alpaka/plugin-Validation/SimpleAtomicHisto.h
+++ b/src/alpaka/plugin-Validation/SimpleAtomicHisto.h
@@ -36,7 +36,7 @@ public:
       }
       ++i;
     }
-    ALPAKA_ASSERT_OFFLOAD(i >= 0 and static_cast<unsigned int>(i) < data_.size());
+    assert(i >= 0 and static_cast<unsigned int>(i) < data_.size());
     data_[i] += 1;
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/cms-patatrack/pixeltrack-standalone/pull/242#discussion_r730900326