### PR TITLE
[alpaka] Use stream-ordered device memory buffers

### DIFF
--- a/src/alpaka/AlpakaCore/alpakaConfigAcc.h
+++ b/src/alpaka/AlpakaCore/alpakaConfigAcc.h
@@ -106,14 +106,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   static_assert(std::is_same_v<Device, alpaka::Dev<Event>>,
                 STRINGIFY(ALPAKA_ACCELERATOR_NAMESPACE) " has incompatible Accelerator and Event types.");
 
-  template <class TData>
-  using AlpakaAccBuf1D = alpaka::Buf<Device, TData, Dim1D, Idx>;
-
-  template <class TData>
-  using AlpakaAccBuf2D = alpaka::Buf<Device, TData, Dim2D, Idx>;
-
   template <typename TData>
-  using AlpakaDeviceBuf = AlpakaAccBuf1D<TData>;
+  using AlpakaDeviceBuf = alpaka::Buf<Device, TData, Dim1D, Idx>;
 
   template <typename TData>
   using AlpakaDeviceView = alpaka::ViewPlainPtr<Device, TData, Dim1D, Idx>;

--- a/src/alpaka/AlpakaCore/alpakaConfigCommon.h
+++ b/src/alpaka/AlpakaCore/alpakaConfigCommon.h
@@ -4,30 +4,38 @@
 #include <alpaka/alpaka.hpp>
 
 namespace alpaka_common {
+
+  // common types and dimensions
   using Idx = uint32_t;
   using Extent = uint32_t;
   using Offsets = Extent;
-  using DevHost = alpaka::DevCpu;
-  using PltfHost = alpaka::Pltf<DevHost>;
 
   using Dim1D = alpaka::DimInt<1u>;
   using Dim2D = alpaka::DimInt<2u>;
+  using Dim3D = alpaka::DimInt<3u>;
 
   template <typename TDim>
   using Vec = alpaka::Vec<TDim, Idx>;
   using Vec1D = Vec<Dim1D>;
   using Vec2D = Vec<Dim2D>;
+  using Vec3D = Vec<Dim3D>;
 
   template <typename TDim>
   using WorkDiv = alpaka::WorkDivMembers<TDim, Idx>;
   using WorkDiv1D = WorkDiv<Dim1D>;
   using WorkDiv2D = WorkDiv<Dim2D>;
+  using WorkDiv3D = WorkDiv<Dim3D>;
+
+  // host types
+  using DevHost = alpaka::DevCpu;
+  using PltfHost = alpaka::Pltf<DevHost>;
 
   template <typename TData>
   using AlpakaHostBuf = alpaka::Buf<DevHost, TData, Dim1D, Idx>;
 
   template <typename TData>
   using AlpakaHostView = alpaka::ViewPlainPtr<DevHost, TData, Dim1D, Idx>;
+
 }  // namespace alpaka_common
 
 // trick to force expanding ALPAKA_ACCELERATOR_NAMESPACE before stringification inside DEFINE_FWK_MODULE

--- a/src/alpaka/AlpakaCore/alpakaMemoryHelper.h
+++ b/src/alpaka/AlpakaCore/alpakaMemoryHelper.h
@@ -19,9 +19,9 @@ namespace cms::alpakatools {
     return alpaka::ViewPlainPtr<DevHost, TData, Dim1D, Idx>(data, host, extent);
   }
 
