### PR TITLE
[alpaka] Simplify the interface for host and device buffers

### DIFF
--- a/src/alpaka/AlpakaCore/AtomicPairCounter.h
+++ b/src/alpaka/AlpakaCore/AtomicPairCounter.h
@@ -3,6 +3,8 @@
 
 #include <cstdint>
 
+#include <alpaka/alpaka.hpp>
+
 namespace cms::alpakatools {
 
   class AtomicPairCounter {

--- a/src/alpaka/AlpakaDataFormats/BeamSpotAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/BeamSpotAlpaka.h
@@ -22,8 +22,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     BeamSpotAlpaka& operator=(BeamSpotAlpaka const&) = delete;
     BeamSpotAlpaka& operator=(BeamSpotAlpaka&&) = default;
 
-    BeamSpotPOD* data() { return alpaka::getPtrNative(data_d_); }
-    BeamSpotPOD const* data() const { return alpaka::getPtrNative(data_d_); }
+    BeamSpotPOD* data() { return data_d_.data(); }
+    BeamSpotPOD const* data() const { return data_d_.data(); }
 
     cms::alpakatools::device_buffer<Device, BeamSpotPOD>& buf() { return data_d_; }
     cms::alpakatools::device_buffer<Device, BeamSpotPOD> const& buf() const { return data_d_; }

--- a/src/alpaka/AlpakaDataFormats/SiPixelClustersAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/SiPixelClustersAlpaka.h
@@ -24,20 +24,20 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     uint32_t nClusters() const { return nClusters_h; }
 
-    uint32_t *moduleStart() { return alpaka::getPtrNative(moduleStart_d); }
-    uint32_t *clusInModule() { return alpaka::getPtrNative(clusInModule_d); }
-    uint32_t *moduleId() { return alpaka::getPtrNative(moduleId_d); }
-    uint32_t *clusModuleStart() { return alpaka::getPtrNative(clusModuleStart_d); }
+    uint32_t *moduleStart() { return moduleStart_d.data(); }
+    uint32_t *clusInModule() { return clusInModule_d.data(); }
+    uint32_t *moduleId() { return moduleId_d.data(); }
+    uint32_t *clusModuleStart() { return clusModuleStart_d.data(); }
 
-    uint32_t const *moduleStart() const { return alpaka::getPtrNative(moduleStart_d); }
-    uint32_t const *clusInModule() const { return alpaka::getPtrNative(clusInModule_d); }
-    uint32_t const *moduleId() const { return alpaka::getPtrNative(moduleId_d); }
-    uint32_t const *clusModuleStart() const { return alpaka::getPtrNative(clusModuleStart_d); }
+    uint32_t const *moduleStart() const { return moduleStart_d.data(); }
+    uint32_t const *clusInModule() const { return clusInModule_d.data(); }
+    uint32_t const *moduleId() const { return moduleId_d.data(); }
+    uint32_t const *clusModuleStart() const { return clusModuleStart_d.data(); }
 
-    uint32_t const *c_moduleStart() const { return alpaka::getPtrNative(moduleStart_d); }
-    uint32_t const *c_clusInModule() const { return alpaka::getPtrNative(clusInModule_d); }
-    uint32_t const *c_moduleId() const { return alpaka::getPtrNative(moduleId_d); }
-    uint32_t const *c_clusModuleStart() const { return alpaka::getPtrNative(clusModuleStart_d); }
+    uint32_t const *c_moduleStart() const { return moduleStart_d.data(); }
+    uint32_t const *c_clusInModule() const { return clusInModule_d.data(); }
+    uint32_t const *c_moduleId() const { return moduleId_d.data(); }
+    uint32_t const *c_clusModuleStart() const { return clusModuleStart_d.data(); }
 
     class DeviceConstView {
     public:

--- a/src/alpaka/AlpakaDataFormats/SiPixelDigiErrorsAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/SiPixelDigiErrorsAlpaka.h
@@ -18,10 +18,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           error_d{cms::alpakatools::make_device_buffer<cms::alpakatools::SimpleVector<PixelErrorCompact>>(queue)},
           error_h{cms::alpakatools::make_host_buffer<cms::alpakatools::SimpleVector<PixelErrorCompact>>()},
           formatterErrors_h{std::move(errors)} {
-      auto perror_h = alpaka::getPtrNative(error_h);
-      perror_h->construct(maxFedWords, alpaka::getPtrNative(data_d));
-      ALPAKA_ASSERT_OFFLOAD(perror_h->empty());
-      ALPAKA_ASSERT_OFFLOAD(perror_h->capacity() == static_cast<int>(maxFedWords));
+      error_h->construct(maxFedWords, data_d.data());
+      ALPAKA_ASSERT_OFFLOAD(error_h->empty());
+      ALPAKA_ASSERT_OFFLOAD(error_h->capacity() == static_cast<int>(maxFedWords));
 
       alpaka::memcpy(queue, error_d, error_h);
     }
@@ -34,9 +33,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     const PixelFormatterErrors& formatterErrors() const { return formatterErrors_h; }
 
-    cms::alpakatools::SimpleVector<PixelErrorCompact>* error() { return alpaka::getPtrNative(error_d); }
-    cms::alpakatools::SimpleVector<PixelErrorCompact> const* error() const { return alpaka::getPtrNative(error_d); }
-    cms::alpakatools::SimpleVector<PixelErrorCompact> const* c_error() const { return alpaka::getPtrNative(error_d); }
+    cms::alpakatools::SimpleVector<PixelErrorCompact>* error() { return error_d.data(); }
+    cms::alpakatools::SimpleVector<PixelErrorCompact> const* error() const { return error_d.data(); }
+    cms::alpakatools::SimpleVector<PixelErrorCompact> const* c_error() const { return error_d.data(); }
 
 #ifdef TODO
     using HostDataError =

--- a/src/alpaka/AlpakaDataFormats/SiPixelDigisAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/SiPixelDigisAlpaka.h
@@ -33,29 +33,29 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     uint32_t nModules() const { return nModules_h; }
     uint32_t nDigis() const { return nDigis_h; }
 
-    uint16_t *xx() { return alpaka::getPtrNative(xx_d); }
-    uint16_t *yy() { return alpaka::getPtrNative(yy_d); }
-    uint16_t *adc() { return alpaka::getPtrNative(adc_d); }
-    uint16_t *moduleInd() { return alpaka::getPtrNative(moduleInd_d); }
-    int32_t *clus() { return alpaka::getPtrNative(clus_d); }
-    uint32_t *pdigi() { return alpaka::getPtrNative(pdigi_d); }
-    uint32_t *rawIdArr() { return alpaka::getPtrNative(rawIdArr_d); }
+    uint16_t *xx() { return xx_d.data(); }
+    uint16_t *yy() { return yy_d.data(); }
+    uint16_t *adc() { return adc_d.data(); }
+    uint16_t *moduleInd() { return moduleInd_d.data(); }
+    int32_t *clus() { return clus_d.data(); }
+    uint32_t *pdigi() { return pdigi_d.data(); }
+    uint32_t *rawIdArr() { return rawIdArr_d.data(); }
 
-    uint16_t const *xx() const { return alpaka::getPtrNative(xx_d); }
-    uint16_t const *yy() const { return alpaka::getPtrNative(yy_d); }
-    uint16_t const *adc() const { return alpaka::getPtrNative(adc_d); }
-    uint16_t const *moduleInd() const { return alpaka::getPtrNative(moduleInd_d); }
-    int32_t const *clus() const { return alpaka::getPtrNative(clus_d); }
-    uint32_t const *pdigi() const { return alpaka::getPtrNative(pdigi_d); }
-    uint32_t const *rawIdArr() const { return alpaka::getPtrNative(rawIdArr_d); }
+    uint16_t const *xx() const { return xx_d.data(); }
+    uint16_t const *yy() const { return yy_d.data(); }
+    uint16_t const *adc() const { return adc_d.data(); }
+    uint16_t const *moduleInd() const { return moduleInd_d.data(); }
+    int32_t const *clus() const { return clus_d.data(); }
+    uint32_t const *pdigi() const { return pdigi_d.data(); }
+    uint32_t const *rawIdArr() const { return rawIdArr_d.data(); }
 
-    uint16_t const *c_xx() const { return alpaka::getPtrNative(xx_d); }
-    uint16_t const *c_yy() const { return alpaka::getPtrNative(yy_d); }
-    uint16_t const *c_adc() const { return alpaka::getPtrNative(adc_d); }
-    uint16_t const *c_moduleInd() const { return alpaka::getPtrNative(moduleInd_d); }
-    int32_t const *c_clus() const { return alpaka::getPtrNative(clus_d); }
-    uint32_t const *c_pdigi() const { return alpaka::getPtrNative(pdigi_d); }
-    uint32_t const *c_rawIdArr() const { return alpaka::getPtrNative(rawIdArr_d); }
+    uint16_t const *c_xx() const { return xx_d.data(); }
+    uint16_t const *c_yy() const { return yy_d.data(); }
+    uint16_t const *c_adc() const { return adc_d.data(); }
+    uint16_t const *c_moduleInd() const { return moduleInd_d.data(); }
+    int32_t const *c_clus() const { return clus_d.data(); }
+    uint32_t const *c_pdigi() const { return pdigi_d.data(); }
+    uint32_t const *c_rawIdArr() const { return rawIdArr_d.data(); }
 
     auto adcToHostAsync(Queue &queue) const {
       auto ret = cms::alpakatools::make_host_buffer<uint16_t[]>(nDigis());

--- a/src/alpaka/AlpakaDataFormats/TrackingRecHit2DAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/TrackingRecHit2DAlpaka.h
@@ -49,30 +49,29 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // so unless proven VERY inefficient we keep it ordered as generated
 
       // Copy data to the SoA view:
-      TrackingRecHit2DSoAView& view = *alpaka::getPtrNative(m_view_h);
       // By value:
-      view.m_nHits = nHits;
+      m_view_h->m_nHits = nHits;
       // Raw pointer to data already owned in the event by SiPixelClusterAlpaka object:
-      view.m_hitsModuleStart = hitsModuleStart;
+      m_view_h->m_hitsModuleStart = hitsModuleStart;
       // Raw pointer to data already owned in the eventSetup by PixelCPEFast object:
-      view.m_cpeParams = cpeParams;
+      m_view_h->m_cpeParams = cpeParams;
       // Raw pointers to data owned here in TrackingRecHit2DAlpaka object:
-      view.m_xl = alpaka::getPtrNative(m_xl);
-      view.m_yl = alpaka::getPtrNative(m_yl);
-      view.m_xerr = alpaka::getPtrNative(m_xerr);
-      view.m_yerr = alpaka::getPtrNative(m_yerr);
-      view.m_xg = alpaka::getPtrNative(m_xg);
-      view.m_yg = alpaka::getPtrNative(m_yg);
-      view.m_zg = alpaka::getPtrNative(m_zg);
-      view.m_rg = alpaka::getPtrNative(m_rg);
-      view.m_iphi = alpaka::getPtrNative(m_iphi);
-      view.m_charge = alpaka::getPtrNative(m_charge);
-      view.m_xsize = alpaka::getPtrNative(m_xsize);
-      view.m_ysize = alpaka::getPtrNative(m_ysize);
-      view.m_detInd = alpaka::getPtrNative(m_detInd);
-      view.m_averageGeometry = alpaka::getPtrNative(m_averageGeometry);
-      view.m_hitsLayerStart = alpaka::getPtrNative(m_hitsLayerStart);
-      view.m_hist = alpaka::getPtrNative(m_hist);
+      m_view_h->m_xl = m_xl.data();
+      m_view_h->m_yl = m_yl.data();
+      m_view_h->m_xerr = m_xerr.data();
+      m_view_h->m_yerr = m_yerr.data();
+      m_view_h->m_xg = m_xg.data();
+      m_view_h->m_yg = m_yg.data();
+      m_view_h->m_zg = m_zg.data();
+      m_view_h->m_rg = m_rg.data();
+      m_view_h->m_iphi = m_iphi.data();
+      m_view_h->m_charge = m_charge.data();
+      m_view_h->m_xsize = m_xsize.data();
+      m_view_h->m_ysize = m_ysize.data();
+      m_view_h->m_detInd = m_detInd.data();
+      m_view_h->m_averageGeometry = m_averageGeometry.data();
+      m_view_h->m_hitsLayerStart = m_hitsLayerStart.data();
+      m_view_h->m_hist = m_hist.data();
       // Copy the SoA view to the device
       alpaka::memcpy(queue, m_view, m_view_h);
     }
@@ -84,17 +83,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     TrackingRecHit2DAlpaka(TrackingRecHit2DAlpaka&&) = default;
     TrackingRecHit2DAlpaka& operator=(TrackingRecHit2DAlpaka&&) = default;
 
-    TrackingRecHit2DSoAView* view() { return alpaka::getPtrNative(m_view); }
-    TrackingRecHit2DSoAView const* view() const { return alpaka::getPtrNative(m_view); }
+    TrackingRecHit2DSoAView* view() { return m_view.data(); }
+    TrackingRecHit2DSoAView const* view() const { return m_view.data(); }
 
     auto nHits() const { return m_nHits; }
     auto hitsModuleStart() const { return m_hitsModuleStart; }
 
-    auto hitsLayerStart() { return alpaka::getPtrNative(m_hitsLayerStart); }
-    auto const* c_hitsLayerStart() const { return alpaka::getPtrNative(m_hitsLayerStart); }
-    auto phiBinner() { return alpaka::getPtrNative(m_hist); }
-    auto iphi() { return alpaka::getPtrNative(m_iphi); }
-    auto const* c_iphi() const { return alpaka::getPtrNative(m_iphi); }
+    auto hitsLayerStart() { return m_hitsLayerStart.data(); }
+    auto const* c_hitsLayerStart() const { return m_hitsLayerStart.data(); }
+    auto phiBinner() { return m_hist.data(); }
+    auto iphi() { return m_iphi.data(); }
+    auto const* c_iphi() const { return m_iphi.data(); }
 
     auto xlToHostAsync(Queue& queue) const {
       auto ret = cms::alpakatools::make_host_buffer<float[]>(nHits());
@@ -156,17 +155,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     cms::alpakatools::host::unique_ptr<uint16_t[]> detIndexToHostAsync(cudaStream_t stream) const;
     cms::alpakatools::host::unique_ptr<uint32_t[]> hitsModuleStartToHostAsync(cudaStream_t stream) const;
 #endif
-    auto const* xl() const { return alpaka::getPtrNative(m_xl); }
-    auto const* yl() const { return alpaka::getPtrNative(m_yl); }
-    auto const* xerr() const { return alpaka::getPtrNative(m_xerr); }
-    auto const* yerr() const { return alpaka::getPtrNative(m_yerr); }
-    auto const* xg() const { return alpaka::getPtrNative(m_xg); }
-    auto const* yg() const { return alpaka::getPtrNative(m_yg); }
-    auto const* zg() const { return alpaka::getPtrNative(m_zg); }
-    auto const* rg() const { return alpaka::getPtrNative(m_rg); }
-    auto const* charge() const { return alpaka::getPtrNative(m_charge); }
-    auto const* xsize() const { return alpaka::getPtrNative(m_xsize); }
-    auto const* ysize() const { return alpaka::getPtrNative(m_ysize); }
+    auto const* xl() const { return m_xl.data(); }
+    auto const* yl() const { return m_yl.data(); }
+    auto const* xerr() const { return m_xerr.data(); }
+    auto const* yerr() const { return m_yerr.data(); }
+    auto const* xg() const { return m_xg.data(); }
+    auto const* yg() const { return m_yg.data(); }
+    auto const* zg() const { return m_zg.data(); }
+    auto const* rg() const { return m_rg.data(); }
+    auto const* charge() const { return m_charge.data(); }
+    auto const* xsize() const { return m_xsize.data(); }
+    auto const* ysize() const { return m_ysize.data(); }
 
   private:
     uint32_t m_nHits;

--- a/src/alpaka/CondFormats/SiPixelFedCablingMapGPUWrapper.h
+++ b/src/alpaka/CondFormats/SiPixelFedCablingMapGPUWrapper.h
@@ -20,14 +20,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         : modToUnpDefault_(modToUnp.size()),
           cablingMapHost_{cms::alpakatools::make_host_buffer<SiPixelFedCablingMapGPU>()},
           hasQuality_{true} {
-      std::memcpy(alpaka::getPtrNative(cablingMapHost_), &cablingMap, sizeof(SiPixelFedCablingMapGPU));
+      std::memcpy(cablingMapHost_.data(), &cablingMap, sizeof(SiPixelFedCablingMapGPU));
       std::copy(modToUnp.begin(), modToUnp.end(), modToUnpDefault_.begin());
     }
     ~SiPixelFedCablingMapGPUWrapper() = default;
 
     bool hasQuality() const { return hasQuality_; }
 
-    const SiPixelFedCablingMapGPU* cablingMap() const { return alpaka::getPtrNative(cablingMapHost_); }
+    const SiPixelFedCablingMapGPU* cablingMap() const { return cablingMapHost_.data(); }
 
     const SiPixelFedCablingMapGPU* getGPUProductAsync(Queue& queue) const {
       const auto& data = gpuData_.dataForDeviceAsync(queue, [this](Queue& queue) {
@@ -36,7 +36,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::memcpy(queue, gpuData.cablingMapDevice, cablingMapHost_);
         return gpuData;
       });
-      return alpaka::getPtrNative(data.cablingMapDevice);
+      return data.cablingMapDevice.data();
     }
 
     const unsigned char* getModToUnpAllAsync(Queue& queue) const {
@@ -47,7 +47,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::memcpy(queue, modToUnp.modToUnpDefault, modToUnpDefault_view);
         return modToUnp;
       });
-      return alpaka::getPtrNative(data.modToUnpDefault);
+      return data.modToUnpDefault.data();
     }
 
   private:

--- a/src/alpaka/CondFormats/SiPixelGainCalibrationForHLTGPU.h
+++ b/src/alpaka/CondFormats/SiPixelGainCalibrationForHLTGPU.h
@@ -17,7 +17,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         : gainForHLTonHost_{cms::alpakatools::make_host_buffer<SiPixelGainForHLTonGPU>()},
           gainData_(gainData),
           numDecodingStructures_(gainData.size()) {
-      *alpaka::getPtrNative(gainForHLTonHost_) = gain;
+      *gainForHLTonHost_ = gain;
       alpaka::prepareForAsyncCopy(gainForHLTonHost_);
     };
 
@@ -29,13 +29,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         auto gainDataView(cms::alpakatools::make_host_view(gainData_.data(), numDecodingStructures_));
         alpaka::memcpy(queue, gpuData.v_pedestalsGPU, gainDataView);
 
-        *alpaka::getPtrNative(gpuData.gainDataOnGPU) = *alpaka::getPtrNative(gainForHLTonHost_);
-        alpaka::getPtrNative(gpuData.gainDataOnGPU)->pedestals_ = alpaka::getPtrNative(gpuData.v_pedestalsGPU);
+        *gpuData.gainDataOnGPU = *gainForHLTonHost_;
+        gpuData.gainDataOnGPU->pedestals_ = gpuData.v_pedestalsGPU.data();
 
         alpaka::memcpy(queue, gpuData.gainForHLTonGPU, gpuData.gainDataOnGPU);
         return gpuData;
       });
