### PR TITLE
Revert "[alpaka] Increase vertex count tolerance to 2 to avoid spurious test failures"

### DIFF
--- a/src/alpaka/plugin-Validation/alpaka/CountValidator.cc
+++ b/src/alpaka/plugin-Validation/alpaka/CountValidator.cc
@@ -64,12 +64,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   void CountValidator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     constexpr float trackTolerance = 0.012f;  // in 200 runs of 1k events all events are withing this tolerance
-#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
-    // For some reason the TBB backend occasionally gives difference of 2
-    constexpr int vertexTolerance = 2;
-#else
     constexpr int vertexTolerance = 1;
-#endif
     std::stringstream ss;
     bool ok = true;
 


### PR DESCRIPTION
Reverts cms-patatrack/pixeltrack-standalone#238 following discussion in https://github.com/cms-patatrack/pixeltrack-standalone/pull/238#issuecomment-1013139694 showing that the random issue has disappeared since (likely because of all the updates in between).