-  template <typename TData, typename TDevice>
-  auto allocDeviceBuf(TDevice const& device, Extent extent) {
-    return alpaka::allocBuf<TData, Idx>(device, extent);
+  template <typename TData, typename TQueue>
+  auto allocDeviceBuf(TQueue& queue, Extent extent) {
+    return alpaka::allocAsyncBuf<TData, Idx>(queue, extent);
   }
 
   template <typename TData, typename TDevice>

--- a/src/alpaka/AlpakaDataFormats/BeamSpotAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/BeamSpotAlpaka.h
@@ -14,8 +14,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     BeamSpotAlpaka() = default;
 
     // constructor that allocates cached device memory on the given queue
-    BeamSpotAlpaka(Queue const& queue)
-        : data_d_{::cms::alpakatools::allocDeviceBuf<BeamSpotPOD>(alpaka::getDev(queue), 1u)} {}
+    BeamSpotAlpaka(Queue const& queue) : data_d_{::cms::alpakatools::allocDeviceBuf<BeamSpotPOD>(queue, 1u)} {}
 
     // movable, non-copiable
     BeamSpotAlpaka(BeamSpotAlpaka const&) = delete;

--- a/src/alpaka/AlpakaDataFormats/SiPixelClustersAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/SiPixelClustersAlpaka.h
@@ -8,11 +8,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class SiPixelClustersAlpaka {
   public:
     SiPixelClustersAlpaka() = default;
-    explicit SiPixelClustersAlpaka(Device const &device, size_t maxClusters)
-        : moduleStart_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(device, maxClusters + 1)},
-          clusInModule_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(device, maxClusters)},
-          moduleId_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(device, maxClusters)},
-          clusModuleStart_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(device, maxClusters + 1)} {}
+    explicit SiPixelClustersAlpaka(Queue &queue, size_t maxClusters)
+        : moduleStart_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(queue, maxClusters + 1)},
+          clusInModule_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(queue, maxClusters)},
+          moduleId_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(queue, maxClusters)},
+          clusModuleStart_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(queue, maxClusters + 1)} {}
     ~SiPixelClustersAlpaka() = default;
 
     SiPixelClustersAlpaka(const SiPixelClustersAlpaka &) = delete;

--- a/src/alpaka/AlpakaDataFormats/SiPixelDigiErrorsAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/SiPixelDigiErrorsAlpaka.h
@@ -13,9 +13,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class SiPixelDigiErrorsAlpaka {
   public:
     SiPixelDigiErrorsAlpaka() = default;
-    explicit SiPixelDigiErrorsAlpaka(Device const& device, size_t maxFedWords, PixelFormatterErrors errors, Queue& queue)
-        : data_d{::cms::alpakatools::allocDeviceBuf<PixelErrorCompact>(device, maxFedWords)},
-          error_d{::cms::alpakatools::allocDeviceBuf<::cms::alpakatools::SimpleVector<PixelErrorCompact>>(device, 1u)},
+    explicit SiPixelDigiErrorsAlpaka(Queue& queue, size_t maxFedWords, PixelFormatterErrors errors)
+        : data_d{::cms::alpakatools::allocDeviceBuf<PixelErrorCompact>(queue, maxFedWords)},
+          error_d{::cms::alpakatools::allocDeviceBuf<::cms::alpakatools::SimpleVector<PixelErrorCompact>>(queue, 1u)},
           error_h{::cms::alpakatools::allocHostBuf<::cms::alpakatools::SimpleVector<PixelErrorCompact>>(1u)},
           formatterErrors_h{std::move(errors)} {
       auto perror_h = alpaka::getPtrNative(error_h);

--- a/src/alpaka/AlpakaDataFormats/SiPixelDigisAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/SiPixelDigisAlpaka.h
@@ -10,14 +10,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class SiPixelDigisAlpaka {
   public:
     SiPixelDigisAlpaka() = default;
-    explicit SiPixelDigisAlpaka(Device const &device, size_t maxFedWords)
-        : xx_d{::cms::alpakatools::allocDeviceBuf<uint16_t>(device, maxFedWords)},
-          yy_d{::cms::alpakatools::allocDeviceBuf<uint16_t>(device, maxFedWords)},
-          adc_d{::cms::alpakatools::allocDeviceBuf<uint16_t>(device, maxFedWords)},
-          moduleInd_d{::cms::alpakatools::allocDeviceBuf<uint16_t>(device, maxFedWords)},
-          clus_d{::cms::alpakatools::allocDeviceBuf<int32_t>(device, maxFedWords)},
-          pdigi_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(device, maxFedWords)},
-          rawIdArr_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(device, maxFedWords)} {}
+    explicit SiPixelDigisAlpaka(Queue &queue, size_t maxFedWords)
+        : xx_d{::cms::alpakatools::allocDeviceBuf<uint16_t>(queue, maxFedWords)},
+          yy_d{::cms::alpakatools::allocDeviceBuf<uint16_t>(queue, maxFedWords)},
+          adc_d{::cms::alpakatools::allocDeviceBuf<uint16_t>(queue, maxFedWords)},
+          moduleInd_d{::cms::alpakatools::allocDeviceBuf<uint16_t>(queue, maxFedWords)},
+          clus_d{::cms::alpakatools::allocDeviceBuf<int32_t>(queue, maxFedWords)},
+          pdigi_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(queue, maxFedWords)},
+          rawIdArr_d{::cms::alpakatools::allocDeviceBuf<uint32_t>(queue, maxFedWords)} {}
     ~SiPixelDigisAlpaka() = default;
 
     SiPixelDigisAlpaka(const SiPixelDigisAlpaka &) = delete;