-      return alpaka::getPtrNative(data.gainForHLTonGPU);
+      return data.gainForHLTonGPU.data();
     };
 
   private:

--- a/src/alpaka/plugin-BeamSpotProducer/alpaka/BeamSpotToAlpaka.cc
+++ b/src/alpaka/plugin-BeamSpotProducer/alpaka/BeamSpotToAlpaka.cc
@@ -30,7 +30,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   }
 
   void BeamSpotToAlpaka::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-    *alpaka::getPtrNative(bsHost_) = iSetup.get<BeamSpotPOD>();
+    *bsHost_ = iSetup.get<BeamSpotPOD>();
 
     cms::alpakatools::ScopedContextProduce<Queue> ctx{iEvent.streamID()};
 

--- a/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/BrokenLineFitOnGPU.cc
@@ -32,9 +32,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       tuples_d,
                                                       tupleMultiplicity_d,
                                                       hv,
-                                                      alpaka::getPtrNative(hitsGPU_),
-                                                      alpaka::getPtrNative(hits_geGPU_),
-                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      hitsGPU_.data(),
+                                                      hits_geGPU_.data(),
+                                                      fast_fit_resultsGPU_.data(),
                                                       3,
                                                       offset));
 
@@ -44,9 +44,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       tupleMultiplicity_d,
                                                       bField_,
                                                       outputSoa_d,
