### PR TITLE
Propagate per-thread CPU efficiency through run-many.py

### DIFF
--- a/run-many.py
+++ b/run-many.py
@@ -6,6 +6,7 @@ import time
 import socket
 import argparse
 import importlib
+import statistics
 import subprocess
 import collections
 import multiprocessing
@@ -229,8 +230,9 @@ def runMany(programs, opts, logfilenamebase, monitor):
 
     ret = []
     for i in range(len(programs)):
-        with open(logfilenamebase.format(i)) as logfile:
-            ret.append(scan.throughput(logfile))
+        fname = logfilenamebase.format(i)
+        with open(fname) as logfile:
+            ret.append(scan.throughput(logfile, fname))
     return ret
 
             
@@ -288,7 +290,8 @@ def main(opts):
 
     d = dict(
         hostname=hostname,
-        throughput=sum([m.throughput for m in measurements]),
+        throughput=sum(m.throughput for m in measurements),
+        cpueff=statistics.mean(m.cpueff for m in measurements) if len(measurements) > 0 else 0,
         programs=[]
     )
     scan.printMessage("Total throughput {} events/s".format(d["throughput"]))
@@ -296,7 +299,8 @@ def main(opts):
         dp = dict(
             events=m.events,
             time=m.time,
-            throughput=m.throughput
+            throughput=m.throughput,
+            cpueff=m.cpueff,
         )
         p.addMetadata(dp)
         d["programs"].append(dp)

--- a/run-scan.py
+++ b/run-scan.py
@@ -99,7 +99,7 @@ class Monitor:
 def printMessage(*args):
     print(time.strftime("%y-%m-%d %H:%M:%S"), *args)
 
-def throughput(output):
+def throughput(output, filename):
     for line in output:
         m = result_re.search(line)
         if m:
@@ -219,7 +219,7 @@ def _run(processUntil, nstr, cores_main, opts, logfilename, monitor, cudaDevices
         if p.returncode != 0:
             raise Exception("Got return code %d, see output in the log file %s" % (p.returncode, logfilename))
     with open(logfilename) as logfile:
-        return throughput(logfile)
+        return throughput(logfile, logfilename)
 
 def runEvents(nev, *args, **kwargs):
     return _run(["--maxEvents", str(nev)], *args, **kwargs)


### PR DESCRIPTION
Follow up to https://github.com/cms-patatrack/pixeltrack-standalone/pull/325