@@ -110,4 +110,4 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
-#endif
+#endif  // CUDADataFormats_SiPixelDigi_interface_SiPixelDigisCUDA_h

--- a/src/alpaka/AlpakaDataFormats/TrackingRecHit2DAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/TrackingRecHit2DAlpaka.h
@@ -24,25 +24,24 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           // NON-OWNING DEVICE POINTERS:
           m_hitsModuleStart(hitsModuleStart),
           // OWNING DEVICE POINTERS:
-          m_xl{::cms::alpakatools::allocDeviceBuf<float>(alpaka::getDev(queue), nHits)},
-          m_yl{::cms::alpakatools::allocDeviceBuf<float>(alpaka::getDev(queue), nHits)},
-          m_xerr{::cms::alpakatools::allocDeviceBuf<float>(alpaka::getDev(queue), nHits)},
-          m_yerr{::cms::alpakatools::allocDeviceBuf<float>(alpaka::getDev(queue), nHits)},
-          m_xg{::cms::alpakatools::allocDeviceBuf<float>(alpaka::getDev(queue), nHits)},
-          m_yg{::cms::alpakatools::allocDeviceBuf<float>(alpaka::getDev(queue), nHits)},
-          m_zg{::cms::alpakatools::allocDeviceBuf<float>(alpaka::getDev(queue), nHits)},
-          m_rg{::cms::alpakatools::allocDeviceBuf<float>(alpaka::getDev(queue), nHits)},
-          m_iphi{::cms::alpakatools::allocDeviceBuf<int16_t>(alpaka::getDev(queue), nHits)},
-          m_charge{::cms::alpakatools::allocDeviceBuf<int32_t>(alpaka::getDev(queue), nHits)},
-          m_xsize{::cms::alpakatools::allocDeviceBuf<int16_t>(alpaka::getDev(queue), nHits)},
-          m_ysize{::cms::alpakatools::allocDeviceBuf<int16_t>(alpaka::getDev(queue), nHits)},
-          m_detInd{::cms::alpakatools::allocDeviceBuf<uint16_t>(alpaka::getDev(queue), nHits)},
-          m_averageGeometry{
-              ::cms::alpakatools::allocDeviceBuf<TrackingRecHit2DSOAView::AverageGeometry>(alpaka::getDev(queue), 1u)},
-          m_hitsLayerStart{::cms::alpakatools::allocDeviceBuf<uint32_t>(alpaka::getDev(queue), nHits)},
-          m_hist{::cms::alpakatools::allocDeviceBuf<Hist>(alpaka::getDev(queue), 1u)},
+          m_xl{::cms::alpakatools::allocDeviceBuf<float>(queue, nHits)},
+          m_yl{::cms::alpakatools::allocDeviceBuf<float>(queue, nHits)},
+          m_xerr{::cms::alpakatools::allocDeviceBuf<float>(queue, nHits)},
+          m_yerr{::cms::alpakatools::allocDeviceBuf<float>(queue, nHits)},
+          m_xg{::cms::alpakatools::allocDeviceBuf<float>(queue, nHits)},
+          m_yg{::cms::alpakatools::allocDeviceBuf<float>(queue, nHits)},
+          m_zg{::cms::alpakatools::allocDeviceBuf<float>(queue, nHits)},
+          m_rg{::cms::alpakatools::allocDeviceBuf<float>(queue, nHits)},
+          m_iphi{::cms::alpakatools::allocDeviceBuf<int16_t>(queue, nHits)},
+          m_charge{::cms::alpakatools::allocDeviceBuf<int32_t>(queue, nHits)},
+          m_xsize{::cms::alpakatools::allocDeviceBuf<int16_t>(queue, nHits)},
+          m_ysize{::cms::alpakatools::allocDeviceBuf<int16_t>(queue, nHits)},
+          m_detInd{::cms::alpakatools::allocDeviceBuf<uint16_t>(queue, nHits)},
+          m_averageGeometry{::cms::alpakatools::allocDeviceBuf<TrackingRecHit2DSOAView::AverageGeometry>(queue, 1u)},
+          m_hitsLayerStart{::cms::alpakatools::allocDeviceBuf<uint32_t>(queue, nHits)},
+          m_hist{::cms::alpakatools::allocDeviceBuf<Hist>(queue, 1u)},
           // SoA view:
