### PR TITLE
[alpaka] Host and device memory caching allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,25 @@ $ make kokkos ...
 | `-DKOKKOS_SERIALONLY_DISABLE_ATOMICS`  | Disable Kokkos (real) atomics, can be used with Serial-only build |
 
 
+#### `alpaka`
+
+The `alpaka` code base is loosely based on the `cuda` code base, with some minor changes introduced during the porting.
+
+The use of caching allocator can be disabled at compile time setting the
+`ALPAKA_DISABLE_CACHING_ALLOCATOR` preprocessor symbol:
+```
+make alpaka ... USER_CXXFLAGS="-DALPAKA_DISABLE_CACHING_ALLOCATOR"
+```
+
+If the caching allocator is disabled and CUDA version is 11.2 or greater is detected,
+device allocations and deallocations will use the stream-ordered CUDA functions
+`cudaMallocAsync` and `cudaFreeAsync`. Their use can be disabled explicitly at
+compile time setting also the `ALPAKA_DISABLE_ASYNC_ALLOCATOR` preprocessor symbol:
+
+```
+make alpaka ... USER_CXXFLAGS="-DALPAKA_DISABLE_CACHING_ALLOCATOR -DALPAKA_DISABLE_ASYNC_ALLOCATOR"
+```
+
 ## Code structure
 
 The project is split into several programs, one (or more) for each

--- a/src/alpaka/AlpakaCore/AllocatorConfig.h
+++ b/src/alpaka/AlpakaCore/AllocatorConfig.h
@@ -1,0 +1,31 @@
+#ifndef AlpakaCore_AllocatorConfig_h
+#define AlpakaCore_AllocatorConfig_h
+
+#include <limits>
+
+namespace cms::alpakatools {
+
+  namespace config {
+
+    // bin growth factor (bin_growth in cub::CachingDeviceAllocator)
+    constexpr unsigned int binGrowth = 2;
+
+    // smallest bin, corresponds to binGrowth^minBin bytes (min_bin in cub::CacingDeviceAllocator
+    constexpr unsigned int minBin = 8;  // 256 bytes
+
+    // largest bin, corresponds to binGrowth^maxBin bytes (max_bin in cub::CachingDeviceAllocator). Note that unlike in cub, allocations larger than binGrowth^maxBin are set to fail.
+    constexpr unsigned int maxBin = 30;  // 1 GB
+
+    // total storage for the allocator; 0 means no limit.
+    constexpr size_t maxCachedBytes = 0;
+
+    // fraction of total device memory taken for the allocator; 0 means no limit.
+    constexpr double maxCachedFraction = 0.8;
+
+    // if both maxCachedBytes and maxCachedFraction are non-zero, the smallest resulting value is used.
+
+  }  // namespace config
+
+}  // namespace cms::alpakatools
+
+#endif  // AlpakaCore_AllocatorConfig_h

--- a/src/alpaka/AlpakaCore/AllocatorPolicy.h
+++ b/src/alpaka/AlpakaCore/AllocatorPolicy.h
@@ -1,0 +1,45 @@
+#ifndef AlpakaCore_AllocatorPolicy_h
+#define AlpakaCore_AllocatorPolicy_h
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#include <cuda_runtime.h>
+#endif
+
+#include <alpaka/alpaka.hpp>
+
+namespace cms::alpakatools {
+
+  // Which memory allocator to use
+  //   - Synchronous:   (device and host) cudaMalloc and cudaMallocHost
+  //   - Asynchronous:  (device only)     cudaMallocAsync (requires CUDA >= 11.2)
+  //   - Caching:       (device and host) caching allocator
+  enum class AllocatorPolicy { Synchronous = 0, Asynchronous = 1, Caching = 2 };
+
+  template <typename TDev>
+  constexpr AllocatorPolicy allocator_policy = AllocatorPolicy::Synchronous;
+
+#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+  template <>
+  constexpr AllocatorPolicy allocator_policy<alpaka::DevCpu> =
+#if ! defined ALPAKA_DISABLE_CACHING_ALLOCATOR
+    AllocatorPolicy::Caching;
+#else
+    AllocatorPolicy::Synchronous;
+#endif
+#endif  // defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+
+#if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+  template <>
+  constexpr AllocatorPolicy allocator_policy<alpaka::DevUniformCudaHipRt> =
+#if ! defined ALPAKA_DISABLE_CACHING_ALLOCATOR
+    AllocatorPolicy::Caching;
+#elif CUDA_VERSION >= 11020 && ! defined ALPAKA_DISABLE_ASYNC_ALLOCATOR
+    AllocatorPolicy::Asynchronous;
+#else
+    AllocatorPolicy::Synchronous;
+#endif
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+}  // namespace cms::alpakatools
+
+#endif  // AlpakaCore_AllocatorPolicy_h

