### PR TITLE
[cudadev][RFC] Prototype edm::async() and replace cudaStreamAddCallback with it

### DIFF
--- a/src/cudadev/CUDACore/EventCache.cc
+++ b/src/cudadev/CUDACore/EventCache.cc
@@ -45,7 +45,7 @@ namespace cms::cuda {
     return cache_[dev].makeOrGet([dev]() {
       cudaEvent_t event;
       // it should be a bit faster to ignore timings
-      cudaCheck(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
+      cudaCheck(cudaEventCreateWithFlags(&event, cudaEventDisableTiming | cudaEventBlockingSync));
       return std::unique_ptr<BareEvent, Deleter>(event, Deleter{dev});
     });
   }

--- a/src/cudadev/CUDACore/ScopedContext.cc
+++ b/src/cudadev/CUDACore/ScopedContext.cc
@@ -56,20 +56,20 @@ namespace cms::cuda {
     void ScopedContextHolderHelper::enqueueCallback(int device, cudaStream_t stream) {
       SharedEventPtr event = getEventCache().get();
       cudaEventRecord(event.get(), stream);
-      edm::async(waitingTaskHolder_, [device, stream, event=std::move(event)]() mutable {
-          auto status = cudaEventSynchronize(event.get());
-          event.reset();
-          if (status != cudaSuccess) {
-            auto error = cudaGetErrorName(status);
-            auto message = cudaGetErrorString(status);
-            throw std::runtime_error("Callback of CUDA stream " +
-                                     std::to_string(reinterpret_cast<unsigned long>(stream)) + " in device " +
-                                     std::to_string(device) + " error " + std::string(error) + ": " + std::string(message));
-          } else {
-            //std::cout << " GPU kernel finished (in callback) device " << device << " CUDA stream "
-            //          << stream << std::endl;
-          }
-        });
+      edm::async(waitingTaskHolder_, [device, stream, event = std::move(event)]() mutable {
+        auto status = cudaEventSynchronize(event.get());
+        event.reset();
+        if (status != cudaSuccess) {
+          auto error = cudaGetErrorName(status);
+          auto message = cudaGetErrorString(status);
+          throw std::runtime_error(
+              "Callback of CUDA stream " + std::to_string(reinterpret_cast<unsigned long>(stream)) + " in device " +
+              std::to_string(device) + " error " + std::string(error) + ": " + std::string(message));
+        } else {
+          //std::cout << " GPU kernel finished (in callback) device " << device << " CUDA stream "
+          //          << stream << std::endl;
+        }
+      });
     }
   }  // namespace impl
 

--- a/src/cudadev/CUDACore/ScopedContext.cc
+++ b/src/cudadev/CUDACore/ScopedContext.cc
@@ -54,19 +54,22 @@ namespace cms::cuda {
     }
 
     void ScopedContextHolderHelper::enqueueCallback(int device, cudaStream_t stream) {
-      edm::async(waitingTaskHolder_, [device, stream]() {
-        auto status = cudaStreamSynchronize(stream);
-        if (status != cudaSuccess) {
-          auto error = cudaGetErrorName(status);
-          auto message = cudaGetErrorString(status);
-          throw std::runtime_error(
-              "Callback of CUDA stream " + std::to_string(reinterpret_cast<unsigned long>(stream)) + " in device " +
-              std::to_string(device) + " error " + std::string(error) + ": " + std::string(message));
-        } else {
-          //std::cout << " GPU kernel finished (in callback) device " << device << " CUDA stream "
-          //          << stream << std::endl;
-        }
-      });
+      SharedEventPtr event = getEventCache().get();
+      cudaEventRecord(event.get(), stream);
+      edm::async(waitingTaskHolder_, [device, stream, event=std::move(event)]() mutable {
+          auto status = cudaEventSynchronize(event.get());
+          event.reset();
+          if (status != cudaSuccess) {
+            auto error = cudaGetErrorName(status);
+            auto message = cudaGetErrorString(status);
+            throw std::runtime_error("Callback of CUDA stream " +
+                                     std::to_string(reinterpret_cast<unsigned long>(stream)) + " in device " +
+                                     std::to_string(device) + " error " + std::string(error) + ": " + std::string(message));
+          } else {
+            //std::cout << " GPU kernel finished (in callback) device " << device << " CUDA stream "
+            //          << stream << std::endl;
+          }
+        });
     }
   }  // namespace impl
 

--- a/src/cudadev/Framework/async.cc
+++ b/src/cudadev/Framework/async.cc
@@ -1,0 +1,25 @@
+#include "Framework/async.h"
+
+namespace edm::impl {
+  WaitingThread::WaitingThread() { thread_ = std::thread(&WaitingThread::threadLoop, this); }
+
+  WaitingThread::~WaitingThread() {
+    if (not stopThread_) {
+      stopThread();
+    }
+    thread_.join();
+  }
+
+  void WaitingThread::threadLoop() {
+    std::unique_lock lk(mutex_);
+
+    do {
+      cond_.wait(lk, [this]() { return static_cast<bool>(func_) or stopThread_; });
+      if (func_) {
+        func_();
+        decltype(func_)().swap(func_);
+        thisPtr_.reset();
+      }
+    } while (not stopThread_);
+  }
+}  // namespace edm::impl

