### PR TITLE
[alpaka] modify hierarchy for atomics

### DIFF
--- a/src/alpaka/AlpakaCore/radixSort.h
+++ b/src/alpaka/AlpakaCore/radixSort.h
@@ -111,7 +111,7 @@ namespace cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE {
       // fill bins
       ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::for_each_element_in_block_strided(acc, size, [&](uint32_t idx) {
         auto bin = (a[j[idx]] >> d * p) & (sb - 1);
-        alpaka::atomicAdd(acc, &c[bin], 1, alpaka::hierarchy::Blocks{});
+        alpaka::atomicAdd(acc, &c[bin], 1, alpaka::hierarchy::Threads{});
       });
       alpaka::syncBlockThreads(acc);
 
@@ -159,7 +159,7 @@ namespace cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE {
           if (i >= 0) {
             bin = (a[j[i]] >> d * p) & (sb - 1);
             ct[idx] = bin;
-            alpaka::atomicMax(acc, &cu[bin], int(i), alpaka::hierarchy::Blocks{});
+            alpaka::atomicMax(acc, &cu[bin], int(i), alpaka::hierarchy::Threads{});
           }
         });
         alpaka::syncBlockThreads(acc);

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksByDensity.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksByDensity.h
@@ -194,7 +194,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
         if (iv[i] == int(i)) {
           if (nn[i] >= minT) {
-            auto old = alpaka::atomicInc(acc, &foundClusters, 0xffffffff, alpaka::hierarchy::Blocks{});
+            auto old = alpaka::atomicInc(acc, &foundClusters, 0xffffffff, alpaka::hierarchy::Threads{});
             iv[i] = -(old + 1);
           } else {  // noise
             iv[i] = -9998;

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksDBSCAN.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksDBSCAN.h
@@ -207,7 +207,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
           if (iv[i] == int(i)) {
             if (nn[i] >= minT) {
-              auto old = alpaka::atomicInc(acc, &foundClusters, 0xffffffff, alpaka::hierarchy::Blocks{});
+              auto old = alpaka::atomicInc(acc, &foundClusters, 0xffffffff, alpaka::hierarchy::Threads{});
               iv[i] = -(old + 1);
             } else {  // noise
               iv[i] = -9998;

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksIterative.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuClusterTracksIterative.h
@@ -184,7 +184,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
           if (iv[i] == int(i)) {
             if (nn[i] >= minT) {
-              auto old = alpaka::atomicInc(acc, &foundClusters, 0xffffffff, alpaka::hierarchy::Blocks{});
+              auto old = alpaka::atomicInc(acc, &foundClusters, 0xffffffff, alpaka::hierarchy::Threads{});
               iv[i] = -(old + 1);
             } else {  // noise
               iv[i] = -9998;

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuFitVertices.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuFitVertices.h
@@ -61,7 +61,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::for_each_element_in_block_strided(acc, nt, [&](uint32_t i) {
         if (iv[i] > 9990) {
           if (verbose)
-            alpaka::atomicAdd(acc, &noise, 1, alpaka::hierarchy::Blocks{});
+            alpaka::atomicAdd(acc, &noise, 1, alpaka::hierarchy::Threads{});
         } else {
           ALPAKA_ASSERT_OFFLOAD(iv[i] >= 0);
           ALPAKA_ASSERT_OFFLOAD(iv[i] < int(foundClusters));

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuSplitVertices.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuSplitVertices.h
@@ -72,7 +72,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         // copy to local
         ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::for_each_element_in_block_strided(acc, nt, [&](uint32_t k) {
           if (iv[k] == int(kv)) {
-            auto old = alpaka::atomicInc(acc, &nq, MAXTK, alpaka::hierarchy::Blocks{});
+            auto old = alpaka::atomicInc(acc, &nq, MAXTK, alpaka::hierarchy::Threads{});
             zz[old] = zt[k] - zv[kv];
             newV[old] = zz[old] < 0 ? 0 : 1;
             ww[old] = 1.f / ezt2[k];

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuSplitVertices.h
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuSplitVertices.h
@@ -102,8 +102,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
           ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::for_each_element_in_block_strided(acc, nq, [&](uint32_t k) {
             auto i = newV[k];
-            alpaka::atomicAdd(acc, &znew[i], zz[k] * ww[k], alpaka::hierarchy::Blocks{});
-            alpaka::atomicAdd(acc, &wnew[i], ww[k], alpaka::hierarchy::Blocks{});
+            alpaka::atomicAdd(acc, &znew[i], zz[k] * ww[k], alpaka::hierarchy::Threads{});
+            alpaka::atomicAdd(acc, &wnew[i], ww[k], alpaka::hierarchy::Threads{});
           });
           alpaka::syncBlockThreads(acc);
 

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/gpuClusterChargeCut.h
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/gpuClusterChargeCut.h
@@ -94,7 +94,7 @@ namespace gpuClustering {
           continue;  // not valid
         if (id[i] != thisModuleId)
           break;  // end of module
-        alpaka::atomicAdd(acc, &charge[clusterId[i]], static_cast<int32_t>(adc[i]), alpaka::hierarchy::Blocks{});
+        alpaka::atomicAdd(acc, &charge[clusterId[i]], static_cast<int32_t>(adc[i]), alpaka::hierarchy::Threads{});
       }
       alpaka::syncBlockThreads(acc);
 

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/gpuClustering.h
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/gpuClustering.h
@@ -94,7 +94,7 @@ namespace gpuClustering {
         if (id[i] == InvId)  // skip invalid pixels
           continue;
         if (id[i] != thisModuleId) {  // find the first pixel in a different module
-          alpaka::atomicMin(acc, &msize, i, alpaka::hierarchy::Blocks{});
+          alpaka::atomicMin(acc, &msize, i, alpaka::hierarchy::Threads{});
           break;
         }
       }
@@ -312,7 +312,7 @@ namespace gpuClustering {
           acc, msize, firstPixel, [&](uint32_t i) {
             if (id[i] != InvId) {  // skip invalid pixels
               if (clusterId[i] == static_cast<int>(i)) {
-                auto old = alpaka::atomicInc(acc, &foundClusters, 0xffffffff, alpaka::hierarchy::Blocks{});
+                auto old = alpaka::atomicInc(acc, &foundClusters, 0xffffffff, alpaka::hierarchy::Threads{});
                 clusterId[i] = -(old + 1);
               }
             }

--- a/src/alpaka/plugin-SiPixelRecHits/alpaka/gpuPixelRecHits.h
+++ b/src/alpaka/plugin-SiPixelRecHits/alpaka/gpuPixelRecHits.h
@@ -137,10 +137,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             cl -= startClus;
             ALPAKA_ASSERT_OFFLOAD(cl >= 0);
             ALPAKA_ASSERT_OFFLOAD(cl < MaxHitsInIter);
-            alpaka::atomicMin(acc, &clusParams.minRow[cl], x, alpaka::hierarchy::Blocks{});
-            alpaka::atomicMax(acc, &clusParams.maxRow[cl], x, alpaka::hierarchy::Blocks{});
-            alpaka::atomicMin(acc, &clusParams.minCol[cl], y, alpaka::hierarchy::Blocks{});
-            alpaka::atomicMax(acc, &clusParams.maxCol[cl], y, alpaka::hierarchy::Blocks{});
+            alpaka::atomicMin(acc, &clusParams.minRow[cl], x, alpaka::hierarchy::Threads{});
+            alpaka::atomicMax(acc, &clusParams.maxRow[cl], x, alpaka::hierarchy::Threads{});
+            alpaka::atomicMin(acc, &clusParams.minCol[cl], y, alpaka::hierarchy::Threads{});
+            alpaka::atomicMax(acc, &clusParams.maxCol[cl], y, alpaka::hierarchy::Threads{});
           }
 
           alpaka::syncBlockThreads(acc);
@@ -168,15 +168,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             const uint32_t x = digis.xx(i);
             const uint32_t y = digis.yy(i);
             const int32_t ch = std::min(digis.adc(i), pixmx);
-            alpaka::atomicAdd(acc, &clusParams.charge[cl], ch, alpaka::hierarchy::Blocks{});
+            alpaka::atomicAdd(acc, &clusParams.charge[cl], ch, alpaka::hierarchy::Threads{});
             if (clusParams.minRow[cl] == x)
-              alpaka::atomicAdd(acc, &clusParams.Q_f_X[cl], ch, alpaka::hierarchy::Blocks{});
+              alpaka::atomicAdd(acc, &clusParams.Q_f_X[cl], ch, alpaka::hierarchy::Threads{});
             if (clusParams.maxRow[cl] == x)
-              alpaka::atomicAdd(acc, &clusParams.Q_l_X[cl], ch, alpaka::hierarchy::Blocks{});
+              alpaka::atomicAdd(acc, &clusParams.Q_l_X[cl], ch, alpaka::hierarchy::Threads{});
             if (clusParams.minCol[cl] == y)
-              alpaka::atomicAdd(acc, &clusParams.Q_f_Y[cl], ch, alpaka::hierarchy::Blocks{});
+              alpaka::atomicAdd(acc, &clusParams.Q_f_Y[cl], ch, alpaka::hierarchy::Threads{});
             if (clusParams.maxCol[cl] == y)
-              alpaka::atomicAdd(acc, &clusParams.Q_l_Y[cl], ch, alpaka::hierarchy::Blocks{});
+              alpaka::atomicAdd(acc, &clusParams.Q_l_Y[cl], ch, alpaka::hierarchy::Threads{});
           }
 
           alpaka::syncBlockThreads(acc);


### PR DESCRIPTION
For atomics that operate on shared memory objects, operations don't need to be atomic among different blocks. 
The hierarchy for these atomics operations has been modified to avoid contention when running on CPU parallel backends.
Speedup of about 10% was observed with tbb backend.