-                                                      alpaka::getPtrNative(hitsGPU_),
-                                                      alpaka::getPtrNative(hits_geGPU_),
-                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      hitsGPU_.data(),
+                                                      hits_geGPU_.data(),
+                                                      fast_fit_resultsGPU_.data(),
                                                       3,
                                                       offset));
 
@@ -57,9 +57,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       tuples_d,
                                                       tupleMultiplicity_d,
                                                       hv,
-                                                      alpaka::getPtrNative(hitsGPU_),
-                                                      alpaka::getPtrNative(hits_geGPU_),
-                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      hitsGPU_.data(),
+                                                      hits_geGPU_.data(),
+                                                      fast_fit_resultsGPU_.data(),
                                                       4,
                                                       offset));
 
@@ -69,9 +69,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       tupleMultiplicity_d,
                                                       bField_,
                                                       outputSoa_d,
-                                                      alpaka::getPtrNative(hitsGPU_),
-                                                      alpaka::getPtrNative(hits_geGPU_),
-                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      hitsGPU_.data(),
+                                                      hits_geGPU_.data(),
+                                                      fast_fit_resultsGPU_.data(),
                                                       4,
                                                       offset));
 
@@ -83,9 +83,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         tuples_d,
                                                         tupleMultiplicity_d,
                                                         hv,
