### PR TITLE
[alpaka] Restructure TrackingRecHit2DAlpaka with SoA's like the cuda version

### DIFF
--- a/src/alpaka/AlpakaDataFormats/alpaka/TrackingRecHit2DAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/alpaka/TrackingRecHit2DAlpaka.h
@@ -22,26 +22,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                     const uint32_t* hitsModuleStart,
                                     Queue& queue)
         : m_nHits(nHits),
-          // NON-OWNING DEVICE POINTERS:
+          // non-owning device pointers
           m_hitsModuleStart(hitsModuleStart),
-          // OWNING DEVICE POINTERS:
-          m_xl{cms::alpakatools::make_device_buffer<float[]>(queue, nHits)},
-          m_yl{cms::alpakatools::make_device_buffer<float[]>(queue, nHits)},
-          m_xerr{cms::alpakatools::make_device_buffer<float[]>(queue, nHits)},
-          m_yerr{cms::alpakatools::make_device_buffer<float[]>(queue, nHits)},
-          m_xg{cms::alpakatools::make_device_buffer<float[]>(queue, nHits)},
-          m_yg{cms::alpakatools::make_device_buffer<float[]>(queue, nHits)},
-          m_zg{cms::alpakatools::make_device_buffer<float[]>(queue, nHits)},
-          m_rg{cms::alpakatools::make_device_buffer<float[]>(queue, nHits)},
-          m_iphi{cms::alpakatools::make_device_buffer<int16_t[]>(queue, nHits)},
-          m_charge{cms::alpakatools::make_device_buffer<int32_t[]>(queue, nHits)},
-          m_xsize{cms::alpakatools::make_device_buffer<int16_t[]>(queue, nHits)},
-          m_ysize{cms::alpakatools::make_device_buffer<int16_t[]>(queue, nHits)},
-          m_detInd{cms::alpakatools::make_device_buffer<uint16_t[]>(queue, nHits)},
+          // TODO replace with Eric's SoA
+          // 32-bit SoA data members packed in a single buffer
+          m_store32{cms::alpakatools::make_device_buffer<uint32_t[]>(
+              queue, nHits * static_cast<uint32_t>(Fields32::size_) + 11)},
+          // 16-bit SoA data members packed in a single buffer
+          m_store16{
+              cms::alpakatools::make_device_buffer<uint16_t[]>(queue, nHits * static_cast<uint32_t>(Fields16::size_))},
+          // other owning device pointers
           m_averageGeometry{cms::alpakatools::make_device_buffer<TrackingRecHit2DSoAView::AverageGeometry>(queue)},
-          m_hitsLayerStart{cms::alpakatools::make_device_buffer<uint32_t[]>(queue, nHits)},
           m_hist{cms::alpakatools::make_device_buffer<Hist>(queue)},
-          // SoA view:
+          // SoA view
           m_view{cms::alpakatools::make_device_buffer<TrackingRecHit2DSoAView>(queue)},
           m_view_h{cms::alpakatools::make_host_buffer<TrackingRecHit2DSoAView>()} {
       // the hits are actually accessed in order only in building
@@ -49,31 +42,34 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // this will break 1to1 correspondence with cluster and module locality
       // so unless proven VERY inefficient we keep it ordered as generated
 
-      // Copy data to the SoA view:
-      // By value:
+      // copy all the pointers
       m_view_h->m_nHits = nHits;
-      // Raw pointer to data already owned in the event by SiPixelClusterAlpaka object:
+      m_view_h->m_hist = phiBinner();
+
+      // pointer to data already owned in the event by SiPixelClusterAlpaka object:
       m_view_h->m_hitsModuleStart = hitsModuleStart;
-      // Raw pointer to data already owned in the eventSetup by PixelCPEFast object:
+
+      // pointer to data already owned in the eventSetup by PixelCPEFast object:
       m_view_h->m_cpeParams = cpeParams;
-      // Raw pointers to data owned here in TrackingRecHit2DAlpaka object:
-      m_view_h->m_xl = m_xl.data();
-      m_view_h->m_yl = m_yl.data();
-      m_view_h->m_xerr = m_xerr.data();
-      m_view_h->m_yerr = m_yerr.data();
-      m_view_h->m_xg = m_xg.data();
-      m_view_h->m_yg = m_yg.data();
-      m_view_h->m_zg = m_zg.data();
-      m_view_h->m_rg = m_rg.data();
-      m_view_h->m_iphi = m_iphi.data();
-      m_view_h->m_charge = m_charge.data();
-      m_view_h->m_xsize = m_xsize.data();
-      m_view_h->m_ysize = m_ysize.data();
-      m_view_h->m_detInd = m_detInd.data();
+
+      // pointers to data owned by this TrackingRecHit2DAlpaka object:
+      m_view_h->m_xl = xl();
+      m_view_h->m_yl = yl();
+      m_view_h->m_xerr = xerr();
+      m_view_h->m_yerr = yerr();
+      m_view_h->m_xg = xg();
+      m_view_h->m_yg = yg();
+      m_view_h->m_zg = zg();
+      m_view_h->m_rg = rg();
+      m_view_h->m_iphi = iphi();
+      m_view_h->m_charge = charge();
+      m_view_h->m_xsize = xsize();
+      m_view_h->m_ysize = ysize();
+      m_view_h->m_detInd = detInd();
+      m_view_h->m_hitsLayerStart = hitsLayerStart();
       m_view_h->m_averageGeometry = m_averageGeometry.data();
-      m_view_h->m_hitsLayerStart = m_hitsLayerStart.data();
-      m_view_h->m_hist = m_hist.data();
-      // Copy the SoA view to the device
+
+      // copy the SoA view to the device
       alpaka::memcpy(queue, m_view, m_view_h);
     }
 
