### PR TITLE
[alpaka] Fix CachingAllocator for pinned host memory in presence of multiple devices

### DIFF
--- a/src/alpaka/AlpakaCore/CachingAllocator.h
+++ b/src/alpaka/AlpakaCore/CachingAllocator.h
@@ -273,14 +273,13 @@ namespace cms::alpakatools {
         if ((reuseSameQueueAllocations_ and (*block.queue == *(iBlock->second.queue))) or
             alpaka::isComplete(*(iBlock->second.event))) {
           // associate the cached buffer to the new queue
-          auto const& previousDevice = block.device();
           auto queue = std::move(*(block.queue));
           // TODO cache (or remove) the debug information and use std::move()
           block = iBlock->second;
           block.queue = std::move(queue);
 
-          // if the old and new queues are associated to different devices, generate a new event
-          if (block.device() != previousDevice) {
+          // if the new queue is on different device than the old event, create a new event
+          if (block.device() != alpaka::getDev(*(block.event))) {
             block.event = Event{block.device()};
           }
 


### PR DESCRIPTION
I noticed that `alpaka` (and `alpakatest`)  was crashing with
```
Processing 1000 events, of which 2 concurrently, with 2 threads.
terminate called after throwing an instance of 'std::runtime_error'
  what():  .../pixeltrack-standalone/external/alpaka/include/alpaka/event/EventUniformCudaHipRt.hpp(157) 'cudaEventRecord( event.m_spEventImpl->m_UniformCudaHipEvent, queue.m_spQueueImpl->m_UniformCudaHipQueue)' returned error  : 'cudaErrorInvalidResourceHandle': 'invalid resource handle'!
```
when run on 2 GPUs. I managed to trace the problem into the pinned host memory allocations in CachingAllocator, when a pinned host memory block was previously used on device A, and is then used on device B.

The current code does
```cpp
// Take previous device from *the argument block*
auto const& previousDevice = block.device();
// Take the queue of the argument block
auto queue = std::move(*(block.queue));
// Copy the information of the block to be reused
block = iBlock->second;
// Assign the queue originally from the argument block
block.queue = std::move(queue);
```
Since the `block.device()` returns the device of its `Queue`, this means that both `block.device()` and `previousDevice` point to the same device, and the subsequent code to create a new `Event` never runs.

A minimal fix would be
```diff
-auto const& previousDevice = block.device();
+auto const& previousDevice = iBlock->second.device();
```
but given that the point is to create a new `Event` if the device of the `Queue` accessing the block differs from the device of the `Event` that the block had, I think testing explicitly that condition makes the intention of the code more clear.