-          m_view{::cms::alpakatools::allocDeviceBuf<TrackingRecHit2DSOAView>(alpaka::getDev(queue), 1u)},
+          m_view{::cms::alpakatools::allocDeviceBuf<TrackingRecHit2DSOAView>(queue, 1u)},
           m_view_h{::cms::alpakatools::allocHostBuf<TrackingRecHit2DSOAView>(1u)} {
       // the hits are actually accessed in order only in building
       // if ordering is relevant they may have to be stored phi-ordered by layer or so

--- a/src/alpaka/CondFormats/PixelCPEFast.h
+++ b/src/alpaka/CondFormats/PixelCPEFast.h
@@ -79,14 +79,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       GPUData() = delete;
       GPUData(Queue &queue, unsigned int ndetParams)
           : h_paramsOnGPU{::cms::alpakatools::allocHostBuf<pixelCPEforGPU::ParamsOnGPU>(1u)},
-            d_paramsOnGPU{::cms::alpakatools::allocDeviceBuf<pixelCPEforGPU::ParamsOnGPU>(alpaka::getDev(queue), 1u)},
-            d_commonParams{::cms::alpakatools::allocDeviceBuf<pixelCPEforGPU::CommonParams>(alpaka::getDev(queue), 1u)},
-            d_layerGeometry{
-                ::cms::alpakatools::allocDeviceBuf<pixelCPEforGPU::LayerGeometry>(alpaka::getDev(queue), 1u)},
-            d_averageGeometry{
-                ::cms::alpakatools::allocDeviceBuf<pixelCPEforGPU::AverageGeometry>(alpaka::getDev(queue), 1u)},
-            d_detParams{
-                ::cms::alpakatools::allocDeviceBuf<pixelCPEforGPU::DetParams>(alpaka::getDev(queue), ndetParams)} {
+            d_paramsOnGPU{::cms::alpakatools::allocDeviceBuf<pixelCPEforGPU::ParamsOnGPU>(queue, 1u)},
+            d_commonParams{::cms::alpakatools::allocDeviceBuf<pixelCPEforGPU::CommonParams>(queue, 1u)},
+            d_layerGeometry{::cms::alpakatools::allocDeviceBuf<pixelCPEforGPU::LayerGeometry>(queue, 1u)},
+            d_averageGeometry{::cms::alpakatools::allocDeviceBuf<pixelCPEforGPU::AverageGeometry>(queue, 1u)},
+            d_detParams{::cms::alpakatools::allocDeviceBuf<pixelCPEforGPU::DetParams>(queue, ndetParams)} {
         alpaka::prepareForAsyncCopy(h_paramsOnGPU);
       };
       ~GPUData() = default;

--- a/src/alpaka/CondFormats/SiPixelFedCablingMapGPUWrapper.h
+++ b/src/alpaka/CondFormats/SiPixelFedCablingMapGPUWrapper.h
@@ -60,7 +60,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     public:
       GPUData() = delete;
       GPUData(Queue const& queue)
-          : cablingMapDevice{::cms::alpakatools::allocDeviceBuf<SiPixelFedCablingMapGPU>(alpaka::getDev(queue), 1u)} {
+          : cablingMapDevice{::cms::alpakatools::allocDeviceBuf<SiPixelFedCablingMapGPU>(queue, 1u)} {
         alpaka::prepareForAsyncCopy(cablingMapDevice);
       };
       ~GPUData() = default;
@@ -73,7 +73,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     public:
       ModulesToUnpack() = delete;
       ModulesToUnpack(Queue const& queue, unsigned int modToUnpSize)
-          : modToUnpDefault{::cms::alpakatools::allocDeviceBuf<unsigned char>(alpaka::getDev(queue), modToUnpSize)} {};
+          : modToUnpDefault{::cms::alpakatools::allocDeviceBuf<unsigned char>(queue, modToUnpSize)} {};
       ~ModulesToUnpack() = default;
 
       AlpakaDeviceBuf<unsigned char> modToUnpDefault;  // pointer to GPU

--- a/src/alpaka/CondFormats/SiPixelGainCalibrationForHLTGPU.h
+++ b/src/alpaka/CondFormats/SiPixelGainCalibrationForHLTGPU.h
@@ -43,10 +43,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     public:
       GPUData() = delete;
       GPUData(Queue const& queue, unsigned int numDecodingStructures)
-          : gainForHLTonGPU{::cms::alpakatools::allocDeviceBuf<SiPixelGainForHLTonGPU>(alpaka::getDev(queue), 1u)},
+          : gainForHLTonGPU{::cms::alpakatools::allocDeviceBuf<SiPixelGainForHLTonGPU>(queue, 1u)},
             gainDataOnGPU{::cms::alpakatools::allocHostBuf<SiPixelGainForHLTonGPU>(1u)},
-            v_pedestalsGPU{
-                ::cms::alpakatools::allocDeviceBuf<DecodingStructure>(alpaka::getDev(queue), numDecodingStructures)} {
+            v_pedestalsGPU{::cms::alpakatools::allocDeviceBuf<DecodingStructure>(queue, numDecodingStructures)} {
         alpaka::prepareForAsyncCopy(gainDataOnGPU);
       };
       ~GPUData() = default;

--- a/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
@@ -19,13 +19,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     //  Fit internals
     auto hitsGPU_ = ::cms::alpakatools::allocDeviceBuf<double>(
-        alpaka::getDev(queue), maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix3xNd<4>) / sizeof(double));
-
+        queue, maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix3xNd<4>) / sizeof(double));
     auto hits_geGPU_ = ::cms::alpakatools::allocDeviceBuf<float>(
-        alpaka::getDev(queue), maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix6x4f) / sizeof(float));
-
+        queue, maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix6x4f) / sizeof(float));
     auto fast_fit_resultsGPU_ = ::cms::alpakatools::allocDeviceBuf<double>(
-        alpaka::getDev(queue), maxNumberOfConcurrentFits_ * sizeof(Rfit::Vector4d) / sizeof(double));
+        queue, maxNumberOfConcurrentFits_ * sizeof(Rfit::Vector4d) / sizeof(double));
 
     for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
       // fit triplets