--- a/src/alpaka/AlpakaCore/CachedBufAlloc.h
+++ b/src/alpaka/AlpakaCore/CachedBufAlloc.h
@@ -1,0 +1,95 @@
+#ifndef AlpakaCore_CachedBufAlloc_h
+#define AlpakaCore_CachedBufAlloc_h
+
+#include <alpaka/alpaka.hpp>
+
+#include "AlpakaCore/getDeviceCachingAllocator.h"
+#include "AlpakaCore/getHostCachingAllocator.h"
+#include "Framework/demangle.h"
+
+namespace cms::alpakatools {
+
+  namespace traits {
+
+    //! The caching memory allocator trait.
+    template <typename TElem, typename TDim, typename TIdx, typename TDev, typename TQueue, typename TSfinae = void>
+    struct CachedBufAlloc {
+      static_assert(alpaka::meta::DependentFalseType<TDev>::value, "This device does not support a caching allocator");
+    };
+
+    //! The caching memory allocator implementation for the CPU device
+    template <typename TElem, typename TDim, typename TIdx, typename TQueue>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpu, TQueue, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpu const& dev, TQueue queue, TExtent const& extent)
+          -> alpaka::BufCpu<TElem, TDim, TIdx> {
+        // non-cached host-only memory
+        return alpaka::allocAsyncBuf<TElem, TIdx>(queue, extent);
+      }
+    };
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+
+    //! The caching memory allocator implementation for the pinned host memory
+    template <typename TElem, typename TDim, typename TIdx>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpu, alpaka::QueueUniformCudaHipRtNonBlocking, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpu const& dev,
+                                                alpaka::QueueUniformCudaHipRtNonBlocking queue,
+                                                TExtent const& extent) -> alpaka::BufCpu<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getHostCachingAllocator<alpaka::QueueUniformCudaHipRtNonBlocking>();
+
+        // FIXME the BufCpu does not support a pitch ?
+        size_t size = alpaka::extent::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufCpu<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), extent);
+      }
+    };
+
+    //! The caching memory allocator implementation for the CUDA/HIP device
+    template <typename TElem, typename TDim, typename TIdx, typename TQueue>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevUniformCudaHipRt, TQueue, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevUniformCudaHipRt const& dev,
+                                                TQueue queue,
+                                                TExtent const& extent)
+          -> alpaka::BufUniformCudaHipRt<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getDeviceCachingAllocator<alpaka::DevUniformCudaHipRt, TQueue>(dev);
+
+        size_t width = alpaka::extent::getWidth(extent);
+        size_t widthBytes = width * static_cast<TIdx>(sizeof(TElem));
+        // TODO implement pitch for TDim > 1
+        size_t pitchBytes = widthBytes;
+        size_t size = alpaka::extent::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufUniformCudaHipRt<TElem, TDim, TIdx>(
+            dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), pitchBytes, extent);
+      }
+    };
+
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+  }  // namespace traits
+
+  template <typename TElem, typename TIdx, typename TExtent, typename TQueue, typename TDev>
+  ALPAKA_FN_HOST auto allocCachedBuf(TDev const& dev, TQueue queue, TExtent const& extent = TExtent()) {
+    return traits::CachedBufAlloc<TElem, alpaka::Dim<TExtent>, TIdx, TDev, TQueue>::allocCachedBuf(dev, queue, extent);
+  }
+
+}  // namespace cms::alpakatools
+
+#endif  // AlpakaCore_CachedBufAlloc_h