-                                                        alpaka::getPtrNative(hitsGPU_),
-                                                        alpaka::getPtrNative(hits_geGPU_),
-                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        hitsGPU_.data(),
+                                                        hits_geGPU_.data(),
+                                                        fast_fit_resultsGPU_.data(),
                                                         5,
                                                         offset));
 
@@ -95,9 +95,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         tupleMultiplicity_d,
                                                         bField_,
                                                         outputSoa_d,
-                                                        alpaka::getPtrNative(hitsGPU_),
-                                                        alpaka::getPtrNative(hits_geGPU_),
-                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        hitsGPU_.data(),
+                                                        hits_geGPU_.data(),
+                                                        fast_fit_resultsGPU_.data(),
                                                         5,
                                                         offset));
       } else {
@@ -108,9 +108,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         tuples_d,
                                                         tupleMultiplicity_d,
                                                         hv,
-                                                        alpaka::getPtrNative(hitsGPU_),
-                                                        alpaka::getPtrNative(hits_geGPU_),
-                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        hitsGPU_.data(),
+                                                        hits_geGPU_.data(),
+                                                        fast_fit_resultsGPU_.data(),
                                                         5,
                                                         offset));
 
@@ -120,9 +120,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         tupleMultiplicity_d,
                                                         bField_,
                                                         outputSoa_d,
