### PR TITLE
[alpaka] Remove unnecessary synchronisations

### DIFF
--- a/src/alpaka/AlpakaCore/HistoContainer.h
+++ b/src/alpaka/AlpakaCore/HistoContainer.h
@@ -60,7 +60,6 @@ namespace cms {
           poff, Histo::totbins());
 
       alpaka::memset(queue, histoOffView, 0, Histo::totbins());
-      alpaka::wait(queue);
     }
 
     template <typename Histo>

--- a/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
@@ -103,7 +103,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         alpaka::getPtrNative(fast_fit_resultsGPU_),
                                                         5,
                                                         offset));
-        alpaka::wait(queue);
       } else {
         // fit penta (all 5)
         alpaka::enqueue(queue,
@@ -129,7 +128,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         alpaka::getPtrNative(fast_fit_resultsGPU_),
                                                         5,
                                                         offset));
-        alpaka::wait(queue);
       }
 
     }  // loop on concurrent fits

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.cc
@@ -15,7 +15,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         queue,
         alpaka::createTaskKernel<Acc1D>(
             fillHitDetWorkDiv, kernel_fillHitDetIndices(), &tracks_d->hitIndices, hv, &tracks_d->detIndices));
-    alpaka::wait(queue);
   }
 
   void CAHitNtupletGeneratorKernels::launchKernels(HitsOnCPU const &hh, TkSoA *tracks_d, Queue &queue) {
@@ -84,7 +83,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       alpaka::getPtrNative(device_isOuterHitOfCell_),
                                                       nhits,
                                                       false));
-      alpaka::wait(queue);
     }
 
     blockSize = 64;
@@ -111,10 +109,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       alpaka::getPtrNative(device_theCells_),
                                                       alpaka::getPtrNative(device_nCells_)));
     }
-
-#ifdef GPU_DEBUG
-    alpaka::wait(queue);
-#endif
 
     blockSize = 128;
     numberOfBlocks = (HitContainer::totbins() + blockSize - 1) / blockSize;
@@ -175,7 +169,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       alpaka::getPtrNative(device_isOuterHitOfCell_),
                                                       nhits,
                                                       true));
-      alpaka::wait(queue);
     }
 
     if (m_params.doStats_) {
@@ -196,11 +189,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       nhits,
                                                       m_params.maxNumberOfDoublets_,
                                                       alpaka::getPtrNative(counters_)));
-      alpaka::wait(queue);
     }
-#ifdef GPU_DEBUG
-    alpaka::wait(queue);
-#endif
 
     // free space asap
     // device_isOuterHitOfCell_.reset();
@@ -211,10 +200,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
 #ifdef NTUPLE_DEBUG
     std::cout << "building Doublets out of " << nhits << " Hits" << std::endl;
-#endif
-
-#ifdef GPU_DEBUG
-    alpaka::wait(queue);
 #endif
 
     ALPAKA_ASSERT_OFFLOAD(alpaka::getPtrNative(device_isOuterHitOfCell_));
@@ -234,12 +219,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       alpaka::getPtrNative(device_theCellNeighborsContainer_),
                                                       alpaka::getPtrNative(device_theCellTracks_),
                                                       alpaka::getPtrNative(device_theCellTracksContainer_)));
-      alpaka::wait(queue);
     }
-
-#ifdef GPU_DEBUG
-    alpaka::wait(queue);
-#endif
 
     if (0 == nhits)
       return;  // protect against empty events
@@ -274,11 +254,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                     m_params.doZ0Cut_,
                                                     m_params.doPtCut_,
                                                     m_params.maxNumberOfDoublets_));
-    alpaka::wait(queue);
-
-#ifdef GPU_DEBUG
-    alpaka::wait(queue);
-#endif
   }
 
   void CAHitNtupletGeneratorKernels::classifyTuples(HitsOnCPU const &hh, TkSoA *tracks_d, Queue &queue) {
@@ -307,7 +282,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       alpaka::getPtrNative(device_theCells_),
                                                       alpaka::getPtrNative(device_nCells_),
                                                       quality_d));
-      alpaka::wait(queue);
     }
 
     // remove duplicates (tracks that share a doublet)
@@ -340,7 +314,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           queue,
           alpaka::createTaskKernel<Acc1D>(
               workDiv1D, kernel_fillHitInTracks(), tuples_d, quality_d, alpaka::getPtrNative(device_hitToTuple_)));
-      alpaka::wait(queue);
     }
     if (m_params.minHitsPerNtuplet_ < 4) {
       // remove duplicates (tracks that share a hit)
@@ -355,7 +328,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       tracks_d,
                                                       quality_d,
                                                       alpaka::getPtrNative(device_hitToTuple_)));
-      alpaka::wait(queue);
     }
 
     if (m_params.doStats_) {
@@ -375,11 +347,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       alpaka::enqueue(queue,
                       alpaka::createTaskKernel<Acc1D>(
                           workDiv1D, kernel_doStatsForTracks(), tuples_d, quality_d, alpaka::getPtrNative(counters_)));
-      alpaka::wait(queue);
     }
-#ifdef GPU_DEBUG
-    alpaka::wait(queue);
-#endif
 
 #ifdef DUMP_GPU_TK_TUPLES
     static std::atomic<int> iev(0);
@@ -403,7 +371,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::make_workdiv(Vec1D::all(1u), Vec1D::all(1u));
     alpaka::enqueue(
         queue, alpaka::createTaskKernel<Acc1D>(workDiv1D, kernel_printCounters(), alpaka::getPtrNative(counters_)));
-    alpaka::wait(queue);
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.h
@@ -203,9 +203,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       launchZero(alpaka::getPtrNative(device_tupleMultiplicity_), queue);
       launchZero(alpaka::getPtrNative(device_hitToTuple_), queue);
-
-      // we may wish to keep it in the edm...
-      alpaka::wait(queue);
     }
 
     ~CAHitNtupletGeneratorKernels() = default;

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorOnGPU.cc
@@ -112,7 +112,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       kernels.printCounters(queue);
     }
 
-    alpaka::wait(queue);
     return tracks;
   }
 

--- a/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
@@ -149,7 +149,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         alpaka::getPtrNative(fast_fit_resultsGPU_),
                                                         alpaka::getPtrNative(circle_fit_resultsGPU_),
                                                         offset));
-        alpaka::wait(queue);
       } else {
         // penta all 5
         alpaka::enqueue(queue,
@@ -188,7 +187,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         alpaka::getPtrNative(fast_fit_resultsGPU_),
                                                         alpaka::getPtrNative(circle_fit_resultsGPU_),
                                                         offset));
-        alpaka::wait(queue);
       }
     }
   }

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
@@ -182,7 +182,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(finderSorterWorkDiv, sortByPt2Kernel(), soa, ws_d));
       }
 
-      alpaka::wait(queue);
       return vertices;
     }
 

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
@@ -622,6 +622,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           digiErrors_d.copyErrorToHostAsync(stream);
         }
 #endif
+        // FIXME what needs to be done before we can remove the synchronisation ?
         alpaka::wait(queue);  // Wait for work to be completed before end of scope.
       }
       // End of Raw2Digi and passing data for clustering


### PR DESCRIPTION
Remove synchronisation points that should not be necessary.
Seems to give a 1-2% improvement in performance.