--- a/src/alpaka/AlpakaCore/CachingAllocator.h
+++ b/src/alpaka/AlpakaCore/CachingAllocator.h
@@ -1,0 +1,414 @@
+#ifndef AlpakaCore_CachingAllocator_h
+#define AlpakaCore_CachingAllocator_h
+
+#include <cassert>
+#include <exception>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+
+#include <boost/core/demangle.hpp>
+
+#include <alpaka/alpaka.hpp>
+
+#include "AlpakaCore/alpakaDevices.h"
+
+// Inspired by cub::CachingDeviceAllocator
+
+namespace cms::alpakatools {
+
+  namespace detail {
+
+    inline constexpr unsigned int power(unsigned int base, unsigned int exponent) {
+      unsigned int power = 1;
+      while (exponent > 0) {
+        if (exponent & 1) {
+          power = power * base;
+        }
+        base = base * base;
+        exponent = exponent >> 1;
+      }
+      return power;
+    }
+
+    // format a memory size in B/kB/MB/GB
+    inline std::string as_bytes(size_t value) {
+      if (value == std::numeric_limits<size_t>::max()) {
+        return "unlimited";
+      } else if (value >= (1 << 30) and value % (1 << 30) == 0) {
+        return std::to_string(value >> 30) + " GB";
+      } else if (value >= (1 << 20) and value % (1 << 20) == 0) {
+        return std::to_string(value >> 20) + " MB";
+      } else if (value >= (1 << 10) and value % (1 << 10) == 0) {
+        return std::to_string(value >> 10) + " kB";
+      } else {
+        return std::to_string(value) + "  B";
+      }
+    }
+
+  }  // namespace detail
+
+  /*
+   * The "memory device" identifies the memory space, i.e. the device where the memory is allocated.
+   * A caching allocator object is associated to a single memory `Device`, set at construction time, and unchanged for
+   * the lifetime of the allocator.
+   *
+   * Each allocation is associated to an event on a queue, that identifies the "synchronisation device" according to
+   * which the synchronisation occurs.
+   * The `Event` type depends only on the synchronisation `Device` type.
+   * The `Queue` type depends on the synchronisation `Device` type and the queue properties, either `Sync` or `Async`.
+   *
+   * **Note**: how to handle different queue and event types in a single allocator ?  store and access type-punned
+   * queues and events ?  or template the internal structures on them, but with a common base class ?
+   * alpaka does rely on the compile-time type for dispatch.
+   *
+   * Common use case #1: accelerator's memory allocations
+   *   - the "memory device" is the accelerator device (e.g. a GPU);
+   *   - the "synchronisation device" is the same accelerator device;
+   *   - the `Queue` type is usually always the same (either `Sync` or `Async`).
+   *
+   * Common use case #2: pinned host memory allocations
+   *    - the "memory device" is the host device (e.g. system memory);
+   *    - the "synchronisation device" is the accelerator device (e.g. a GPU) whose work queue will access the host;
+   *      memory (direct memory access from the accelerator, or scheduling `alpaka::memcpy`/`alpaka::memset`), and can
+   *      be different for each allocation;
+   *    - the synchronisation `Device` _type_ could potentially be different, but memory pinning is currently tied to
+   *      the accelerator's platform (CUDA, HIP, etc.), so the device type needs to be fixed to benefit from caching;
+   *    - the `Queue` type can be either `Sync` _or_ `Async` on any allocation.
+   */
+
+  template <typename TDevice, typename TQueue>
+  class CachingAllocator {
+  public:
+    using Device = TDevice;              // the "memory device", where the memory will be allocated
+    using Queue = TQueue;                // the queue used to submit the memory operations
+    using Event = alpaka::Event<Queue>;  // the events used to synchronise the operations
+    using Buffer = alpaka::Buf<Device, std::byte, alpaka::DimInt<1u>, size_t>;
+
+    struct CachedBytes {
+      size_t free = 0;       // total bytes freed and cached on this device
+      size_t live = 0;       // total bytes currently in use oin this device
+      size_t requested = 0;  // total bytes requested and currently in use on this device
+    };
+
+    explicit CachingAllocator(
+        Device const& device,
+        unsigned int binGrowth,          // bin growth factor;
+        unsigned int minBin,             // smallest bin, corresponds to binGrowth^minBin bytes;
+                                         // smaller allocations are rounded to this value;
+        unsigned int maxBin,             // largest bin, corresponds to binGrowth^maxBin bytes;
+                                         // larger allocations will fail;
+        size_t maxCachedBytes,           // total storage for the allocator (0 means no limit);
+        double maxCachedFraction,        // fraction of total device memory taken for the allocator (0 means no limit);
+                                         // if both maxCachedBytes and maxCachedFraction are non-zero,
+                                         // the smallest resulting value is used.
+        bool reuseSameQueueAllocations,  // reuse non-ready allocations if they are in the same queue as the new one;
+                                         // this is safe only if all memory operations are scheduled in the same queue
+        bool debug)
+        : device_(device),
+          binGrowth_(binGrowth),
+          minBin_(minBin),
+          maxBin_(maxBin),
+          minBinBytes_(detail::power(binGrowth, minBin)),
+          maxBinBytes_(detail::power(binGrowth, maxBin)),
+          maxCachedBytes_(cacheSize(maxCachedBytes, maxCachedFraction)),
+          reuseSameQueueAllocations_(reuseSameQueueAllocations),
+          debug_(debug) {
+      if (debug_) {
+        std::ostringstream out;
+        out << "CachingAllocator settings\n"
+            << "  bin growth " << binGrowth_ << "\n"
+            << "  min bin    " << minBin_ << "\n"
+            << "  max bin    " << maxBin_ << "\n"
+            << "  resulting bins:\n";
+        for (auto bin = minBin_; bin <= maxBin_; ++bin) {
+          auto binSize = detail::power(binGrowth, bin);
+          out << "    " << std::right << std::setw(12) << detail::as_bytes(binSize) << '\n';
+        }
+        out << "  maximum amount of cached memory: " << detail::as_bytes(maxCachedBytes_);
+        std::cout << out.str() << std::endl;
+      }
+    }
+
+    ~CachingAllocator() {
+      {
+        // this should never be called while some memory blocks are still live
+        std::scoped_lock lock(mutex_);
+        assert(liveBlocks_.empty());
+        assert(cachedBytes_.live == 0);
+      }
+
+      freeAllCached();
+    }
+
+    // return a copy of the cache allocation status, for monitoring purposes
+    CachedBytes cacheStatus() const {
+      std::scoped_lock lock(mutex_);
+      return cachedBytes_;
+    }
+
+    // Allocate given number of bytes on the current device associated to given queue
+    void* allocate(size_t bytes, Queue queue) {
+      // create a block descriptor for the requested allocation
+      BlockDescriptor block;
+      block.queue = std::move(queue);
+      block.requested = bytes;
+      std::tie(block.bin, block.bytes) = findBin(bytes);
+
+      // try to re-use a cached block, or allocate a new buffer
+      if (not tryReuseCachedBlock(block)) {
+        allocateNewBlock(block);
+      }
+
+      return block.buffer->data();
+    }
+
+    // frees an allocation
+    void free(void* ptr) {
+      std::scoped_lock lock(mutex_);
+
+      auto iBlock = liveBlocks_.find(ptr);
+      if (iBlock == liveBlocks_.end()) {
+        std::stringstream ss;
+        ss << "Trying to free a non-live block at " << ptr;
+        throw std::runtime_error(ss.str());
+      }
+      // remove the block from the list of live blocks
+      BlockDescriptor block = std::move(iBlock->second);
+      liveBlocks_.erase(iBlock);
+      cachedBytes_.live -= block.bytes;
+      cachedBytes_.requested -= block.requested;
+
+      bool recache = (cachedBytes_.free + block.bytes <= maxCachedBytes_);
+      if (recache) {
+        alpaka::enqueue(*(block.queue), *(block.event));
+        cachedBytes_.free += block.bytes;
+        // after the call to insert(), cachedBlocks_ shares ownership of the buffer
+        // TODO use std::move ?
+        cachedBlocks_.insert(std::make_pair(block.bin, block));
+
+        if (debug_) {
+          std::ostringstream out;
+          out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " returned " << block.bytes << " bytes at "
+              << ptr << " from associated queue " << block.queue->m_spQueueImpl.get() << " , event "
+              << block.event->m_spEventImpl.get() << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached ("
+              << cachedBytes_.free << " bytes), " << liveBlocks_.size() << " live blocks (" << cachedBytes_.live
+              << " bytes) outstanding." << std::endl;
+          std::cout << out.str() << std::endl;
+        }
+      } else {
+        // if the buffer is not recached, it is automatically freed when block goes out of scope
+        if (debug_) {
+          std::ostringstream out;
+          out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " freed " << block.bytes << " bytes at "
+              << ptr << " from associated queue " << block.queue->m_spQueueImpl.get() << ", event "
+              << block.event->m_spEventImpl.get() << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached ("
+              << cachedBytes_.free << " bytes), " << liveBlocks_.size() << " live blocks (" << cachedBytes_.live
+              << " bytes) outstanding." << std::endl;
+          std::cout << out.str() << std::endl;
+        }
+      }
+    }
+
+  private:
+    struct BlockDescriptor {
+      std::optional<Buffer> buffer;
+      std::optional<Queue> queue;
+      std::optional<Event> event;
+      size_t bytes = 0;
+      size_t requested = 0;  // for monitoring only
+      unsigned int bin = 0;
+
+      // the "synchronisation device" for this block
+      auto device() { return alpaka::getDev(*queue); }
+    };
+
+  private:
+    // return the maximum amount of memory that should be cached on this device
+    size_t cacheSize(size_t maxCachedBytes, double maxCachedFraction) const {
+      // note that getMemBytes() returns 0 if the platform does not support querying the device memory
+      size_t totalMemory = alpaka::getMemBytes(device_);
+      size_t memoryFraction = static_cast<size_t>(maxCachedFraction * totalMemory);
+      size_t size = std::numeric_limits<size_t>::max();
+      if (maxCachedBytes > 0 and maxCachedBytes < size) {
+        size = maxCachedBytes;
+      }
+      if (memoryFraction > 0 and memoryFraction < size) {
+        size = memoryFraction;
+      }
+      return size;
+    }
+
+    // return (bin, bin size)
+    std::tuple<unsigned int, size_t> findBin(size_t bytes) const {
+      if (bytes < minBinBytes_) {
+        return std::make_tuple(minBin_, minBinBytes_);
+      }
+      if (bytes > maxBinBytes_) {
+        throw std::runtime_error("Requested allocation size " + std::to_string(bytes) +
+                                 " bytes is too large for the caching detail with maximum bin " +
+                                 std::to_string(maxBinBytes_) +
+                                 " bytes. You might want to increase the maximum bin size");
+      }
+      unsigned int bin = minBin_;
+      size_t binBytes = minBinBytes_;
+      while (binBytes < bytes) {
+        ++bin;
+        binBytes *= binGrowth_;
+      }
+      return std::make_tuple(bin, binBytes);
+    }
+
+    bool tryReuseCachedBlock(BlockDescriptor& block) {
+      std::scoped_lock lock(mutex_);
+
+      // iterate through the range of cached blocks in the same bin
+      const auto [begin, end] = cachedBlocks_.equal_range(block.bin);
+      for (auto iBlock = begin; iBlock != end; ++iBlock) {
+        if ((reuseSameQueueAllocations_ and (*block.queue == *(iBlock->second.queue))) or
+            alpaka::isComplete(*(iBlock->second.event))) {
+          // associate the cached buffer to the new queue
+          auto const& previousDevice = block.device();
+          auto queue = std::move(*(block.queue));
+          // TODO cache (or remove) the debug information and use std::move()
+          block = iBlock->second;
+          block.queue = std::move(queue);
+
+          // if the old and new queues are associated to different devices, generate a new event
+          if (block.device() != previousDevice) {
+            block.event = Event{block.device()};
+          }
+
+          // insert the cached block into the live blocks
+          // TODO cache (or remove) the debug information and use std::move()
+          liveBlocks_[block.buffer->data()] = block;
+
+          // update the accounting information
+          cachedBytes_.free -= block.bytes;
+          cachedBytes_.live += block.bytes;
+          cachedBytes_.requested += block.requested;
+
+          if (debug_) {
+            std::ostringstream out;
+            out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " reused cached block at "
+                << block.buffer->data() << " (" << block.bytes << " bytes) for queue "
+                << block.queue->m_spQueueImpl.get() << ", event " << block.event->m_spEventImpl.get()
+                << " (previously associated with stream " << iBlock->second.queue->m_spQueueImpl.get() << " , event "
+                << iBlock->second.event->m_spEventImpl.get() << ")." << std::endl;
+            std::cout << out.str() << std::endl;
+          }
+
+          // remove the reused block from the list of cached blocks
+          cachedBlocks_.erase(iBlock);
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    void allocateNewBlock(BlockDescriptor& block) {
+      try {
+        // FIXME simplify alpaka::Vec<alpaka::DimInt<1u>, size_t>{block.bytes} to block.bytes ?
+        block.buffer =
+            alpaka::allocBuf<std::byte, size_t>(device_, alpaka::Vec<alpaka::DimInt<1u>, size_t>{block.bytes});
+      } catch (std::runtime_error const& e) {
+        // the allocation attempt failed: free all cached blocks on the device and retry
+        if (debug_) {
+          std::ostringstream out;
+          out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " failed to allocate " << block.bytes
+              << " bytes for queue " << block.queue->m_spQueueImpl.get()
+              << ", retrying after freeing cached allocations" << std::endl;
+          std::cout << out.str() << std::endl;
+        }
+        // TODO implement a method that frees only up to block.bytes bytes
+        freeAllCached();
+
+        // throw an exception if it fails again
+        block.buffer =
+            alpaka::allocBuf<std::byte, size_t>(device_, alpaka::Vec<alpaka::DimInt<1u>, size_t>{block.bytes});
+      }
+
+      // for host memory, pin the newly allocated block
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+      if (not cms::alpakatools::devices<alpaka::PltfUniformCudaHipRt>.empty()) {
+        // it is possible to initialise the CUDA runtime and call cudaHostRegister
+        // only if the system has at least one supported GPU
+        alpaka::prepareForAsyncCopy(*block.buffer);
+      }
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+      // create a new event associated to the "synchronisation device"
+      block.event = Event{block.device()};
+
+      {
+        std::scoped_lock lock(mutex_);
+        cachedBytes_.live += block.bytes;
+        cachedBytes_.requested += block.requested;
+        // TODO use std::move() ?
+        liveBlocks_[block.buffer->data()] = block;
+      }
+
+      if (debug_) {
+        std::ostringstream out;
+        out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " allocated new block at "
+            << block.buffer->data() << " (" << block.bytes << " bytes associated with queue "
+            << block.queue->m_spQueueImpl.get() << ", event " << block.event->m_spEventImpl.get() << "." << std::endl;
+        std::cout << out.str() << std::endl;
+      }
+    }
+
+    void freeAllCached() {
+      std::scoped_lock lock(mutex_);
+
+      while (not cachedBlocks_.empty()) {
+        auto iBlock = cachedBlocks_.begin();
+        cachedBytes_.free -= iBlock->second.bytes;
+
+        if (debug_) {
+          std::ostringstream out;
+          out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " freed " << iBlock->second.bytes
+              << " bytes.\n\t\t  " << (cachedBlocks_.size() - 1) << " available blocks cached (" << cachedBytes_.free
+              << " bytes), " << liveBlocks_.size() << " live blocks (" << cachedBytes_.live << " bytes) outstanding."
+              << std::endl;
+          std::cout << out.str() << std::endl;
+        }
+
+        cachedBlocks_.erase(iBlock);
+      }
+    }
+
+    // TODO replace with a tbb::concurrent_multimap ?
+    using CachedBlocks = std::multimap<unsigned int, BlockDescriptor>;  // ordered by the allocation bin
+    // TODO replace with a tbb::concurrent_map ?
+    using BusyBlocks = std::map<void*, BlockDescriptor>;  // ordered by the address of the allocated memory
+
+    inline static const std::string deviceType_ = boost::core::demangle(typeid(Device).name());
+
+    mutable std::mutex mutex_;
+    Device device_;  // the device where the memory is allocated
+
+    CachedBytes cachedBytes_;
+    CachedBlocks cachedBlocks_;  // Set of cached device allocations available for reuse
+    BusyBlocks liveBlocks_;      // map of pointers to the live device allocations currently in use
+
+    const unsigned int binGrowth_;  // Geometric growth factor for bin-sizes
+    const unsigned int minBin_;
+    const unsigned int maxBin_;
+
+    const size_t minBinBytes_;
+    const size_t maxBinBytes_;
+    const size_t maxCachedBytes_;  // Maximum aggregate cached bytes per device
+
+    const bool reuseSameQueueAllocations_;
+    const bool debug_;
+  };
+
+}  // namespace cms::alpakatools
+
+#endif  // AlpakaCore_CachingAllocator_h

--- a/src/alpaka/AlpakaCore/getDeviceCachingAllocator.h
+++ b/src/alpaka/AlpakaCore/getDeviceCachingAllocator.h
@@ -1,0 +1,65 @@
+#ifndef AlpakaCore_getDeviceCachingAllocator_h
+#define AlpakaCore_getDeviceCachingAllocator_h
+
+#include <optional>
+#include <mutex>
+#include <vector>
+
+#include "AlpakaCore/AllocatorConfig.h"
+#include "AlpakaCore/CachingAllocator.h"
+#include "AlpakaCore/alpakaDevices.h"
+#include "AlpakaCore/getDevIndex.h"
+
+namespace cms::alpakatools {
+
+  namespace detail {
+
+    template <typename TDevice, typename TQueue>
+    auto allocate_device_allocators() {
+      using Allocator = CachingAllocator<TDevice, TQueue>;
+      auto const& devices = cms::alpakatools::devices<alpaka::Pltf<TDevice>>;
+      auto const size = devices.size();
+
+      // allocate the storage for the objects
+      auto ptr = std::allocator<Allocator>().allocate(size);
+
+      // construct the objects in the storage
+      for (size_t index = 0; index < size; ++index) {
+        new (ptr + index) Allocator(devices[index],
+                                    config::binGrowth,
+                                    config::minBin,
+                                    config::maxBin,
+                                    config::maxCachedBytes,
+                                    config::maxCachedFraction,
+                                    true,    // reuseSameQueueAllocations
+                                    false);  // debug
+      }
+
+      // use a custom deleter to destroy all objects and deallocate the memory
+      auto deleter = [size](Allocator* ptr) {
+        for (size_t i = size; i > 0; --i) {
+          (ptr + i - 1)->~Allocator();
+        }
+        std::allocator<Allocator>().deallocate(ptr, size);
+      };
+
+      return std::unique_ptr<Allocator[], decltype(deleter)>(ptr, deleter);
+    }
+
+  }  // namespace detail
+
+  template <typename TDevice, typename TQueue>
+  inline CachingAllocator<TDevice, TQueue>& getDeviceCachingAllocator(TDevice const& device) {
+    // initialise all allocators, one per device
+    static auto allocators = detail::allocate_device_allocators<TDevice, TQueue>();
+
+    auto const index = getDevIndex(device);
+    assert(index < cms::alpakatools::devices<alpaka::Pltf<TDevice>>.size());
+
+    // the public interface is thread safe
+    return allocators[index];
+  }
+
+}  // namespace cms::alpakatools
+
+#endif  // AlpakaCore_getDeviceCachingAllocator_h

--- a/src/alpaka/AlpakaCore/getHostCachingAllocator.h
+++ b/src/alpaka/AlpakaCore/getHostCachingAllocator.h
@@ -1,0 +1,28 @@
+#ifndef AlpakaCore_getHostCachingAllocator_h
+#define AlpakaCore_getHostCachingAllocator_h
+
+#include "AlpakaCore/AllocatorConfig.h"
+#include "AlpakaCore/CachingAllocator.h"
+#include "AlpakaCore/alpakaDevices.h"
+
+namespace cms::alpakatools {
+
+  template <typename TQueue>
+  inline CachingAllocator<alpaka_common::DevHost, TQueue>& getHostCachingAllocator() {
+    // thread safe initialisation of the host allocator
+    static CachingAllocator<alpaka_common::DevHost, TQueue> allocator(host,
+                                                                      config::binGrowth,
+                                                                      config::minBin,
+                                                                      config::maxBin,
+                                                                      config::maxCachedBytes,
+                                                                      config::maxCachedFraction,
+                                                                      false,   // reuseSameQueueAllocations
+                                                                      false);  // debug
+
+    // the public interface is thread safe
+    return allocator;
+  }
+
+}  // namespace cms::alpakatools
+
+#endif  // AlpakaCore_getHostCachingAllocator_h

--- a/src/alpaka/AlpakaDataFormats/alpaka/SiPixelDigiErrorsAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/alpaka/SiPixelDigiErrorsAlpaka.h
@@ -16,7 +16,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     explicit SiPixelDigiErrorsAlpaka(Queue& queue, size_t maxFedWords, PixelFormatterErrors errors)
         : data_d{cms::alpakatools::make_device_buffer<PixelErrorCompact[]>(queue, maxFedWords)},
           error_d{cms::alpakatools::make_device_buffer<cms::alpakatools::SimpleVector<PixelErrorCompact>>(queue)},
-          error_h{cms::alpakatools::make_host_buffer<cms::alpakatools::SimpleVector<PixelErrorCompact>>()},
+          error_h{cms::alpakatools::make_host_buffer<cms::alpakatools::SimpleVector<PixelErrorCompact>>(queue)},
           formatterErrors_h{std::move(errors)} {
       error_h->construct(maxFedWords, data_d.data());
       ALPAKA_ASSERT_OFFLOAD(error_h->empty());

--- a/src/alpaka/AlpakaDataFormats/alpaka/SiPixelDigisAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/alpaka/SiPixelDigisAlpaka.h
@@ -59,7 +59,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     uint32_t const *c_rawIdArr() const { return rawIdArr_d.data(); }
 
     auto adcToHostAsync(Queue &queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<uint16_t[]>(nDigis());
+      auto ret = cms::alpakatools::make_host_buffer<uint16_t[]>(queue, nDigis());
       alpaka::memcpy(queue, ret, adc_d, nDigis());
       return ret;
     }

--- a/src/alpaka/AlpakaDataFormats/alpaka/TrackingRecHit2DAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/alpaka/TrackingRecHit2DAlpaka.h
@@ -36,7 +36,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           m_hist{cms::alpakatools::make_device_buffer<Hist>(queue)},
           // SoA view
           m_view{cms::alpakatools::make_device_buffer<TrackingRecHit2DSoAView>(queue)},
-          m_view_h{cms::alpakatools::make_host_buffer<TrackingRecHit2DSoAView>()} {
+          m_view_h{cms::alpakatools::make_host_buffer<TrackingRecHit2DSoAView>(queue)} {
       // the hits are actually accessed in order only in building
       // if ordering is relevant they may have to be stored phi-ordered by layer or so
       // this will break 1to1 correspondence with cluster and module locality
@@ -93,67 +93,67 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     auto xlToHostAsync(Queue& queue) const {
       auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), xl(), nHits());
-      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(queue, nHits());
       alpaka::memcpy(queue, host_buffer, device_view);
       return host_buffer;
     }
     auto ylToHostAsync(Queue& queue) const {
       auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), yl(), nHits());
-      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(queue, nHits());
       alpaka::memcpy(queue, host_buffer, device_view);
       return host_buffer;
     }
     auto xerrToHostAsync(Queue& queue) const {
       auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), xerr(), nHits());
-      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(queue, nHits());
       alpaka::memcpy(queue, host_buffer, device_view);
       return host_buffer;
     }
     auto yerrToHostAsync(Queue& queue) const {
       auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), yerr(), nHits());
-      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(queue, nHits());
       alpaka::memcpy(queue, host_buffer, device_view);
       return host_buffer;
     }
     auto xgToHostAsync(Queue& queue) const {
       auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), xg(), nHits());