-                                                        alpaka::getPtrNative(hitsGPU_),
-                                                        alpaka::getPtrNative(hits_geGPU_),
-                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        hitsGPU_.data(),
+                                                        hits_geGPU_.data(),
+                                                        fast_fit_resultsGPU_.data(),
                                                         5,
                                                         offset));
       }

--- a/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.h
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/CAHitNtupletGeneratorKernels.h
@@ -191,13 +191,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           device_nCells_{cms::alpakatools::make_device_buffer<uint32_t>(queue)} {
       alpaka::memset(queue, counters_, 0);
       alpaka::memset(queue, device_nCells_, 0);
-      launchZero(alpaka::getPtrNative(device_tupleMultiplicity_), queue);
-      launchZero(alpaka::getPtrNative(device_hitToTuple_), queue);
+      launchZero(device_tupleMultiplicity_.data(), queue);
+      launchZero(device_hitToTuple_.data(), queue);
     }
 
     ~CAHitNtupletGeneratorKernels() = default;
 
-    TupleMultiplicity const* tupleMultiplicity() const { return alpaka::getPtrNative(device_tupleMultiplicity_); }
+    TupleMultiplicity const* tupleMultiplicity() const { return device_tupleMultiplicity_.data(); }
 
     void launchKernels(HitsOnCPU const& hh, TkSoA* tuples_d, Queue& queue);
 

--- a/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
+++ b/src/alpaka/plugin-PixelTriplets/alpaka/RiemannFitOnGPU.cc
@@ -36,9 +36,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       tupleMultiplicity_d,
                                                       3,
                                                       hv,
