### PR TITLE
[alpaka] Add back a required synchronisation

### DIFF
--- a/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelRecHits.cc
+++ b/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelRecHits.cc
@@ -81,6 +81,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       alpaka::wait(queue);
 #endif
 
+      // FIXME this is required to keep the host buffer inside hits_d alive; it could be removed once the host buffers are also stream-ordered
+      alpaka::wait(queue);
       return hits_d;
     }
 


### PR DESCRIPTION
The `alpaka::wait(queue)` is required to ensure all async operations complete before the host buffer inside the `hits_d` temporary variable goes out of scope and destroyed. It should be possible to remove it once the host buffers are stream-ordered.