--- a/src/cudadev/Framework/async.h
+++ b/src/cudadev/Framework/async.h
@@ -1,0 +1,76 @@
+#ifndef Framework_async_h
+#define Framework_async_h
+
+#include "Framework/ReusableObjectHolder.h"
+#include "Framework/WaitingTaskWithArenaHolder.h"
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+namespace edm {
+  namespace impl {
+    class WaitingThread {
+    public:
+      WaitingThread();
+      ~WaitingThread();
+
+      template <typename F>
+      void run(WaitingTaskWithArenaHolder holder, F&& func, std::shared_ptr<WaitingThread> thisPtr) {
+        std::unique_lock lk(mutex_);
+        func_ = [holder = std::move(holder), func = std::forward<F>(func)]() mutable {
+          try {
+            func();
+            holder.doneWaiting(nullptr);
+          } catch (...) {
+            holder.doneWaiting(std::current_exception());
+          }
+        };
+        thisPtr_ = std::move(thisPtr);
+        cond_.notify_one();
+      }
+
+      void stopThread() {
+        std::unique_lock lk(mutex_);
+        stopThread_ = true;
+        cond_.notify_one();
+      }
+
+    private:
+      void threadLoop();
+
+      std::thread thread_;
+      std::mutex mutex_;
+      std::condition_variable cond_;
+      std::function<void()> func_;
+      std::shared_ptr<WaitingThread> thisPtr_;
+      bool ready_ = false;
+      bool stopThread_ = false;
+    };
+
+    class WaitingThreadPool {
+    public:
+      template <typename F>
+      void run(WaitingTaskWithArenaHolder holder, F&& func) {
+        auto thread = pool_.makeOrGet([]() { return std::make_unique<WaitingThread>(); });
+        thread->run(std::move(holder), std::forward<F>(func), thread);
+      }
+
+    private:
+      edm::ReusableObjectHolder<WaitingThread> pool_;
+    };
+
+    WaitingThreadPool& getWaitingThreadPool() {
+      static WaitingThreadPool pool;
+      return pool;
+    }
+  }  // namespace impl
+
+  template <typename F>
+  void async(WaitingTaskWithArenaHolder holder, F&& func) {
+    auto& pool = impl::getWaitingThreadPool();
+    pool.run(std::move(holder), std::forward<F>(func));
+  }
+}  // namespace edm
+
+#endif

--- a/src/cudadev/bin/main.cc
+++ b/src/cudadev/bin/main.cc
@@ -104,10 +104,28 @@ int main(int argc, char** argv) {
   int numberOfDevices;
   auto status = cudaGetDeviceCount(&numberOfDevices);
   if (cudaSuccess != status) {
-    std::cout << "Failed to initialize the CUDA runtime";
+    std::cout << "Failed to initialize the CUDA runtime" << std::endl;
     return EXIT_FAILURE;
   }
   std::cout << "Found " << numberOfDevices << " devices" << std::endl;
+
+  for (int dev = 0; dev < numberOfDevices; ++dev) {
+    status = cudaSetDevice(dev);
+    if (cudaSuccess != status) {
+      std::cout << "Failed to set device" << std::endl;
+      return EXIT_FAILURE;
+    }
+    status = cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+    if (cudaSuccess != status) {
+      std::cout << "Failed to set device status flags" << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+  status = cudaSetDevice(0);
+  if (cudaSuccess != status) {
+    std::cout << "Failed to set device" << std::endl;
+    return EXIT_FAILURE;
+  }
 
 #if CUDA_VERSION >= 11020
   // Initialize the CUDA memory pool


### PR DESCRIPTION
This PR prototypes `edm::async()` planned in https://github.com/cms-sw/cmssw/issues/29188, and use it in `cudadev` instead of `cudaStreamAddCallback()`.

I made a preliminary test on RTX 2080 (single ~1 minute run on each case, CPU utilization is peak of those given reported by `ps` checked every 10 s). I tested three cases, `cudadev`, `cudadev --transfer`, and `cudadev --histogram` to see if behavior is different with more device-to-host transfers (i.e. synchronization calls) and CPU work.

I tried first to use `cudaStreamSynchronize()` with each of `cudaDeviceScheduleSpin`, `cudaDeviceScheduleYield`, and `cudaDeviceScheduleBlockingSync` (for `cudaSetDeviceFlags()`), but didn't see any substantial difference between them: they give a bit higher throughput at low number of threads, but come with significant use of CPU compared to `cudaStreamAddCallback()`.

Then I tried `cudaEventSynchronize()`, but in first test that didn't seem to improve (I didn't even bother to measure it). Adding `cudaEventBlockingSync` to the CUDA event creation flags finally lead to significantly lower CPU utilization, in case of minimal-transfer `cudadev` much lower than with `cudaStreamAddCallback()`. The throughput on low number of CPU threads takes up to 15 % hit compared to `cudaStreamAddCallback()` and `cudaStreamSynchronize()` (depending on the test case).

![image](https://user-images.githubusercontent.com/33993/155799064-1aad79e8-4626-4135-a380-b077f212b5c8.png)
![image](https://user-images.githubusercontent.com/33993/155799092-f8184d58-9046-45e7-9e45-2953e0a8ce4e.png)
![image](https://user-images.githubusercontent.com/33993/155799122-52da89dd-fd48-4ea6-9c7d-54fcf157aca3.png)

Given that I didn't repeat the measurements, the uncertainty may be high, and therefore I think the measurements should be repeated. I'm planning to do that, but didn't want to hold the prototype for those.