### PR TITLE
[alpaka] Remove unnecessary `__restrict__` attributes

### DIFF
--- a/src/alpaka/AlpakaCore/HistoContainer.h
+++ b/src/alpaka/AlpakaCore/HistoContainer.h
@@ -97,8 +97,8 @@ namespace cms {
     ALPAKA_FN_HOST ALPAKA_FN_INLINE __attribute__((always_inline)) void fillManyFromVector(
         Histo *__restrict__ h,
         uint32_t nh,
-        T const *__restrict__ v,
-        uint32_t const *__restrict__ offsets,
+        T const* v,
+        uint32_t const* offsets,
         uint32_t totSize,
         unsigned int nthreads,
         ::ALPAKA_ACCELERATOR_NAMESPACE::Queue &queue) {


### PR DESCRIPTION
Remove the `__restrict__` attribute on the GPU pointers used on the CPU.