-      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(queue, nHits());
       alpaka::memcpy(queue, host_buffer, device_view);
       return host_buffer;
     }
     auto ygToHostAsync(Queue& queue) const {
       auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), yg(), nHits());
-      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(queue, nHits());
       alpaka::memcpy(queue, host_buffer, device_view);
       return host_buffer;
     }
     auto zgToHostAsync(Queue& queue) const {
       auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), zg(), nHits());
-      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(queue, nHits());
       alpaka::memcpy(queue, host_buffer, device_view);
       return host_buffer;
     }
     auto rgToHostAsync(Queue& queue) const {
       auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), rg(), nHits());
-      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(queue, nHits());
       alpaka::memcpy(queue, host_buffer, device_view);
       return host_buffer;
     }
     auto chargeToHostAsync(Queue& queue) const {
       auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), charge(), nHits());
-      auto host_buffer = cms::alpakatools::make_host_buffer<int32_t[]>(nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<int32_t[]>(queue, nHits());
       alpaka::memcpy(queue, host_buffer, device_view);
       return host_buffer;
     }
     auto xsizeToHostAsync(Queue& queue) const {
       auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), xsize(), nHits());
-      auto host_buffer = cms::alpakatools::make_host_buffer<int16_t[]>(nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<int16_t[]>(queue, nHits());
       alpaka::memcpy(queue, host_buffer, device_view);
       return host_buffer;
     }
     auto ysizeToHostAsync(Queue& queue) const {
       auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), ysize(), nHits());