@@ -81,124 +77,177 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     TrackingRecHit2DAlpaka(const TrackingRecHit2DAlpaka&) = delete;
     TrackingRecHit2DAlpaka& operator=(const TrackingRecHit2DAlpaka&) = delete;
+
     TrackingRecHit2DAlpaka(TrackingRecHit2DAlpaka&&) = default;
     TrackingRecHit2DAlpaka& operator=(TrackingRecHit2DAlpaka&&) = default;
 
     TrackingRecHit2DSoAView* view() { return m_view.data(); }
     TrackingRecHit2DSoAView const* view() const { return m_view.data(); }
 
-    auto nHits() const { return m_nHits; }
-    auto hitsModuleStart() const { return m_hitsModuleStart; }
+    uint32_t nHits() const { return m_nHits; }
 
-    auto hitsLayerStart() { return m_hitsLayerStart.data(); }
-    auto const* c_hitsLayerStart() const { return m_hitsLayerStart.data(); }
-    auto phiBinner() { return m_hist.data(); }
-    auto iphi() { return m_iphi.data(); }
-    auto const* c_iphi() const { return m_iphi.data(); }
+    uint32_t const* hitsModuleStart() const { return m_hitsModuleStart; }
+
+    Hist* phiBinner() { return m_hist.data(); }
+    Hist const* phiBinner() const { return m_hist.data(); }
 
     auto xlToHostAsync(Queue& queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<float[]>(nHits());
-      alpaka::memcpy(queue, ret, m_xl);
-      return ret;
+      auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), xl(), nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      alpaka::memcpy(queue, host_buffer, device_view);
+      return host_buffer;
     }
     auto ylToHostAsync(Queue& queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<float[]>(nHits());
-      alpaka::memcpy(queue, ret, m_yl);
-      return ret;
+      auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), yl(), nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      alpaka::memcpy(queue, host_buffer, device_view);
+      return host_buffer;
     }
     auto xerrToHostAsync(Queue& queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<float[]>(nHits());
-      alpaka::memcpy(queue, ret, m_xerr);
-      return ret;
+      auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), xerr(), nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      alpaka::memcpy(queue, host_buffer, device_view);
+      return host_buffer;
     }
     auto yerrToHostAsync(Queue& queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<float[]>(nHits());
-      alpaka::memcpy(queue, ret, m_yerr);
-      return ret;
+      auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), yerr(), nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      alpaka::memcpy(queue, host_buffer, device_view);
+      return host_buffer;
     }
     auto xgToHostAsync(Queue& queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<float[]>(nHits());
-      alpaka::memcpy(queue, ret, m_xg);
-      return ret;
+      auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), xg(), nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      alpaka::memcpy(queue, host_buffer, device_view);
+      return host_buffer;
     }
     auto ygToHostAsync(Queue& queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<float[]>(nHits());
-      alpaka::memcpy(queue, ret, m_yg);
-      return ret;
+      auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), yg(), nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      alpaka::memcpy(queue, host_buffer, device_view);
+      return host_buffer;
     }
     auto zgToHostAsync(Queue& queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<float[]>(nHits());
-      alpaka::memcpy(queue, ret, m_zg);
-      return ret;
+      auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), zg(), nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      alpaka::memcpy(queue, host_buffer, device_view);
+      return host_buffer;
     }
     auto rgToHostAsync(Queue& queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<float[]>(nHits());
-      alpaka::memcpy(queue, ret, m_rg);
-      return ret;
+      auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), rg(), nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<float[]>(nHits());
+      alpaka::memcpy(queue, host_buffer, device_view);
+      return host_buffer;
     }
     auto chargeToHostAsync(Queue& queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<int32_t[]>(nHits());
-      alpaka::memcpy(queue, ret, m_charge);
-      return ret;
+      auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), charge(), nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<int32_t[]>(nHits());
+      alpaka::memcpy(queue, host_buffer, device_view);
+      return host_buffer;
     }
     auto xsizeToHostAsync(Queue& queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<int16_t[]>(nHits());
-      alpaka::memcpy(queue, ret, m_xsize);
-      return ret;
+      auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), xsize(), nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<int16_t[]>(nHits());
+      alpaka::memcpy(queue, host_buffer, device_view);
+      return host_buffer;
     }
     auto ysizeToHostAsync(Queue& queue) const {
-      auto ret = cms::alpakatools::make_host_buffer<int16_t[]>(nHits());
-      alpaka::memcpy(queue, ret, m_ysize);
-      return ret;
+      auto device_view = cms::alpakatools::make_device_view(alpaka::getDev(queue), ysize(), nHits());
+      auto host_buffer = cms::alpakatools::make_host_buffer<int16_t[]>(nHits());
+      alpaka::memcpy(queue, host_buffer, device_view);
+      return host_buffer;
     }