--- a/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
@@ -129,9 +129,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       }
 
     }  // loop on concurrent fits
-
-    // FIXME: the wait is needed to avoid that the device buffers go out of scope before the kernels have run
-    alpaka::wait(queue);
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.h
@@ -163,37 +163,32 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           //////////////////////////////////////////////////////////
           // ALLOCATIONS FOR THE INTERMEDIATE RESULTS (STAYS ON WORKER)
           //////////////////////////////////////////////////////////
-          counters_{::cms::alpakatools::allocDeviceBuf<Counters>(alpaka::getDev(queue), 1u)},
+          counters_{::cms::alpakatools::allocDeviceBuf<Counters>(queue, 1u)},
 
-          device_hitToTuple_{::cms::alpakatools::allocDeviceBuf<HitToTuple>(alpaka::getDev(queue), 1u)},
-          device_tupleMultiplicity_{::cms::alpakatools::allocDeviceBuf<TupleMultiplicity>(alpaka::getDev(queue), 1u)},
+          device_hitToTuple_{::cms::alpakatools::allocDeviceBuf<HitToTuple>(queue, 1u)},
+          device_tupleMultiplicity_{::cms::alpakatools::allocDeviceBuf<TupleMultiplicity>(queue, 1u)},
 
-          device_theCells_{
-              ::cms::alpakatools::allocDeviceBuf<GPUCACell>(alpaka::getDev(queue), params.maxNumberOfDoublets_)},
+          device_theCells_{::cms::alpakatools::allocDeviceBuf<GPUCACell>(queue, params.maxNumberOfDoublets_)},
           // in principle we can use "nhits" to heuristically dimension the workspace...
