### PR TITLE
[kokkos] serial backend performance fix

### DIFF
--- a/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClusterChargeCut.h
+++ b/src/kokkos/plugin-SiPixelClusterizer/kokkos/gpuClusterChargeCut.h
@@ -94,11 +94,8 @@ namespace gpuClustering {
                                         ::gpuClustering::MaxNumClustersPerModules);
 
           assert(nclus <= ::gpuClustering::MaxNumClustersPerModules);
-          for (uint32_t i = teamMember.team_rank(); i < ::gpuClustering::MaxNumClustersPerModules;
-               i += teamMember.team_size()) {
+          for (uint32_t i = teamMember.team_rank(); i < nclus; i += teamMember.team_size()) {
             charge(i) = 0;
-            ok(i) = 0;
-            newclusId(i) = 0;
           }
           teamMember.team_barrier();
 


### PR DESCRIPTION
The Kokkos serial backend is slower than the plain serial code  - see #297 for more details.

One cause is addressed here, where the Kokkos backend loops over the entire array (size 1024) rather than the number of clusters (about 10).
This loop also sets ok and newclusId to zero.  Those get set later and these assignments can be removed.