-      auto host_buffer = cms::alpakatools::make_host_buffer<int16_t[]>(nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<int16_t[]>(queue, nHits());
       alpaka::memcpy(queue, host_buffer, device_view);
       return host_buffer;
     }

--- a/src/alpaka/CondFormats/alpaka/PixelCPEFast.h
+++ b/src/alpaka/CondFormats/alpaka/PixelCPEFast.h
@@ -27,10 +27,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       in.read(reinterpret_cast<char *>(m_detParamsGPU.data()), ndetParams * sizeof(pixelCPEforGPU::DetParams));
       in.read(reinterpret_cast<char *>(m_averageGeometry.data()), sizeof(pixelCPEforGPU::AverageGeometry));
       in.read(reinterpret_cast<char *>(m_layerGeometry.data()), sizeof(pixelCPEforGPU::LayerGeometry));
-
-      alpaka::prepareForAsyncCopy(m_commonParamsGPU);
-      alpaka::prepareForAsyncCopy(m_layerGeometry);
-      alpaka::prepareForAsyncCopy(m_averageGeometry);
     }
 
     ~PixelCPEFast() = default;
@@ -74,14 +70,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     public:
       GPUData() = delete;
       GPUData(Queue &queue, unsigned int ndetParams)
-          : h_paramsOnGPU{cms::alpakatools::make_host_buffer<pixelCPEforGPU::ParamsOnGPU>()},
+          : h_paramsOnGPU{cms::alpakatools::make_host_buffer<pixelCPEforGPU::ParamsOnGPU>(queue)},
             d_paramsOnGPU{cms::alpakatools::make_device_buffer<pixelCPEforGPU::ParamsOnGPU>(queue)},
             d_commonParams{cms::alpakatools::make_device_buffer<pixelCPEforGPU::CommonParams>(queue)},
             d_layerGeometry{cms::alpakatools::make_device_buffer<pixelCPEforGPU::LayerGeometry>(queue)},
             d_averageGeometry{cms::alpakatools::make_device_buffer<pixelCPEforGPU::AverageGeometry>(queue)},