-          device_isOuterHitOfCell_{::cms::alpakatools::allocDeviceBuf<GPUCACell::OuterHitOfCell>(alpaka::getDev(queue),
-                                                                                                 std::max(1U, nhits))},
+          device_isOuterHitOfCell_{
+              ::cms::alpakatools::allocDeviceBuf<GPUCACell::OuterHitOfCell>(queue, std::max(1U, nhits))},
 
-          device_theCellNeighbors_{
-              ::cms::alpakatools::allocDeviceBuf<CAConstants::CellNeighborsVector>(alpaka::getDev(queue), 1u)},
-          device_theCellTracks_{
-              ::cms::alpakatools::allocDeviceBuf<CAConstants::CellTracksVector>(alpaka::getDev(queue), 1u)},
+          device_theCellNeighbors_{::cms::alpakatools::allocDeviceBuf<CAConstants::CellNeighborsVector>(queue, 1u)},
+          device_theCellTracks_{::cms::alpakatools::allocDeviceBuf<CAConstants::CellTracksVector>(queue, 1u)},
 
-          //cellStorage_{::cms::alpakatools::allocDeviceBuf<unsigned char>(alpaka::getDev(queue), CAConstants::maxNumOfActiveDoublets() * sizeof(GPUCACell::CellNeighbors) + CAConstants::maxNumOfActiveDoublets() * sizeof(GPUCACell::CellTracks))},
+          //cellStorage_{::cms::alpakatools::allocDeviceBuf<unsigned char>(queue, CAConstants::maxNumOfActiveDoublets() * sizeof(GPUCACell::CellNeighbors) + CAConstants::maxNumOfActiveDoublets() * sizeof(GPUCACell::CellTracks))},
           device_theCellNeighborsContainer_{::cms::alpakatools::allocDeviceBuf<CAConstants::CellNeighbors>(
-              alpaka::getDev(queue), CAConstants::maxNumOfActiveDoublets())},
+              queue, CAConstants::maxNumOfActiveDoublets())},
           device_theCellTracksContainer_{::cms::alpakatools::allocDeviceBuf<CAConstants::CellTracks>(
-              alpaka::getDev(queue), CAConstants::maxNumOfActiveDoublets())},
+              queue, CAConstants::maxNumOfActiveDoublets())},
 
-          //device_storage_{::cms::alpakatools::allocDeviceBuf<::ALPAKA_ACCELERATOR_NAMESPACE::cmscuda::AtomicPairCounter::c_type>(alpaka::getDev(queue), 3u)},
+          //device_storage_{::cms::alpakatools::allocDeviceBuf<::ALPAKA_ACCELERATOR_NAMESPACE::cmscuda::AtomicPairCounter::c_type>(queue, 3u)},
           //device_hitTuple_apc_ = (::cms::alpakatools::AtomicPairCounter*)device_storage_.get()},
           //device_hitToTuple_apc_ = (::cms::alpakatools::AtomicPairCounter*)device_storage_.get() + 1;
           //device_nCells_ = (uint32_t*)(device_storage_.get() + 2)},
-          device_hitTuple_apc_{
-              ::cms::alpakatools::allocDeviceBuf<::cms::alpakatools::AtomicPairCounter>(alpaka::getDev(queue), 1u)},
-          device_hitToTuple_apc_{
-              ::cms::alpakatools::allocDeviceBuf<::cms::alpakatools::AtomicPairCounter>(alpaka::getDev(queue), 1u)},
-          device_nCells_{::cms::alpakatools::allocDeviceBuf<uint32_t>(alpaka::getDev(queue), 1u)} {
+          device_hitTuple_apc_{::cms::alpakatools::allocDeviceBuf<::cms::alpakatools::AtomicPairCounter>(queue, 1u)},
+          device_hitToTuple_apc_{::cms::alpakatools::allocDeviceBuf<::cms::alpakatools::AtomicPairCounter>(queue, 1u)},
+          device_nCells_{::cms::alpakatools::allocDeviceBuf<uint32_t>(queue, 1u)} {
       alpaka::memset(queue, counters_, 0, 1u);
 
       alpaka::memset(queue, device_nCells_, 0, 1u);

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.h
@@ -195,9 +195,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       launchZero(alpaka::getPtrNative(device_tupleMultiplicity_), queue);
       launchZero(alpaka::getPtrNative(device_hitToTuple_), queue);
-
-      // we may wish to keep it in the edm...
-      alpaka::wait(queue);
     }
 
     ~CAHitNtupletGeneratorKernels() = default;

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorOnGPU.cc
@@ -111,8 +111,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       kernels.printCounters(queue);
     }
 
