### PR TITLE
[alpaka] Make the CUDA dependency optional

### DIFF
--- a/src/alpaka/AlpakaCore/EventCache.h
+++ b/src/alpaka/AlpakaCore/EventCache.h
@@ -3,8 +3,6 @@
 
 #include <vector>
 
-#include <cuda_runtime.h>
-
 #include "AlpakaCore/ScopedSetDevice.h"
 #include "AlpakaCore/SharedEventPtr.h"
 #include "AlpakaCore/alpakaConfig.h"

--- a/src/alpaka/AlpakaCore/ScopedSetDevice.h
+++ b/src/alpaka/AlpakaCore/ScopedSetDevice.h
@@ -1,7 +1,9 @@
 #ifndef HeterogeneousCore_AlpakaUtilities_ScopedSetDevice_h
 #define HeterogeneousCore_AlpakaUtilities_ScopedSetDevice_h
 
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #include <cuda_runtime.h>
+#endif
 
 namespace cms::alpakatools {
 

--- a/src/alpaka/AlpakaCore/StreamCache.h
+++ b/src/alpaka/AlpakaCore/StreamCache.h
@@ -3,8 +3,6 @@
 
 #include <vector>
 
-#include <cuda_runtime.h>
-
 #include "AlpakaCore/ScopedSetDevice.h"
 #include "AlpakaCore/SharedStreamPtr.h"
 #include "AlpakaCore/currentDevice.h"

--- a/src/alpaka/AlpakaCore/alpaka/alpakaDevAcc.cc
+++ b/src/alpaka/AlpakaCore/alpaka/alpakaDevAcc.cc
@@ -1,5 +1,17 @@
 #include "AlpakaCore/alpakaDevAcc.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  const Device device = alpaka::getDevByIdx<Platform>(0u);
+
+  static
+  std::vector<ALPAKA_ACCELERATOR_NAMESPACE::Device> enumerate() {
+    std::vector<ALPAKA_ACCELERATOR_NAMESPACE::Device> devices;
+    uint32_t n = alpaka::getDevCount<ALPAKA_ACCELERATOR_NAMESPACE::Platform>();
+    devices.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+      devices.push_back(alpaka::getDevByIdx<Platform>(i));
+    }
+    return devices;
+  }
+
+  const std::vector<Device> devices = enumerate();
 }

--- a/src/alpaka/AlpakaCore/alpakaDevAcc.h
+++ b/src/alpaka/AlpakaCore/alpakaDevAcc.h
@@ -1,10 +1,12 @@
 #ifndef ALPAKADEVICEACC_H
 #define ALPAKADEVICEACC_H
 
+#include <vector>
+
 #include "AlpakaCore/alpakaConfigAcc.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  extern const Device device;
+  extern const std::vector<Device> devices;
 }
 
 #endif  // ALPAKADEVICEACC_H

--- a/src/alpaka/AlpakaCore/alpakaMemoryHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaMemoryHelper.h
@@ -20,19 +20,19 @@ namespace cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE {
 
   template <typename TData>
   auto allocDeviceBuf(const Extent& extent) {
-    return alpaka::allocBuf<TData, Idx>(::ALPAKA_ACCELERATOR_NAMESPACE::device, extent);
+    return alpaka::allocBuf<TData, Idx>(::ALPAKA_ACCELERATOR_NAMESPACE::devices[0], extent);
   }
 
   template <typename TData>
   auto createDeviceView(const TData* data, const Extent& extent) {
     return alpaka::ViewPlainPtr<::ALPAKA_ACCELERATOR_NAMESPACE::Device, const TData, Dim1D, Idx>(
-        data, ::ALPAKA_ACCELERATOR_NAMESPACE::device, extent);
+        data, ::ALPAKA_ACCELERATOR_NAMESPACE::devices[0], extent);
   }
 
   template <typename TData>
   auto createDeviceView(TData* data, const Extent& extent) {
     return alpaka::ViewPlainPtr<::ALPAKA_ACCELERATOR_NAMESPACE::Device, TData, Dim1D, Idx>(
-        data, ::ALPAKA_ACCELERATOR_NAMESPACE::device, extent);
+        data, ::ALPAKA_ACCELERATOR_NAMESPACE::devices[0], extent);
   }
 
 }  // namespace cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpaka/plugin-BeamSpotProducer/alpaka/BeamSpotToAlpaka.cc
+++ b/src/alpaka/plugin-BeamSpotProducer/alpaka/BeamSpotToAlpaka.cc
@@ -27,10 +27,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     auto const& bsRaw = iSetup.get<BeamSpotPOD>();
 
     // TO DO: Add inter-event parallelization. cms::alpaka::ScopedContextProduce?
-    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::device,
+    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::devices[0],
                                                                                iEvent.streamID()};
     BeamSpotAlpaka bsDevice(&bsRaw, ctx.stream());
-    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::device, iEvent, bsPutToken_, std::move(bsDevice));
+    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::devices[0], iEvent, bsPutToken_, std::move(bsDevice));
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletAlpaka.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletAlpaka.cc
@@ -36,9 +36,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     auto const& hits = iEvent.get(tokenHitGPU_);
 
-    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::device,
+    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::devices[0],
                                                                                iEvent.streamID()};
-    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::device,
+    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::devices[0],
                 iEvent,
                 tokenTrackGPU_,
                 gpuAlgo_.makeTuplesAsync(hits, bf, ctx.stream()));

--- a/src/alpaka/plugin-PixelTriplets/alpaka/PixelTrackSoAFromAlpaka.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/PixelTrackSoAFromAlpaka.cc
@@ -76,12 +76,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
     auto const& inputData = iEvent.get(tokenAlpaka_);
     auto outputData = ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::allocHostBuf<pixelTrack::TrackSoA>(1u);