-            d_detParams{cms::alpakatools::make_device_buffer<pixelCPEforGPU::DetParams[]>(queue, ndetParams)} {
-        alpaka::prepareForAsyncCopy(h_paramsOnGPU);
-      };
+            d_detParams{cms::alpakatools::make_device_buffer<pixelCPEforGPU::DetParams[]>(queue, ndetParams)} {};
       ~GPUData() = default;
 
     public:

--- a/src/alpaka/CondFormats/alpaka/SiPixelFedCablingMapGPUWrapper.h
+++ b/src/alpaka/CondFormats/alpaka/SiPixelFedCablingMapGPUWrapper.h
@@ -58,9 +58,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     public:
       GPUData() = delete;
       GPUData(Queue const& queue)
-          : cablingMapDevice{cms::alpakatools::make_device_buffer<SiPixelFedCablingMapGPU>(queue)} {
-        alpaka::prepareForAsyncCopy(cablingMapDevice);
-      };
+          : cablingMapDevice{cms::alpakatools::make_device_buffer<SiPixelFedCablingMapGPU>(queue)} {};
       ~GPUData() = default;
 
       cms::alpakatools::device_buffer<Device, SiPixelFedCablingMapGPU> cablingMapDevice;  // pointer to struct in GPU

--- a/src/alpaka/CondFormats/alpaka/SiPixelGainCalibrationForHLTGPU.h
+++ b/src/alpaka/CondFormats/alpaka/SiPixelGainCalibrationForHLTGPU.h
@@ -19,7 +19,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           gainData_(gainData),
           numDecodingStructures_(gainData.size()) {
       *gainForHLTonHost_ = gain;
-      alpaka::prepareForAsyncCopy(gainForHLTonHost_);
     };
 
     ~SiPixelGainCalibrationForHLTGPU() = default;