-    // FIXME: the wait is needed to avoid that the device buffers inside "kernels" go out of scope before the kernels have run
-    alpaka::wait(queue);
     return tracks;
   }
 

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorOnGPU.cc
@@ -7,6 +7,7 @@
 #include <functional>
 #include <vector>
 
+#include "AlpakaDataFormats/PixelTrackAlpaka.h"
 #include "Framework/Event.h"
 
 #include "CAHitNtupletGeneratorOnGPU.h"
@@ -86,12 +87,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif
   }
 
-  CAHitNtupletGeneratorOnGPU::~CAHitNtupletGeneratorOnGPU() {}
-
   PixelTrackAlpaka CAHitNtupletGeneratorOnGPU::makeTuplesAsync(TrackingRecHit2DAlpaka const& hits_d,
                                                                float bfield,
                                                                Queue& queue) const {
-    PixelTrackAlpaka tracks{::cms::alpakatools::allocDeviceBuf<pixelTrack::TrackSoA>(alpaka::getDev(queue), 1u)};
+    PixelTrackAlpaka tracks = ::cms::alpakatools::allocDeviceBuf<pixelTrack::TrackSoA>(queue, 1u);
     auto* soa = alpaka::getPtrNative(tracks);
 
     CAHitNtupletGeneratorKernels kernels(m_params, hits_d.nHits(), queue);

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorOnGPU.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorOnGPU.h
@@ -34,8 +34,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   public:
     CAHitNtupletGeneratorOnGPU(edm::ProductRegistry& reg);
-
-    ~CAHitNtupletGeneratorOnGPU();
+    ~CAHitNtupletGeneratorOnGPU() = default;
 
     PixelTrackAlpaka makeTuplesAsync(TrackingRecHit2DAlpaka const& hits_d, float bfield, Queue& queue) const;
 

--- a/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
@@ -186,9 +186,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         alpaka::getPtrNative(circle_fit_resultsGPU_),
                                                         offset));
       }
-
-      // FIXME: the wait is needed to avoid that the device buffers go out of scope before the kernels have run
-      alpaka::wait(queue);
     }
   }
 

--- a/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
@@ -19,20 +19,18 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     //  Fit internals
     auto hitsGPU_ = ::cms::alpakatools::allocDeviceBuf<double>(
-        alpaka::getDev(queue), maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix3xNd<4>) / sizeof(double));
-
+        queue, maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix3xNd<4>) / sizeof(double));
     auto hits_geGPU_ = ::cms::alpakatools::allocDeviceBuf<float>(
-        alpaka::getDev(queue), maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix6x4f) / sizeof(float));
-
+        queue, maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix6x4f) / sizeof(float));
     auto fast_fit_resultsGPU_ = ::cms::alpakatools::allocDeviceBuf<double>(
-        alpaka::getDev(queue), maxNumberOfConcurrentFits_ * sizeof(Rfit::Vector4d) / sizeof(double));
+        queue, maxNumberOfConcurrentFits_ * sizeof(Rfit::Vector4d) / sizeof(double));
 
     //auto circle_fit_resultsGPU_holder =
     //::cms::alpakatools::make_device_unique<char[]>(maxNumberOfConcurrentFits_ * sizeof(Rfit::circle_fit), stream);
     //Rfit::circle_fit *circle_fit_resultsGPU_ = (Rfit::circle_fit *)(circle_fit_resultsGPU_holder.get());
-    //auto circle_fit_resultsGPU_holder = ::cms::alpakatools::allocDeviceBuf<char>(alpaka::getDev(queue), maxNumberOfConcurrentFits_ * sizeof(Rfit::circle_fit));
+    //auto circle_fit_resultsGPU_holder = ::cms::alpakatools::allocDeviceBuf<char>(queue, maxNumberOfConcurrentFits_ * sizeof(Rfit::circle_fit));
     auto circle_fit_resultsGPU_ =