-                                                      alpaka::getPtrNative(hitsGPU_),
-                                                      alpaka::getPtrNative(hits_geGPU_),
-                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      hitsGPU_.data(),
+                                                      hits_geGPU_.data(),
+                                                      fast_fit_resultsGPU_.data(),
                                                       offset));
 
       alpaka::enqueue(queue,
@@ -47,10 +47,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       tupleMultiplicity_d,
                                                       3,
                                                       bField_,
-                                                      alpaka::getPtrNative(hitsGPU_),
-                                                      alpaka::getPtrNative(hits_geGPU_),
-                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                      alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                      hitsGPU_.data(),
+                                                      hits_geGPU_.data(),
+                                                      fast_fit_resultsGPU_.data(),
+                                                      circle_fit_resultsGPU_.data(),
                                                       offset));
 
       alpaka::enqueue(queue,
@@ -60,10 +60,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       3,
                                                       bField_,
                                                       outputSoa_d,
-                                                      alpaka::getPtrNative(hitsGPU_),
-                                                      alpaka::getPtrNative(hits_geGPU_),
-                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                      alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                      hitsGPU_.data(),
+                                                      hits_geGPU_.data(),
+                                                      fast_fit_resultsGPU_.data(),
+                                                      circle_fit_resultsGPU_.data(),
                                                       offset));
 
       // quads
@@ -74,9 +74,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       tupleMultiplicity_d,
                                                       4,
                                                       hv,
-                                                      alpaka::getPtrNative(hitsGPU_),
-                                                      alpaka::getPtrNative(hits_geGPU_),
-                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                      hitsGPU_.data(),
+                                                      hits_geGPU_.data(),
+                                                      fast_fit_resultsGPU_.data(),
                                                       offset));
 
       alpaka::enqueue(queue,
@@ -85,10 +85,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       tupleMultiplicity_d,
                                                       4,
                                                       bField_,
-                                                      alpaka::getPtrNative(hitsGPU_),
-                                                      alpaka::getPtrNative(hits_geGPU_),
-                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                      alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                      hitsGPU_.data(),
+                                                      hits_geGPU_.data(),
+                                                      fast_fit_resultsGPU_.data(),
+                                                      circle_fit_resultsGPU_.data(),
                                                       offset));
 
       alpaka::enqueue(queue,
@@ -98,10 +98,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       4,
                                                       bField_,
                                                       outputSoa_d,
-                                                      alpaka::getPtrNative(hitsGPU_),
-                                                      alpaka::getPtrNative(hits_geGPU_),
-                                                      alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                      alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                      hitsGPU_.data(),
+                                                      hits_geGPU_.data(),
+                                                      fast_fit_resultsGPU_.data(),
+                                                      circle_fit_resultsGPU_.data(),
                                                       offset));
 
       if (fit5as4_) {
@@ -113,9 +113,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         tupleMultiplicity_d,
                                                         5,
                                                         hv,
-                                                        alpaka::getPtrNative(hitsGPU_),
-                                                        alpaka::getPtrNative(hits_geGPU_),
-                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        hitsGPU_.data(),
+                                                        hits_geGPU_.data(),
+                                                        fast_fit_resultsGPU_.data(),
                                                         offset));
 
         alpaka::enqueue(queue,
@@ -124,10 +124,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         tupleMultiplicity_d,
                                                         5,
                                                         bField_,
-                                                        alpaka::getPtrNative(hitsGPU_),
-                                                        alpaka::getPtrNative(hits_geGPU_),
-                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                        alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                        hitsGPU_.data(),
+                                                        hits_geGPU_.data(),
+                                                        fast_fit_resultsGPU_.data(),
+                                                        circle_fit_resultsGPU_.data(),
                                                         offset));
 
         alpaka::enqueue(queue,
@@ -137,10 +137,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         5,
                                                         bField_,
                                                         outputSoa_d,
-                                                        alpaka::getPtrNative(hitsGPU_),
-                                                        alpaka::getPtrNative(hits_geGPU_),
-                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                        alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                        hitsGPU_.data(),
+                                                        hits_geGPU_.data(),
+                                                        fast_fit_resultsGPU_.data(),
+                                                        circle_fit_resultsGPU_.data(),
                                                         offset));
       } else {
         // penta all 5
@@ -151,9 +151,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         tupleMultiplicity_d,
                                                         5,
                                                         hv,
-                                                        alpaka::getPtrNative(hitsGPU_),
-                                                        alpaka::getPtrNative(hits_geGPU_),
-                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
+                                                        hitsGPU_.data(),
+                                                        hits_geGPU_.data(),
+                                                        fast_fit_resultsGPU_.data(),
                                                         offset));
 
         alpaka::enqueue(queue,
@@ -162,10 +162,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         tupleMultiplicity_d,
                                                         5,
                                                         bField_,
-                                                        alpaka::getPtrNative(hitsGPU_),
-                                                        alpaka::getPtrNative(hits_geGPU_),
-                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                        alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                        hitsGPU_.data(),
+                                                        hits_geGPU_.data(),
+                                                        fast_fit_resultsGPU_.data(),
+                                                        circle_fit_resultsGPU_.data(),
                                                         offset));
 
         alpaka::enqueue(queue,
@@ -175,10 +175,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         5,
                                                         bField_,
                                                         outputSoa_d,
-                                                        alpaka::getPtrNative(hitsGPU_),
-                                                        alpaka::getPtrNative(hits_geGPU_),
-                                                        alpaka::getPtrNative(fast_fit_resultsGPU_),
-                                                        alpaka::getPtrNative(circle_fit_resultsGPU_),
+                                                        hitsGPU_.data(),
+                                                        hits_geGPU_.data(),
+                                                        fast_fit_resultsGPU_.data(),
+                                                        circle_fit_resultsGPU_.data(),
                                                         offset));
       }
     }

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/PixelVertexProducerAlpaka.cc
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/PixelVertexProducerAlpaka.cc
@@ -48,11 +48,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   {}
 
   void PixelVertexProducerAlpaka::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-    cms::alpakatools::Product<Queue, PixelTrackAlpaka> const& tracksBufWrapped = iEvent.get(tokenTrack_);
