### PR TITLE
[alpaka] Freeze the develop branch as of 2022.01.24 / 26cabb4d5a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -551,6 +551,7 @@ external_alpaka: $(ALPAKA_BASE)
 
 $(ALPAKA_BASE):
 	git clone git@github.com:alpaka-group/alpaka.git -b develop $@
+	cd $@ && git checkout 26cabb4d5a635c75a75e37d4c4770d3bb71dcd1c
 
 # Cupla
 .PHONY: external_cupla


### PR DESCRIPTION
Update and freeze the version of alpaka to the HEAD of the `develop` branch as of 2022.01.24, corresponding to the commit https://github.com/alpaka-group/alpaka/commit/26cabb4d5a635c75a75e37d4c4770d3bb71dcd1c .