### PR TITLE
[alpaka] Update the develop branch to 2022.03.15 / eff3dcee30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,7 @@ external_alpaka: $(ALPAKA_BASE)
 
 $(ALPAKA_BASE):
 	git clone git@github.com:alpaka-group/alpaka.git -b develop $@
-	cd $@ && git checkout 4189bd1e2d831bd5bf0c9e00ca79637e3afc208d
+	cd $@ && git checkout eff3dcee30e893af3d7c7597983c9dd1e655faf3
 
 # Cupla
 .PHONY: external_cupla


### PR DESCRIPTION
Update the version of alpaka to the HEAD of the develop branch as of 2022.03.15, corresponding to the commit eff3dcee30 .

Relevant changes:
  - add a grid-wise memory fence.