### PR TITLE
[cuda,alpaka,kokkos] Add threadfence calls to be able to run 'cuda' on A100

### DIFF
--- a/src/alpaka/plugin-PixelTriplets/alpaka/GPUCACell.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/GPUCACell.h
@@ -73,6 +73,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         auto i = cellNeighbors.extend(acc);  // maybe waisted....
         if (i > 0) {
           cellNeighbors[i].reset();
+          ::cms::alpakatools::threadfence(acc);
           // Serial case does not behave properly otherwise (also observed in Kokkos)
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
           theOuterNeighbors = &cellNeighbors[i];
@@ -100,6 +101,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         auto i = cellTracks.extend(acc);  // maybe waisted....
         if (i > 0) {
           cellTracks[i].reset();
+          ::cms::alpakatools::threadfence(acc);
           // Serial case does not behave properly otherwise (also observed in Kokkos)
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
           theTracks = &cellTracks[i];

--- a/src/cuda/plugin-PixelTriplets/GPUCACell.h
+++ b/src/cuda/plugin-PixelTriplets/GPUCACell.h
@@ -70,6 +70,7 @@ public:
       auto i = cellNeighbors.extend();  // maybe waisted....
       if (i > 0) {
         cellNeighbors[i].reset();
+        __threadfence();
 #ifdef __CUDACC__
         auto zero = (ptrAsInt)(&cellNeighbors[0]);
         atomicCAS((ptrAsInt*)(&theOuterNeighbors),
@@ -90,6 +91,7 @@ public:
       auto i = cellTracks.extend();  // maybe waisted....
       if (i > 0) {
         cellTracks[i].reset();
+        __threadfence();
 #ifdef __CUDACC__
         auto zero = (ptrAsInt)(&cellTracks[0]);
         atomicCAS((ptrAsInt*)(&theTracks), zero, (ptrAsInt)(&cellTracks[i]));  // if fails we cannot give "i" back...

--- a/src/cudauvm/plugin-PixelTriplets/GPUCACell.h
+++ b/src/cudauvm/plugin-PixelTriplets/GPUCACell.h
@@ -70,6 +70,7 @@ public:
       auto i = cellNeighbors.extend();  // maybe waisted....
       if (i > 0) {
         cellNeighbors[i].reset();
+        __threadfence();
 #ifdef __CUDACC__
         auto zero = (ptrAsInt)(&cellNeighbors[0]);
         atomicCAS((ptrAsInt*)(&theOuterNeighbors),
@@ -90,6 +91,7 @@ public:
       auto i = cellTracks.extend();  // maybe waisted....
       if (i > 0) {
         cellTracks[i].reset();
+        __threadfence();
 #ifdef __CUDACC__
         auto zero = (ptrAsInt)(&cellTracks[0]);
         atomicCAS((ptrAsInt*)(&theTracks), zero, (ptrAsInt)(&cellTracks[i]));  // if fails we cannot give "i" back...

--- a/src/kokkos/plugin-PixelTriplets/GPUCACell.h
+++ b/src/kokkos/plugin-PixelTriplets/GPUCACell.h
@@ -69,6 +69,7 @@ public:
       auto i = cellNeighbors.extend();  // maybe waisted....
       if (i > 0) {
         cellNeighbors[i].reset();
+        Kokkos::memory_fence();
 #ifdef KOKKOS_BACKEND_SERIAL
         // cuda/cudacompat also do direct assignment when compiling for CPU
         theOuterNeighbors = &cellNeighbors[i];
@@ -92,6 +93,7 @@ public:
       auto i = cellTracks.extend();  // maybe waisted....
       if (i > 0) {
         cellTracks[i].reset();
+        Kokkos::memory_fence();
 #ifdef KOKKOS_BACKEND_SERIAL
         // cuda/cudacompat also do direct assignment when compiling for CPU
         theTracks = &cellTracks[i];


### PR DESCRIPTION
I experienced invalid memory errors on A100 (with CUDA 11.2 and 11.3, more frequently with 11.3 than with 11.2) with `cuda` but not with `cudadev`. Comparing the codes I found that `cudadev` had these `__threadfence()` calls that `cuda` did not. Those were added in CMSSW in https://github.com/cms-sw/cmssw/pull/34386. `cudauvm` has the same issue too.

The `alpaka` and `kokkos` programs ran fine now on A100, but I'd guess the threadfence calls would need to be propagated to those too.
