### PR TITLE
[kokkos] Disable Desul atomics temporarily to improve performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,9 @@ export NVCC_WRAPPER_DEFAULT_COMPILER := $(CXX)
 KOKKOS_CMAKEFLAGS := -DCMAKE_INSTALL_PREFIX=$(KOKKOS_INSTALL) \
                      -DCMAKE_INSTALL_LIBDIR=lib \
                      -DKokkos_CXX_STANDARD=14 \
-                     -DKokkos_ENABLE_SERIAL=On
+                     -DKokkos_ENABLE_SERIAL=On \
+                     -DKokkos_ENABLE_LIBDL=On \
+                     -DKokkos_ENABLE_PROFILING_LOAD_PRINT=On
 KOKKOS_IS_SHARED :=
 ifndef KOKKOS_DEVICE_PARALLEL
   KOKKOS_CMAKEFLAGS += -DCMAKE_CXX_COMPILER=g++

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,8 @@ KOKKOS_CMAKEFLAGS := -DCMAKE_INSTALL_PREFIX=$(KOKKOS_INSTALL) \
                      -DKokkos_CXX_STANDARD=14 \
                      -DKokkos_ENABLE_SERIAL=On \
                      -DKokkos_ENABLE_LIBDL=On \
-                     -DKokkos_ENABLE_PROFILING_LOAD_PRINT=On
+                     -DKokkos_ENABLE_PROFILING_LOAD_PRINT=On \
+                     -DKokkos_ENABLE_IMPL_DESUL_ATOMICS=Off
 KOKKOS_IS_SHARED :=
 ifndef KOKKOS_DEVICE_PARALLEL
   KOKKOS_CMAKEFLAGS += -DCMAKE_CXX_COMPILER=g++

--- a/src/kokkos/KokkosCore/kokkoshost/kokkosConfigCommon.cc
+++ b/src/kokkos/KokkosCore/kokkoshost/kokkosConfigCommon.cc
@@ -47,6 +47,10 @@ namespace kokkos_common {
   InitializeScopeGuard::InitializeScopeGuard(std::vector<Backend> const& backends, int numberOfInnerThreads) {
     // for now pass in the default arguments
     Kokkos::InitArguments arguments(numberOfInnerThreads);
+    auto env_tool_lib = std::getenv("KOKKOS_PROFILE_LIBRARY");
+    if (env_tool_lib != nullptr) {
+      arguments.tool_lib = env_tool_lib;
+    }
     pimpl_ = std::make_unique<Impl>(backends, arguments);
   }
 


### PR DESCRIPTION
The Kokkos update to 3.5 turned out to decrease the throughput by 2-3x. Disabling "Desul atomics" (that Kokkos was changed to use by default in 3.5) appears to cure the issue, but this is only a temporary workaround, because the "old atomics implementation" is going to be phased out. The issue is being followed up with Kokkos developers in https://github.com/kokkos/kokkos/issues/4780.

In addition, this PR adds support for using Kokkos' profiling tools via the `KOKKOS_PROFILE_LIBRARY` environment variable. (functionality that we were missing because of heavily customized initialization of Kokkos).,