@@ -45,10 +44,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       GPUData() = delete;
       GPUData(Queue const& queue, unsigned int numDecodingStructures)
           : gainForHLTonGPU{cms::alpakatools::make_device_buffer<SiPixelGainForHLTonGPU>(queue)},
-            gainDataOnGPU{cms::alpakatools::make_host_buffer<SiPixelGainForHLTonGPU>()},
-            v_pedestalsGPU{cms::alpakatools::make_device_buffer<DecodingStructure[]>(queue, numDecodingStructures)} {
-        alpaka::prepareForAsyncCopy(gainDataOnGPU);
-      };
+            gainDataOnGPU{cms::alpakatools::make_host_buffer<SiPixelGainForHLTonGPU>(queue)},
+            v_pedestalsGPU{cms::alpakatools::make_device_buffer<DecodingStructure[]>(queue, numDecodingStructures)} {};
       ~GPUData() = default;
 
       cms::alpakatools::device_buffer<Device, SiPixelGainForHLTonGPU> gainForHLTonGPU;

--- a/src/alpaka/plugin-BeamSpotProducer/alpaka/BeamSpotToAlpaka.cc
+++ b/src/alpaka/plugin-BeamSpotProducer/alpaka/BeamSpotToAlpaka.cc
@@ -26,9 +26,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   BeamSpotToAlpaka::BeamSpotToAlpaka(edm::ProductRegistry& reg)
       : bsPutToken_{reg.produces<cms::alpakatools::Product<Queue, BeamSpotAlpaka>>()},
-        bsHost_{cms::alpakatools::make_host_buffer<BeamSpotPOD>()} {
-    alpaka::prepareForAsyncCopy(bsHost_);
-  }
+        bsHost_{cms::alpakatools::make_host_buffer<BeamSpotPOD>()} {}
 
   void BeamSpotToAlpaka::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     *bsHost_ = iSetup.get<BeamSpotPOD>();

--- a/src/alpaka/plugin-PixelTrackFitting/alpaka/PixelTrackSoAFromAlpaka.cc
+++ b/src/alpaka/plugin-PixelTrackFitting/alpaka/PixelTrackSoAFromAlpaka.cc
@@ -39,10 +39,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   void PixelTrackSoAFromAlpaka::acquire(edm::Event const& iEvent,
                                         edm::EventSetup const& iSetup,
                                         edm::WaitingTaskWithArenaHolder waitingTaskHolder) {
-    soa_ = cms::alpakatools::make_host_buffer<pixelTrack::TrackSoA>();
     cms::alpakatools::Product<Queue, PixelTrackAlpaka> const& inputDataWrapped = iEvent.get(tokenDevice_);
     cms::alpakatools::ScopedContextAcquire ctx{inputDataWrapped, std::move(waitingTaskHolder)};
     auto const& inputData = ctx.get(inputDataWrapped);
+    soa_ = cms::alpakatools::make_host_buffer<pixelTrack::TrackSoA>(ctx.stream());
     alpaka::memcpy(ctx.stream(), soa_, inputData);
   }
 

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/PixelVertexSoAFromAlpaka.cc
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/PixelVertexSoAFromAlpaka.cc
@@ -45,7 +45,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     cms::alpakatools::ScopedContextAcquire<Queue> ctx{inputDataWrapped, std::move(waitingTaskHolder)};
     auto const& inputData = ctx.get(inputDataWrapped);
 
-    soa_ = cms::alpakatools::make_host_buffer<ZVertexSoA>();
+    soa_ = cms::alpakatools::make_host_buffer<ZVertexSoA>(ctx.stream());
     alpaka::memcpy(ctx.stream(), soa_, inputData);
   }
 

--- a/src/alpaka/plugin-Validation/alpaka/HistoValidator.cc
+++ b/src/alpaka/plugin-Validation/alpaka/HistoValidator.cc
@@ -122,7 +122,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     h_adc = std::move(digis.adcToHostAsync(ctx.stream()));
 
     nClusters_ = clusters.nClusters();
-    h_clusInModule = cms::alpakatools::make_host_buffer<uint32_t[]>(nModules_);
+    h_clusInModule = cms::alpakatools::make_host_buffer<uint32_t[]>(ctx.stream(), nModules_);
     alpaka::memcpy(ctx.stream(),
                    *h_clusInModule,
                    cms::alpakatools::make_device_view(ctx.device(), clusters.clusInModule(), nModules_));

