### PR TITLE
Updates to scanning scripts

### DIFF
--- a/analyze-results.py
+++ b/analyze-results.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+import json
+import argparse
+import statistics
+import collections
+
+cpuCoresSet = None
+
+def analyzeList(names, inputData, peakName):
+    data = {x:[] for x in names}
+    for meas in inputData[1:-1]: # skip first and last
+        for key, lst in data.items():
+            if key in meas:
+                lst.append(float(meas[key]))
+    peak = 0
+    for key, lst in data.items():
+        if len(lst) > 0:
+            if key == peakName:
+                peak = max(lst)
+            print(" {}: mean {:.3f} stdev {:3f} min {:3f} max {:3f}".format(key, statistics.mean(lst),
+                                                                            statistics.stdev(lst) if len(lst) > 1 else 0,
+                                                                            min(lst), max(lst)))
+    return peak
+
+def measurementKey(meas):
+    if "streams" in meas:
+        return meas["streams"]
+    return tuple(m["streams"] for m in meas["programs"])
+
+def hostMemory(data, results):
+    for res in data["results"]:
+        if not "monitor" in res:
+            continue
+        mon = res["monitor"]
+        if "host" in mon:
+            if "process" in mon["host"]:
+                print("Host:")
+                results[measurementKey(res)]["rss"].append(analyzeList(["rss"], mon["host"]["process"], "rss"))
+            elif "processes" in mon["host"]:
+                procs = mon["host"]["processes"]
+                mem = []
+                for i in range(1, len(procs[0])-1):
+                    s = 0
+                    for p in procs:
+                        s += p[i]["rss"]
+                    mem.append(dict(rss=s))
+                results[measurementKey(res)]["rss"].append(analyzeList(["rss"], mem, "rss"))
+
+def hostClock(data, results):
+    for res in data["results"]:
+        if not "monitor" in res:
+            continue
+        mon = res["monitor"]
+        if "host" in mon:
+            if "cpu" in mon["host"]:
+                for core in mon["host"]["cpu"]:
+                    if cpuCoresSet is None or int(core) in cpuCoresSet:
+                        print(core)
+                        results[measurementKey(res)]["cpuClock {}".format(core)].append(analyzeList(["clock"], mon["host"]["cpu"][core], "clock"))
+
+def cudaStats(data, results):
+    for res in data["results"]:
+        if not "monitor" in res:
+            continue
+        mon = res["monitor"]
+        if "cuda" in mon:
+            for dev in mon["cuda"]:
+                print("CUDA {}".format(dev))
+                results[measurementKey(res)]["gpuMem"].append(analyzeList(["temperature","clock","proc_mem_use"], mon["cuda"][dev], "proc_mem_use"))
+
+def throughput(data, results):
+    for res in data["results"]:
+        results[measurementKey(res)]["throughput"].append(res["throughput"])
+
+def main(opts):
+    with open(opts.file) as inp:
+        data = json.load(inp)
+
+    results = collections.defaultdict(lambda: collections.defaultdict(list))
+    throughput(data, results)
+    hostMemory(data, results)
+#    hostClock(data, results)
+    cudaStats(data, results)
+    print()
+    for st, res in results.items():
+        print("Streams {}".format(st))
+        for key, values in res.items():
+            print(" {}: mean {:.3f} stdev {:3f} min {:3f} max {:3f}".format(key, statistics.mean(values),
+                                                                            statistics.stdev(values) if len(values) > 1 else 0,
+                                                                            min(values), max(values)))
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Analyze monitoring data in result JSON files")
+    parser.add_argument("file", type=str,
+                        help="Path to JSON file to analyze")
+    opts = parser.parse_args()
+
+    main(opts)

--- a/run-many.py
+++ b/run-many.py
@@ -17,7 +17,9 @@ RunningProgram = collections.namedtuple("RunningProgram", ["program", "index", "
 class Program:
     def __init__(self, description, opts):
         s = description.split(":")
-        self._program = s[0]
+        s2 = s[0].split(" ")
+        self._program = s2[0]
+        self._programArgs = s2[1:]
         self._options = ["events", "threads","streams","numa","cores","cudaDevices"]
         valid = set(self._options)
         for o in s[1:]:
@@ -52,7 +54,7 @@ class Program:
         return self._cudaDevices
 
     def makeCommandMessage(self, opts):
-        command = [self._program]
+        command = [self._program] + self._programArgs
         if opts.runForMinutes > 0:
             command.extend(["--runForMinutes", str(opts.runForMinutes)])
         else:

--- a/run-many.py
+++ b/run-many.py
@@ -49,7 +49,7 @@ class Program:
             command = ["numactl", "--cpunodebind={}".format(self._numa), "--membind={}".format(self._numa)] + command
             msg += " NUMA node {}".format(self._numa)
         if self._cores is not None:
-            command = ["taskset", "-c", self._cores]
+            command = ["taskset", "-c", self._cores] + command
             msg += " cores {}".format(self._cores)
         if len(self._cudaDevices) > 0:
             msg += " CUDA devices {}".format(",".join(self._cudaDevices))
@@ -226,7 +226,6 @@ def main(opts):
             raise Exception("Some program asked device {} but there is no device with that id".format(d))
 
     data = dict(
-        args=" ".join(opts.args),
         results=[]
     )
     outputJson = opts.output+".json"
@@ -303,6 +302,10 @@ Measuring combined throughput of multiple programs
                         help="Declaration of many programs to run (for syntax see above).")
 
     scan.addCommonArguments(parser)
+
+    parser.add_argument("--runForMinutes", type=int, default=-1,
+                        help="Process the set of events until this many minutes has elapsed. Conflicts with --eventsPerStream and --maxStreamsToAddEvents. (default -1 for disabled)")
+
     opts = scan.parseCommonArguments(parser)
 
     main(opts)


### PR DESCRIPTION
* Minimal fixes to `run-many.py` to get it to run
* Add `--bkgThreads` option to `run-scan.py` to be able to spawn multiple background processes instead of one with many threads
* Add option to specify number of events (per program) in `run-many.py`, either as the number of events directly, or as the number of events per stream
  * When running many instances of same program with same threading settings, specifying the (same) number of events for them leads to smaller "edge effects" than running the programs for "about the same time"
* Add optional monitoring of CPU clock to `run-scan.py` and `run-many.py`
* Allow arbitrary program arguments to be passed in `run-many.py`
* Add a (work in progress) script to print out numbers from the result JSON files.