### PR TITLE
[alpaka] Fix unused variables warnings

### DIFF
--- a/src/alpaka/AlpakaCore/prefixScan.h
+++ b/src/alpaka/AlpakaCore/prefixScan.h
@@ -51,7 +51,6 @@ namespace cms {
     ) {
 #if defined ALPAKA_ACC_GPU_CUDA_ENABLED and __CUDA_ARCH__
       uint32_t const blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u]);
-      uint32_t const gridBlockIdx(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       uint32_t const blockThreadIdx(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
       assert(ws);
       ALPAKA_ASSERT_OFFLOAD(size <= 1024);
@@ -99,7 +98,6 @@ namespace cms {
     ) {
 #if defined ALPAKA_ACC_GPU_CUDA_ENABLED and __CUDA_ARCH__
       uint32_t const blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u]);
-      uint32_t const gridBlockIdx(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       uint32_t const blockThreadIdx(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
       assert(ws);
       ALPAKA_ASSERT_OFFLOAD(size <= 1024);
@@ -146,7 +144,7 @@ namespace cms {
         auto& ws = alpaka::declareSharedVar<T[32], __COUNTER__>(acc);
         // first each block does a scan of size 1024; (better be enough blocks....)
 #ifndef NDEBUG
-        uint32_t const gridDimension(alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+        [[maybe_unused]] uint32_t const gridDimension(alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
         ALPAKA_ASSERT_OFFLOAD(gridDimension / threadDimension <= 1024);
 #endif
         int off = blockDimension * blockIdx * threadDimension;

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernelsImpl.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernelsImpl.h
@@ -533,11 +533,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // fill hit indices
       auto const &hh = *hhp;
 #ifndef NDEBUG
-      auto nhits = hh.nHits();
+      [[maybe_unused]] auto nhits = hh.nHits();
 #endif
       ::cms::alpakatools::ALPAKA_ACCELERATOR_NAMESPACE::for_each_element_in_grid_strided(
           acc, tuples->size(), [&](uint32_t idx) {
+#ifndef NDEBUG
             ALPAKA_ASSERT_OFFLOAD(tuples->bins[idx] < nhits);
+#endif
             hitDetIndices->bins[idx] = hh.detectorIndex(tuples->bins[idx]);
           });
     }

--- a/src/alpaka/plugin-PixelTriplets/alpaka/gpuPixelDoublets.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/gpuPixelDoublets.h
@@ -81,12 +81,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         if (0 == threadIdx) {
           cellNeighbors->construct(CAConstants::maxNumOfActiveDoublets(), cellNeighborsContainer);
           cellTracks->construct(CAConstants::maxNumOfActiveDoublets(), cellTracksContainer);
-          auto i = cellNeighbors->extend(
-              acc);  // NB: Increases cellNeighbors size by 1, returns previous size which should be 0.
+          // NB: Increases cellNeighbors size by 1, returns previous size which should be 0.
+          [[maybe_unused]] auto i = cellNeighbors->extend(acc);
           ALPAKA_ASSERT_OFFLOAD(0 == i);
           (*cellNeighbors)[0].reset();
-          auto ii =
-              cellTracks->extend(acc);  // NB: Increases cellTracks size by 1, returns previous size which should be 0.
+          // NB: Increases cellTracks size by 1, returns previous size which should be 0
+          [[maybe_unused]] auto ii = cellTracks->extend(acc);
           ALPAKA_ASSERT_OFFLOAD(0 == ii);
           (*cellTracks)[0].reset();
         }

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
@@ -489,9 +489,9 @@ namespace pixelgpudetails {
       ALPAKA_ASSERT_OFFLOAD(gpuClustering::MaxNumModules < 2048);  // easy to extend at least till 32*1024
 
 #ifndef NDEBUG
-      const uint32_t blockIdxLocal(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+      [[maybe_unused]] const uint32_t blockIdxLocal(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       ALPAKA_ASSERT_OFFLOAD(0 == blockIdxLocal);
-      const uint32_t gridDimension(alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+      [[maybe_unused]] const uint32_t gridDimension(alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       ALPAKA_ASSERT_OFFLOAD(1 == gridDimension);
 #endif
 

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/gpuClustering.h
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/gpuClustering.h
@@ -178,7 +178,7 @@ namespace gpuClustering {
 #endif
 
 #ifndef NDEBUG
-      const uint32_t runTimeThreadDimension(alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+      [[maybe_unused]] const uint32_t runTimeThreadDimension(alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
       ALPAKA_ASSERT_OFFLOAD(runTimeThreadDimension <= threadDimension);
 #endif
 
@@ -295,7 +295,7 @@ namespace gpuClustering {
           n0 = nloops;
         alpaka::syncBlockThreads(acc);
 #ifndef NDEBUG
-        auto ok = n0 == nloops;
+        [[maybe_unused]] auto ok = n0 == nloops;
         ALPAKA_ASSERT_OFFLOAD(alpaka::syncBlockThreadsPredicate<alpaka::BlockAnd>(acc, ok));
 #endif
         if (thisModuleId % 100 == 1)


### PR DESCRIPTION
Fix warnings about unused variables:
  - remove completely unused variables;
  - mark variables that are used in `ALPAKA_ASSERT_OFFLOAD` as `[[maybe_unused]]`.