--- a/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
+++ b/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
@@ -90,7 +90,7 @@ int main() {
   alpaka::enqueue(queue,
                   alpaka::createTaskKernel<Acc1D>(workDiv, verify(), c_d.data(), n_d.data(), m_d.data(), NUM_VALUES));
 
-  auto c_h = make_host_buffer<AtomicPairCounter>();
+  auto c_h = make_host_buffer<AtomicPairCounter>(queue);
   alpaka::memcpy(queue, c_h, c_d);
   alpaka::wait(queue);
 

--- a/src/alpaka/test/alpaka/HistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/HistoContainer_t.cc
@@ -19,7 +19,7 @@ void go(const DevHost& host, const Device& device, Queue& queue) {
   std::uniform_int_distribution<T> rgen(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
 
   constexpr unsigned int N = 12000;
-  auto v = make_host_buffer<T[]>(N);
+  auto v = make_host_buffer<T[]>(queue, N);
   auto v_d = make_device_buffer<T[]>(queue, N);
   alpaka::memcpy(queue, v_d, v);
 
@@ -31,10 +31,10 @@ void go(const DevHost& host, const Device& device, Queue& queue) {
             << Hist::capacity() << ' ' << offsetof(Hist, bins) - offsetof(Hist, off) << ' '
             << (std::numeric_limits<T>::max() - std::numeric_limits<T>::min()) / Hist::nbins() << std::endl;
 
-  auto offsets = make_host_buffer<uint32_t[]>(nParts + 1);
+  auto offsets = make_host_buffer<uint32_t[]>(queue, nParts + 1);
   auto offsets_d = make_device_buffer<uint32_t[]>(queue, nParts + 1);
 
-  auto h = make_host_buffer<Hist>();
+  auto h = make_host_buffer<Hist>(queue);
   auto h_d = make_device_buffer<Hist>(queue);
 
   for (int it = 0; it < 5; ++it) {

--- a/src/alpaka/test/alpaka/OneHistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/OneHistoContainer_t.cc
@@ -131,7 +131,7 @@ void go(const DevHost& host, const Device& device, Queue& queue) {
             << (rmax - rmin) / Hist::nbins() << std::endl;
   std::cout << "bins " << int(Hist::bin(0)) << ' ' << int(Hist::bin(rmin)) << ' ' << int(Hist::bin(rmax)) << std::endl;
 
-  auto v = make_host_buffer<T[]>(N);
+  auto v = make_host_buffer<T[]>(queue, N);
   auto v_d = make_device_buffer<T[]>(queue, N);
 
   for (int it = 0; it < 5; ++it) {

--- a/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
+++ b/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
@@ -145,7 +145,7 @@ int main() {
 
   constexpr uint32_t N = 4000;
 
-  auto tr = make_host_buffer<std::array<uint16_t, 4>[]>(N);
+  auto tr = make_host_buffer<std::array<uint16_t, 4>[]>(queue, N);
   // fill with "index" to element
   long long ave = 0;
   int imax = 0;
@@ -200,7 +200,7 @@ int main() {
 
   alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv4N, fill(), v_d.data(), a_d.data(), N));
 
-  auto la = make_host_buffer<Assoc>();
+  auto la = make_host_buffer<Assoc>(queue);
   alpaka::memcpy(queue, la, a_d);
   alpaka::wait(queue);
 
@@ -235,7 +235,7 @@ int main() {
 
   alpaka::memcpy(queue, la, a_d);
 
-  auto dc = make_host_buffer<AtomicPairCounter>();
+  auto dc = make_host_buffer<AtomicPairCounter>(queue);
   alpaka::memcpy(queue, dc, dc_d);
   alpaka::wait(queue);
 

--- a/src/alpaka/test/alpaka/clustering_t.cc
+++ b/src/alpaka/test/alpaka/clustering_t.cc
@@ -27,11 +27,11 @@ int main(void) {
 
   constexpr unsigned int numElements = 256 * 2000;
   // these in reality are already on GPU
-  auto h_id = make_host_buffer<uint16_t[]>(numElements);
-  auto h_x = make_host_buffer<uint16_t[]>(numElements);
-  auto h_y = make_host_buffer<uint16_t[]>(numElements);
-  auto h_adc = make_host_buffer<uint16_t[]>(numElements);
-  auto h_clus = make_host_buffer<int[]>(numElements);
+  auto h_id = make_host_buffer<uint16_t[]>(queue, numElements);
+  auto h_x = make_host_buffer<uint16_t[]>(queue, numElements);
+  auto h_y = make_host_buffer<uint16_t[]>(queue, numElements);
+  auto h_adc = make_host_buffer<uint16_t[]>(queue, numElements);
+  auto h_clus = make_host_buffer<int[]>(queue, numElements);
 
   auto d_id = make_device_buffer<uint16_t[]>(queue, numElements);
   auto d_x = make_device_buffer<uint16_t[]>(queue, numElements);
@@ -227,7 +227,7 @@ int main(void) {
     std::cout << "created " << n << " digis in " << ncl << " clusters" << std::endl;
     assert(n <= numElements);
 
-    auto nModules = make_host_buffer<uint32_t[]>(1u);
+    auto nModules = make_host_buffer<uint32_t[]>(queue, 1u);
     nModules[0] = 0;
     alpaka::memcpy(queue, d_moduleStart, nModules, 1u);  // copy only the first element
 
@@ -276,13 +276,13 @@ int main(void) {
                                                     n));
     alpaka::memcpy(queue, nModules, d_moduleStart, 1u);  // copy only the first element
 
-    auto nclus = make_host_buffer<uint32_t[]>(gpuClustering::MaxNumModules);
+    auto nclus = make_host_buffer<uint32_t[]>(queue, gpuClustering::MaxNumModules);
     alpaka::memcpy(queue, nclus, d_clusInModule);
 
     // Wait for memory transfers to be completed
     alpaka::wait(queue);
 
-    auto moduleId = make_host_buffer<uint32_t[]>(nModules[0]);
+    auto moduleId = make_host_buffer<uint32_t[]>(queue, nModules[0]);
 
     std::cout << "before charge cut found "
               << std::accumulate(nclus.data(), nclus.data() + gpuClustering::MaxNumModules, 0) << " clusters"


### PR DESCRIPTION
Implement a caching allocator based on the `cuda`/`cudadev` one for device memory and pinned host memory.

The performance profile of the `alpaka --cuda` program now follows the one of the `cuda` program, while still having a ~5% performance degradation (shown in the plot after merging #307 and #308):

![image](https://user-images.githubusercontent.com/4069793/153302297-c492b643-f10f-4b90-a7df-b252171db36b.png)
