### PR TITLE
[alpaka] cleanup unused parameters

### DIFF
--- a/src/alpaka/AlpakaCore/prefixScan.h
+++ b/src/alpaka/AlpakaCore/prefixScan.h
@@ -207,20 +207,13 @@ namespace alpaka {
       //! \return The size of the shared memory allocated for a block.
       template <typename TVec>
       ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
-          cms::alpakatools::multiBlockPrefixScanSecondStep<T> const& myKernel,
-          TVec const& blockThreadExtent,
-          TVec const& threadElemExtent,
-          T const* ci,
-          T* co,
-          int32_t size,
+          cms::alpakatools::multiBlockPrefixScanSecondStep<T> const& /* myKernel */,
+          TVec const& /* blockThreadExtent */,
+          TVec const& /* threadElemExtent */,
+          T const* /* ci */,
+          T* /* co */,
+          int32_t /* size */,
           int32_t numBlocks) -> T {
-        alpaka::ignore_unused(myKernel);
-        alpaka::ignore_unused(blockThreadExtent);
-        alpaka::ignore_unused(threadElemExtent);
-        alpaka::ignore_unused(ci);
-        alpaka::ignore_unused(co);
-        alpaka::ignore_unused(size);
-
         return static_cast<size_t>(numBlocks) * sizeof(T);
       }
     };


### PR DESCRIPTION
`alpaka::ignore_unused` has been removed in the alpaka `develop` branch.