+
 #ifdef TODO
     // only the local coord and detector index
     cms::alpakatools::host::unique_ptr<uint16_t[]> detIndexToHostAsync(cudaStream_t stream) const;
     cms::alpakatools::host::unique_ptr<uint32_t[]> hitsModuleStartToHostAsync(cudaStream_t stream) const;
 #endif
-    auto const* xl() const { return m_xl.data(); }
-    auto const* yl() const { return m_yl.data(); }
-    auto const* xerr() const { return m_xerr.data(); }
-    auto const* yerr() const { return m_yerr.data(); }
-    auto const* xg() const { return m_xg.data(); }
-    auto const* yg() const { return m_yg.data(); }
-    auto const* zg() const { return m_zg.data(); }
-    auto const* rg() const { return m_rg.data(); }
-    auto const* charge() const { return m_charge.data(); }
-    auto const* xsize() const { return m_xsize.data(); }
-    auto const* ysize() const { return m_ysize.data(); }
+
+    // non-const accessors
+    float* xl() { return getField32<float>(Fields32::xl); }
+    float* yl() { return getField32<float>(Fields32::yl); }
+    float* xerr() { return getField32<float>(Fields32::xerr); }
+    float* yerr() { return getField32<float>(Fields32::yerr); }
+
+    float* xg() { return getField32<float>(Fields32::xg); }
+    float* yg() { return getField32<float>(Fields32::yg); }
+    float* zg() { return getField32<float>(Fields32::zg); }
+    float* rg() { return getField32<float>(Fields32::rg); }
+
+    int32_t* charge() { return getField32<int32_t>(Fields32::charge); }
+    int16_t* xsize() { return getField16<int16_t>(Fields16::xsize); }
+    int16_t* ysize() { return getField16<int16_t>(Fields16::ysize); }
+
+    int16_t* iphi() { return getField16<int16_t>(Fields16::iphi); }
+    uint16_t* detInd() { return getField16<uint16_t>(Fields16::detInd); }
+    uint32_t* hitsLayerStart() { return getField32<uint32_t>(Fields32::size_); }
+
+    // const accessors
+    float const* xl() const { return getField32<float>(Fields32::xl); }
+    float const* yl() const { return getField32<float>(Fields32::yl); }
+    float const* xerr() const { return getField32<float>(Fields32::xerr); }
+    float const* yerr() const { return getField32<float>(Fields32::yerr); }
+
+    float const* xg() const { return getField32<float>(Fields32::xg); }
+    float const* yg() const { return getField32<float>(Fields32::yg); }
+    float const* zg() const { return getField32<float>(Fields32::zg); }
+    float const* rg() const { return getField32<float>(Fields32::rg); }
+
+    int32_t const* charge() const { return getField32<int32_t>(Fields32::charge); }
+    int16_t const* xsize() const { return getField16<int16_t>(Fields16::xsize); }
+    int16_t const* ysize() const { return getField16<int16_t>(Fields16::ysize); }
+
+    int16_t const* iphi() const { return getField16<int16_t>(Fields16::iphi); }
+    uint16_t const* detInd() const { return getField16<uint16_t>(Fields16::detInd); }
+    uint32_t const* hitsLayerStart() const { return getField32<uint32_t>(Fields32::size_); }
+
+    // explicitly const accessors
+    int16_t const* c_iphi() const { return getField16<int16_t>(Fields16::iphi); }
+    uint32_t const* c_hitsLayerStart() const { return getField32<uint32_t>(Fields32::size_); }
 
   private:
     uint32_t m_nHits;
 
