### PR TITLE
[alpaka] Sync TB host copies only when needed

### DIFF
--- a/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelRecHits.cc
+++ b/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelRecHits.cc
@@ -2,6 +2,8 @@
 #include <iostream>
 #endif
 
+#include "AlpakaCore/AllocatorPolicy.h"
+#include "AlpakaCore/alpakaConfig.h"
 #include "CondFormats/pixelCPEforGPU.h"
 
 #include "PixelRecHits.h"
@@ -79,8 +81,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       alpaka::wait(queue);
 #endif
 
+#if defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ASYNC_BACKEND && defined ALPAKA_DISABLE_CACHING_ALLOCATOR
       // FIXME this is required to keep the host buffer inside hits_d alive; it could be removed once the host buffers are also stream-ordered
       alpaka::wait(queue);
+#endif
+
       return hits_d;
     }
 


### PR DESCRIPTION
Synchronise the queues and wait for the host-device copies to complete only when using the TBB async backend, without the caching allocator.