-    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::device,
+    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::devices[0],
                                                                                iEvent.streamID()};
     alpaka::memcpy(ctx.stream(), outputData, inputData, 1u);
 
     // DO NOT  make a copy  (actually TWO....)
-    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::device, iEvent, tokenSOA_, std::move(outputData));
+    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::devices[0], iEvent, tokenSOA_, std::move(outputData));
 #endif
   }
 

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/PixelVertexProducerAlpaka.cc
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/PixelVertexProducerAlpaka.cc
@@ -51,9 +51,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     auto const& tracksBuf = iEvent.get(tokenTrack_);
     auto const tracks = alpaka::getPtrNative(tracksBuf);
 
-    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::device,
+    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::devices[0],
                                                                                iEvent.streamID()};
-    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::device,
+    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::devices[0],
                 iEvent,
                 tokenVertex_,
                 m_gpuAlgo.makeAsync(tracks, m_ptMin, ctx.stream()));

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/PixelVertexSoAFromAlpaka.cc
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/PixelVertexSoAFromAlpaka.cc
@@ -57,12 +57,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
     auto const& inputData = iEvent.get(tokenAlpaka_);
     auto outputData = ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::allocHostBuf<ZVertexSoA>(1u);
-    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::device,
+    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::devices[0],
                                                                                iEvent.streamID()};
     alpaka::memcpy(ctx.stream(), outputData, inputData, 1u);
 
     // No copies....
-    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::device, iEvent, tokenSOA_, std::move(outputData));
+    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::devices[0], iEvent, tokenSOA_, std::move(outputData));
 #endif
   }
 

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelFedCablingMapESProducer.cc
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelFedCablingMapESProducer.cc
@@ -29,7 +29,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     std::vector<unsigned char> modToUnpDefault(modToUnpDefSize);
     in.read(reinterpret_cast<char*>(modToUnpDefault.data()), modToUnpDefSize);
 
-    Queue queue(device);
+    Queue queue(devices[0]);
 
     auto cablingMap_h{
         ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::createHostView<SiPixelFedCablingMapGPU>(&obj, 1u)};

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelGainCalibrationForHLTESProducer.cc
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelGainCalibrationForHLTESProducer.cc
@@ -42,7 +42,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     std::vector<char> gainData(nbytes);
     in.read(gainData.data(), nbytes);
 
-    Queue queue(device);
+    Queue queue(devices[0]);
 
     const uint32_t numDecodingStructures = gainData.size() / sizeof(SiPixelGainForHLTonGPU_DecodingStructure);
     auto ped_h{

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToCluster.cc
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToCluster.cc
@@ -140,7 +140,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     }  // end of for loop
 
-    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::device,
+    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::devices[0],
                                                                                iEvent.streamID()};
     gpuAlgo_.makeClustersAsync(isRun2_,
                                gpuMap,
@@ -156,10 +156,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                ctx.stream());
 
     auto tmp = gpuAlgo_.getResults();
-    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::device, iEvent, digiPutToken_, std::move(tmp.first));
-    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::device, iEvent, clusterPutToken_, std::move(tmp.second));
+    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::devices[0], iEvent, digiPutToken_, std::move(tmp.first));
+    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::devices[0], iEvent, clusterPutToken_, std::move(tmp.second));
     if (includeErrors_) {
-      ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::device, iEvent, digiErrorPutToken_, gpuAlgo_.getErrors());
+      ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::devices[0], iEvent, digiErrorPutToken_, gpuAlgo_.getErrors());
     }
   }
 

--- a/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelCPEFastESProducer.cc
+++ b/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelCPEFastESProducer.cc
@@ -23,7 +23,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     std::ifstream in((data_ + "/cpefast.bin").c_str(), std::ios::binary);
     in.exceptions(std::ifstream::badbit | std::ifstream::failbit | std::ifstream::eofbit);
 
-    Queue queue(device);
+    Queue queue(devices[0]);
 
     pixelCPEforGPU::CommonParams commonParams;
     in.read(reinterpret_cast<char *>(&commonParams), sizeof(pixelCPEforGPU::CommonParams));

--- a/src/alpaka/plugin-SiPixelRecHits/alpaka/SiPixelRecHitAlpaka.cc
+++ b/src/alpaka/plugin-SiPixelRecHits/alpaka/SiPixelRecHitAlpaka.cc
@@ -54,9 +54,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
     // TO DO: Async: Would need to add a queue as a parameter, not async for now!
-    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::device,
+    ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::ScopedContextProduce ctx{::ALPAKA_ACCELERATOR_NAMESPACE::devices[0],
                                                                                iEvent.streamID()};
-    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::device,
+    ctx.emplace(::ALPAKA_ACCELERATOR_NAMESPACE::devices[0],
                 iEvent,
                 tokenHit_,
                 gpuAlgo_.makeHitsAsync(digis, clusters, bs, fcpe.params(), ctx.stream()));

--- a/src/alpaka/plugin-Validation/alpaka/HistoValidator.cc
+++ b/src/alpaka/plugin-Validation/alpaka/HistoValidator.cc
@@ -120,7 +120,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     auto const nHits = hits.nHits();
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-    Queue queue(device);
+    Queue queue(devices[0]);
     auto const h_adcBuf = digis.adcToHostAsync(queue);
     auto const h_adc = alpaka::getPtrNative(h_adcBuf);
 


### PR DESCRIPTION
Support building `alpaka` without CUDA support.
Support running without CUDA devices when `alpaka` is built with CUDA support.