-    cms::alpakatools::ScopedContextProduce<Queue> ctx{tracksBufWrapped};
-    auto const& tracksBuf = ctx.get(tracksBufWrapped);
-    auto const tracks = alpaka::getPtrNative(tracksBuf);
-    ctx.emplace(iEvent, tokenVertex_, m_gpuAlgo.makeAsync(tracks, m_ptMin, ctx.stream()));
+    cms::alpakatools::Product<Queue, PixelTrackAlpaka> const& tracksWrapped = iEvent.get(tokenTrack_);
+    cms::alpakatools::ScopedContextProduce<Queue> ctx{tracksWrapped};
+    auto const& tracks = ctx.get(tracksWrapped);
+    ctx.emplace(iEvent, tokenVertex_, m_gpuAlgo.makeAsync(tracks.data(), m_ptMin, ctx.stream()));
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/gpuVertexFinder.cc
@@ -109,11 +109,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       ALPAKA_ASSERT_OFFLOAD(tksoa);
 
       ZVertexAlpaka vertices = cms::alpakatools::make_device_buffer<ZVertexSoA>(queue);
-      auto* soa = alpaka::getPtrNative(vertices);
+      auto* soa = vertices.data();
       ALPAKA_ASSERT_OFFLOAD(soa);
 
       auto ws_dBuf{cms::alpakatools::make_device_buffer<WorkSpace>(queue)};
-      auto ws_d = alpaka::getPtrNative(ws_dBuf);
+      auto ws_d = ws_dBuf.data();
 
       auto nvFinalVerticesView = cms::alpakatools::make_device_view(alpaka::getDev(queue), soa->nvFinal);
       alpaka::memset(queue, nvFinalVerticesView, 0);

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
@@ -41,8 +41,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                           unsigned int wordCounterGPU,
                                                                           const uint32_t *src,
                                                                           unsigned int length) {
-      std::memcpy(alpaka::getPtrNative(word_) + wordCounterGPU, src, sizeof(uint32_t) * length);
-      std::memset(alpaka::getPtrNative(fedId_) + wordCounterGPU / 2, fedId - 1200, length / 2);
+      std::memcpy(word_.data() + wordCounterGPU, src, sizeof(uint32_t) * length);
+      std::memset(fedId_.data() + wordCounterGPU / 2, fedId - 1200, length / 2);
     }
 
     ////////////////////
@@ -598,8 +598,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                         cablingMap,
                                                         modToUnp,
                                                         wordCounter,
-                                                        alpaka::getPtrNative(word_d),
-                                                        alpaka::getPtrNative(fedId_d),
+                                                        word_d.data(),
+                                                        fedId_d.data(),
                                                         digis_d->xx(),
                                                         digis_d->yy(),
                                                         digis_d->adc(),
@@ -727,8 +727,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             alpaka::getDev(queue),
             const_cast<uint32_t const *>(clusters_d->clusModuleStart() + gpuClustering::MaxNumModules),
             1u);
-        auto nModules_Clusters_h_1 =
-            cms::alpakatools::make_host_view(alpaka::getPtrNative(nModules_Clusters_h) + 1, 1u);
+        auto nModules_Clusters_h_1 = cms::alpakatools::make_host_view(nModules_Clusters_h.data() + 1, 1u);
         alpaka::memcpy(queue, nModules_Clusters_h_1, clusModuleStartLastElement);
 
       }  // end clusterizer scope

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.h
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.h
@@ -191,9 +191,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                              Queue& queue);
 
       std::pair<SiPixelDigisAlpaka, SiPixelClustersAlpaka> getResults() {
-        auto pnModules_Clusters_h = alpaka::getPtrNative(nModules_Clusters_h);
-        digis_d->setNModulesDigis(pnModules_Clusters_h[0], nDigis);
-        clusters_d->setNClusters(pnModules_Clusters_h[1]);
+        digis_d->setNModulesDigis(nModules_Clusters_h[0], nDigis);
+        clusters_d->setNClusters(nModules_Clusters_h[1]);
         return std::make_pair(std::move(*digis_d), std::move(*clusters_d));
       }
 