-        ::cms::alpakatools::allocDeviceBuf<Rfit::circle_fit>(alpaka::getDev(queue), maxNumberOfConcurrentFits_);
+        ::cms::alpakatools::allocDeviceBuf<Rfit::circle_fit>(queue, maxNumberOfConcurrentFits_);
 
     for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
       // triplets

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
@@ -183,8 +183,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(finderSorterWorkDiv, sortByPt2Kernel(), soa, ws_d));
       }
 
-      // FIXME: the wait is needed to avoid that ws_dBuf goes out of scope before the kernels have run
-      alpaka::wait(queue);
       return vertices;
     }
 

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
@@ -109,11 +109,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // std::cout << "producing Vertices on GPU" << std::endl;
       ALPAKA_ASSERT_OFFLOAD(tksoa);
 
-      ZVertexAlpaka vertices = ::cms::alpakatools::allocDeviceBuf<ZVertexSoA>(alpaka::getDev(queue), 1u);
+      ZVertexAlpaka vertices = ::cms::alpakatools::allocDeviceBuf<ZVertexSoA>(queue, 1u);
       auto* soa = alpaka::getPtrNative(vertices);
       ALPAKA_ASSERT_OFFLOAD(soa);
 
-      auto ws_dBuf{::cms::alpakatools::allocDeviceBuf<WorkSpace>(alpaka::getDev(queue), 1u)};
+      auto ws_dBuf{::cms::alpakatools::allocDeviceBuf<WorkSpace>(queue, 1u)};
       auto ws_d = alpaka::getPtrNative(ws_dBuf);
 
       auto nvFinalVerticesView =

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
@@ -565,12 +565,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       std::cout << "decoding " << wordCounter << " digis. Max is " << pixelgpudetails::MAX_FED_WORDS << std::endl;
 #endif
 
-      digis_d = SiPixelDigisAlpaka(alpaka::getDev(queue), pixelgpudetails::MAX_FED_WORDS);
+      digis_d = SiPixelDigisAlpaka(queue, pixelgpudetails::MAX_FED_WORDS);
       if (includeErrors) {
-        digiErrors_d =
-            SiPixelDigiErrorsAlpaka(alpaka::getDev(queue), pixelgpudetails::MAX_FED_WORDS, std::move(errors), queue);
+        digiErrors_d = SiPixelDigiErrorsAlpaka(queue, pixelgpudetails::MAX_FED_WORDS, std::move(errors));
       }
-      clusters_d = SiPixelClustersAlpaka(alpaka::getDev(queue), gpuClustering::MaxNumModules);
+      clusters_d = SiPixelClustersAlpaka(queue, gpuClustering::MaxNumModules);
 
       if (wordCounter)  // protect in case of empty event....
       {
@@ -587,11 +586,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         ALPAKA_ASSERT_OFFLOAD(0 == wordCounter % 2);
         // wordCounter is the total no of words in each event to be trasfered on device
-        auto word_d = ::cms::alpakatools::allocDeviceBuf<uint32_t>(alpaka::getDev(queue), wordCounter);
+        auto word_d = ::cms::alpakatools::allocDeviceBuf<uint32_t>(queue, wordCounter);
         // NB: IMPORTANT: fedId_d: In legacy, wordCounter elements are allocated.
         // However, only the first half of elements end up eventually used:
         // hence, here, only wordCounter/2 elements are allocated.
-        auto fedId_d = ::cms::alpakatools::allocDeviceBuf<uint8_t>(alpaka::getDev(queue), wordCounter / 2);
+        auto fedId_d = ::cms::alpakatools::allocDeviceBuf<uint8_t>(queue, wordCounter / 2);
 
         alpaka::memcpy(queue, word_d, wordFed.word(), wordCounter);
         alpaka::memcpy(queue, fedId_d, wordFed.fedId(), wordCounter / 2);


### PR DESCRIPTION
Change the interface and behaviour of `allocDeviceBuf` to take as argument a `Queue&` instead of a `Device const&`, and allocate stream-ordered (or queue-ordered) memory.

The memory is scheduled for freeing when the buffer is destroyed, but is actually freed only when the queue reaches that point on the device side.