### PR TITLE
Add workaround for building oneTBB with CentOS 7 devtools compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,12 @@ export TBB_DEPS := $(TBB_LIB)
 export TBB_CXXFLAGS := -isystem $(TBB_BASE)/include -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_NUMA_SUPPORT -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS
 export TBB_LDFLAGS := -L$(TBB_LIBDIR) -ltbb
 export TBB_NVCC_CXXFLAGS :=
+# The libstdc++ library used by the devtools on RHEL 7 / CentOS 7 requires a workaround because
+# some STL containers do not support the allocator traits, even when using more recent compilers
+ifneq ($(shell [ -f /etc/redhat-release ] && grep -q 'release 7' /etc/redhat-release && which $(CXX) | grep devtoolset),)
+TBB_CXXFLAGS += -DTBB_ALLOCATOR_TRAITS_BROKEN
+TBB_CMAKEFLAGS += -DCMAKE_CXX_FLAGS=-DTBB_ALLOCATOR_TRAITS_BROKEN
+endif
 
 EIGEN_BASE := $(EXTERNAL_BASE)/eigen
 export EIGEN_DEPS := $(EIGEN_BASE)


### PR DESCRIPTION
The libstdc++ library used by the devtools on RHEL 7 / CentOS 7 requires a workaround because some STL containers do not support the allocator traits, even when using more recent compilers.