--- a/src/alpaka/plugin-Validation/alpaka/CountValidator.cc
+++ b/src/alpaka/plugin-Validation/alpaka/CountValidator.cc
@@ -93,9 +93,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     {
       auto const& count = iEvent.get(trackCountToken_);
-      auto const& tracksBuf = iEvent.get(trackToken_);
-      auto const tracks = alpaka::getPtrNative(tracksBuf);
-
+      auto const& tracks = iEvent.get(trackToken_);
       int nTracks = 0;
       for (int i = 0; i < tracks->stride(); ++i) {
         if (tracks->nHits(i) > 0) {
@@ -117,9 +115,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     {
       auto const& count = iEvent.get(vertexCountToken_);
-      auto const& verticesBuf = iEvent.get(vertexToken_);
-      auto const vertices = alpaka::getPtrNative(verticesBuf);
-
+      auto const& vertices = iEvent.get(vertexToken_);
       auto diff = std::abs(int(vertices->nvFinal) - int(count.nVertices()));
       if (diff != 0) {
         sumVertexDifference += diff;

--- a/src/alpaka/plugin-Validation/alpaka/HistoValidator.cc
+++ b/src/alpaka/plugin-Validation/alpaka/HistoValidator.cc
@@ -143,29 +143,29 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     histos["module_n"].fill(nModules_);
     histos["digi_n"].fill(nDigis_);
     for (uint32_t i = 0; i < nDigis_; ++i) {
-      histos["digi_adc"].fill(alpaka::getPtrNative(*h_adc)[i]);
+      histos["digi_adc"].fill((*h_adc)[i]);
     }
     h_adc.reset();
 
     histos["cluster_n"].fill(nClusters_);
     for (uint32_t i = 0; i < nModules_; ++i) {
-      histos["cluster_per_module_n"].fill(alpaka::getPtrNative(*h_clusInModule)[i]);
+      histos["cluster_per_module_n"].fill((*h_clusInModule)[i]);
     }
     h_clusInModule.reset();
 
     histos["hit_n"].fill(nHits_);
     for (uint32_t i = 0; i < nHits_; ++i) {
-      histos["hit_lx"].fill(alpaka::getPtrNative(*h_lx)[i]);
-      histos["hit_ly"].fill(alpaka::getPtrNative(*h_ly)[i]);
-      histos["hit_lex"].fill(alpaka::getPtrNative(*h_lex)[i]);
-      histos["hit_ley"].fill(alpaka::getPtrNative(*h_ley)[i]);
-      histos["hit_gx"].fill(alpaka::getPtrNative(*h_gx)[i]);
-      histos["hit_gy"].fill(alpaka::getPtrNative(*h_gy)[i]);
-      histos["hit_gz"].fill(alpaka::getPtrNative(*h_gz)[i]);
-      histos["hit_gr"].fill(alpaka::getPtrNative(*h_gr)[i]);
-      histos["hit_charge"].fill(alpaka::getPtrNative(*h_charge)[i]);
-      histos["hit_sizex"].fill(alpaka::getPtrNative(*h_sizex)[i]);
-      histos["hit_sizey"].fill(alpaka::getPtrNative(*h_sizey)[i]);
+      histos["hit_lx"].fill((*h_lx)[i]);
+      histos["hit_ly"].fill((*h_ly)[i]);
+      histos["hit_lex"].fill((*h_lex)[i]);
+      histos["hit_ley"].fill((*h_ley)[i]);
+      histos["hit_gx"].fill((*h_gx)[i]);
+      histos["hit_gy"].fill((*h_gy)[i]);
+      histos["hit_gz"].fill((*h_gz)[i]);
+      histos["hit_gr"].fill((*h_gr)[i]);
+      histos["hit_charge"].fill((*h_charge)[i]);
+      histos["hit_sizex"].fill((*h_sizex)[i]);
+      histos["hit_sizey"].fill((*h_sizey)[i]);
     }
     h_lx.reset();
     h_ly.reset();
@@ -180,9 +180,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     h_sizey.reset();
 
     {
-      auto const& tracksBuf = iEvent.get(trackToken_);
-      auto const tracks = alpaka::getPtrNative(tracksBuf);
-
+      auto const& tracks = iEvent.get(trackToken_);
       int nTracks = 0;
       for (int i = 0; i < tracks->stride(); ++i) {
         if (tracks->nHits(i) > 0 and tracks->quality(i) >= trackQuality::loose) {
@@ -199,14 +197,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           histos["track_quality"].fill(tracks->quality(i));
         }
       }
-
       histos["track_n"].fill(nTracks);
     }
 
     {
-      auto const& verticesBuf = iEvent.get(vertexToken_);
-      auto const vertices = alpaka::getPtrNative(verticesBuf);
-
+      auto const& vertices = iEvent.get(vertexToken_);
       histos["vertex_n"].fill(vertices->nvFinal);
       for (uint32_t i = 0; i < vertices->nvFinal; ++i) {
         histos["vertex_z"].fill(vertices->zv[i]);


### PR DESCRIPTION
0-dimensional (scalar) buffers now implement the dereference `*` and member access `->` operators.
1-dimensional buffers now implement the array subscript `[]` operators.
all buffers implement the `.data()` method to access the underlying pointer.