### PR TITLE
[alpaka] Initialize devices in many alpaka unit test

### DIFF
--- a/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
+++ b/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
@@ -5,6 +5,7 @@
 #include "AlpakaCore/alpakaConfig.h"
 #include "AlpakaCore/alpakaMemory.h"
 #include "AlpakaCore/alpakaWorkDiv.h"
+#include "AlpakaCore/initialise.h"
 
 using namespace cms::alpakatools;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
@@ -55,6 +56,7 @@ struct verify {
 };
 
 int main() {
+  cms::alpakatools::initialise<Platform>();
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
   const Device device(alpaka::getDevByIdx<Platform>(0u));
   Queue queue(device);

--- a/src/alpaka/test/alpaka/HistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/HistoContainer_t.cc
@@ -9,6 +9,7 @@
 #include "AlpakaCore/alpakaConfig.h"
 #include "AlpakaCore/alpakaMemory.h"
 #include "AlpakaCore/alpakaWorkDiv.h"
+#include "AlpakaCore/initialise.h"
 
 using namespace cms::alpakatools;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
@@ -156,6 +157,7 @@ void go(const DevHost& host, const Device& device, Queue& queue) {
 }
 
 int main() {
+  cms::alpakatools::initialise<Platform>();
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
   const Device device(alpaka::getDevByIdx<Platform>(0u));
   Queue queue(device);

--- a/src/alpaka/test/alpaka/OneHistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/OneHistoContainer_t.cc
@@ -6,6 +6,7 @@
 
 #include "AlpakaCore/HistoContainer.h"
 #include "AlpakaCore/alpakaMemory.h"
+#include "AlpakaCore/initialise.h"
 
 using namespace cms::alpakatools;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
@@ -152,6 +153,7 @@ void go(const DevHost& host, const Device& device, Queue& queue) {
 }
 
 int main() {
+  cms::alpakatools::initialise<Platform>();
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
   const Device device(alpaka::getDevByIdx<Platform>(0u));
   Queue queue(device);

--- a/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
+++ b/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
@@ -9,6 +9,7 @@
 #include "AlpakaCore/HistoContainer.h"
 #include "AlpakaCore/alpakaMemory.h"
 #include "AlpakaCore/alpakaWorkDiv.h"
+#include "AlpakaCore/initialise.h"
 
 constexpr uint32_t MaxElem = 64000;
 constexpr uint32_t MaxTk = 8000;
@@ -132,6 +133,7 @@ struct verifyBulk {
 };
 
 int main() {
+  cms::alpakatools::initialise<Platform>();
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
   const Device device(alpaka::getDevByIdx<Platform>(0u));
   Queue queue(device);

--- a/src/alpaka/test/alpaka/clustering_t.cc
+++ b/src/alpaka/test/alpaka/clustering_t.cc
@@ -12,6 +12,7 @@
 #include "AlpakaCore/alpakaConfig.h"
 #include "AlpakaCore/alpakaMemory.h"
 #include "AlpakaCore/alpakaWorkDiv.h"
+#include "AlpakaCore/initialise.h"
 
 // dirty, but works
 #include "plugin-SiPixelClusterizer/alpaka/gpuClustering.h"
@@ -21,6 +22,8 @@ using namespace cms::alpakatools;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 int main(void) {
+  cms::alpakatools::initialise<Platform>();
+
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
   const Device device(alpaka::getDevByIdx<Platform>(0u));
   Queue queue(device);

--- a/src/alpaka/test/alpaka/prefixScan_t.cc
+++ b/src/alpaka/test/alpaka/prefixScan_t.cc
@@ -3,6 +3,7 @@
 #include "AlpakaCore/alpakaConfig.h"
 #include "AlpakaCore/alpakaMemory.h"
 #include "AlpakaCore/alpakaWorkDiv.h"
+#include "AlpakaCore/initialise.h"
 #include "AlpakaCore/prefixScan.h"
 
 using namespace cms::alpakatools;
@@ -106,6 +107,8 @@ struct verify {
 };
 
 int main() {
+  cms::alpakatools::initialise<Platform>();
+
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
   const Device device(alpaka::getDevByIdx<Platform>(0u));
   const Vec1D size(1u);


### PR DESCRIPTION
Fixes assertion failure in DeviceCachingAllocator. With this PR all the unit tests in `alpaka` run successfully for Serial, TBB, and CUDA backends.