### PR TITLE
[alpaka] Fix the use of non-blocking queues with TBB

### DIFF
--- a/src/alpaka/AlpakaCore/alpakaConfig.h
+++ b/src/alpaka/AlpakaCore/alpakaConfig.h
@@ -96,7 +96,7 @@ namespace alpaka_tbb_async {
 
   using Platform = alpaka::PltfCpu;
   using Device = alpaka::DevCpu;
-  using Queue = alpaka::QueueCpuBlocking;
+  using Queue = alpaka::QueueCpuNonBlocking;
   using Event = alpaka::EventCpu;
 
   template <typename TDim>


### PR DESCRIPTION
Revert a change mistakenly introduced in the last reorganisation of the Alpaka configuration.