-    // NON-OWNING DEVICE POINTERS
+    // non-owning device pointers
     // m_hitsModuleStart data is already owned by SiPixelClusterAlpaka, let's not abuse of shared_ptr!!
     uint32_t const* m_hitsModuleStart;  // needed for legacy, this is on GPU!
 
-    // OWNING DEVICE POINTERS
-    // local coord
-    cms::alpakatools::device_buffer<Device, float[]> m_xl;
-    cms::alpakatools::device_buffer<Device, float[]> m_yl;
-    cms::alpakatools::device_buffer<Device, float[]> m_xerr;
-    cms::alpakatools::device_buffer<Device, float[]> m_yerr;
+    // TODO replace with Eric's SoA
+    static_assert(sizeof(uint32_t) == sizeof(float));  // just stating the obvious
+    // 32-bit SoA data members (float, int32_t or uint32_t) packed in a single buffer
+    enum class Fields32 : uint32_t { xl, yl, xerr, yerr, xg, yg, zg, rg, charge, size_ };
+    // 16-bit SoA data members (int16_t or uint16_t) packed in a single buffer
+    enum class Fields16 : uint32_t { iphi, detInd, xsize, ysize, size_ };
 
-    // global coord
-    cms::alpakatools::device_buffer<Device, float[]> m_xg;
-    cms::alpakatools::device_buffer<Device, float[]> m_yg;
-    cms::alpakatools::device_buffer<Device, float[]> m_zg;
-    cms::alpakatools::device_buffer<Device, float[]> m_rg;
-    cms::alpakatools::device_buffer<Device, int16_t[]> m_iphi;
+    template <typename T>
+    T* getField32(Fields32 field) {
+      return reinterpret_cast<T*>(m_store32.data() + static_cast<uint32_t>(field) * m_nHits);
+    }
 
-    // cluster properties
-    cms::alpakatools::device_buffer<Device, int32_t[]> m_charge;
-    cms::alpakatools::device_buffer<Device, int16_t[]> m_xsize;
-    cms::alpakatools::device_buffer<Device, int16_t[]> m_ysize;
-    cms::alpakatools::device_buffer<Device, uint16_t[]> m_detInd;
+    template <typename T>
+    T const* getField32(Fields32 field) const {
+      return reinterpret_cast<T const*>(m_store32.data() + static_cast<uint32_t>(field) * m_nHits);
+    }
+
+    template <typename T>
+    T* getField16(Fields16 field) {
+      return reinterpret_cast<T*>(m_store16.data() + static_cast<uint32_t>(field) * m_nHits);
+    }
+
+    template <typename T>
+    T const* getField16(Fields16 field) const {
+      return reinterpret_cast<T const*>(m_store16.data() + static_cast<uint32_t>(field) * m_nHits);
+    }
+
+    // 32-bit SoA data members packed in a single buffer
+    cms::alpakatools::device_buffer<Device, uint32_t[]> m_store32;
+    // 16-bit SoA data members packed in a single buffer
+    cms::alpakatools::device_buffer<Device, uint16_t[]> m_store16;
 
     cms::alpakatools::device_buffer<Device, TrackingRecHit2DSoAView::AverageGeometry> m_averageGeometry;
 
     // needed as kernel params...
-    cms::alpakatools::device_buffer<Device, uint32_t[]> m_hitsLayerStart;
     cms::alpakatools::device_buffer<Device, Hist> m_hist;
 
     // This is a SoA view which itself gathers non-owning pointers to the data owned above (in TrackingRecHit2DAlpaka instance).


### PR DESCRIPTION
Replaces the 14 memory buffers used in the `alpaka` version with 2 larger memory buffers, as is done in the `cuda` version.