### PR TITLE
[sycltest] Update Makefile and wait synchronously explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,9 +255,13 @@ export KOKKOS_DEPS := $(KOKKOS_LIB)
 
 # Intel oneAPI
 ONEAPI_BASE := /opt/intel/oneapi
-ONEAPI_ENV  := $(ONEAPI_BASE)/setvars.sh
-DPCT_BASE   := $(ONEAPI_BASE)/dpcpp-ct/latest
-SYCL_BASE   := $(ONEAPI_BASE)/compiler/latest/linux
+ifneq ($(wildcard $(ONEAPI_BASE)),)
+# OneAPI platform found
+ONEAPI_ENV    := $(ONEAPI_BASE)/setvars.sh
+DPCT_BASE     := $(ONEAPI_BASE)/dpcpp-ct/latest
+SYCL_BASE     := $(ONEAPI_BASE)/compiler/latest/linux
+DPCT_CXXFLAGS := -isystem $(DPCT_BASE)/include
+endif
 SYCL_UNSUPPORTED_CXXFLAGS := --param vect-max-version-for-alias-checks=50 -Wno-non-template-friend -Werror=format-contains-nul -Werror=return-local-addr -Werror=unused-but-set-variable
 
 # to use a different toolchain
@@ -274,9 +278,10 @@ else
 SYCL_BASE :=
 endif
 endif
+USER_SYCLFLAGS :=
 ifdef SYCL_BASE
 export SYCL_CXX      := $(SYCL_BASE)/bin/dpcpp
-export SYCL_CXXFLAGS := -fsycl -isystem $(DPCT_BASE)/include $(filter-out $(SYCL_UNSUPPORTED_CXXFLAGS),$(CXXFLAGS))
+export SYCL_CXXFLAGS := -fsycl $(DPCT_CXXFLAGS) $(filter-out $(SYCL_UNSUPPORTED_CXXFLAGS),$(CXXFLAGS)) $(USER_SYCLFLAGS)
 ifdef CUDA_BASE
 export SYCL_CUDA_PLUGIN := $(wildcard $(SYCL_LIBDIR)/libpi_cuda.so)
 export SYCL_CUDA_FLAGS  := --cuda-path=$(CUDA_BASE) -Wno-unknown-cuda-version

--- a/src/sycltest/SYCLCore/ScopedContext.cc
+++ b/src/sycltest/SYCLCore/ScopedContext.cc
@@ -55,10 +55,10 @@ namespace cms::sycltools {
     }
 
     void ScopedContextHolderHelper::enqueueCallback(sycl::queue stream) {
-      std::async([&]() {
-        stream.wait();
-        waitingTaskHolder_.doneWaiting(nullptr);
-      });
+      // TODO: make truly asynchronous
+      // TODO: propagate exception to waitingTaskHolder_
+      stream.wait();
+      waitingTaskHolder_.doneWaiting(nullptr);
     }
   }  // namespace impl
 


### PR DESCRIPTION
I gave a try on `sycltest` with  `dpcpp` compiled manually with the CUDA support enabled. I modified a bit the Makefile variables to make the `dpct` dependence optional (although the `-isystem $(DPCT_BASE)/include` didn't do any practical harm in my case), and added `USER_SYCLFLAGS` to add custom compilation (even if currently `USER_CXXFLAGS` would have done the same).

The compiler complained about not capturing the return value of `std::async()`, so for time being I removed the call and made the `ScopedContextHolderHelper::enqueueCallback()` explicitly synchronous. This was the behavior effectively earlier too, since the destructor of `std::future` returned by `std::async()` blocks until the asynchronous work is complete.