### PR TITLE
[kokkos] Add functions for profiling hooks

### DIFF
--- a/src/kokkos/Framework/PluginFactory.cc
+++ b/src/kokkos/Framework/PluginFactory.cc
@@ -28,7 +28,7 @@ namespace edm {
     };  // namespace impl
 
     std::unique_ptr<Worker> create(std::string const& name, ProductRegistry& reg) {
-      return impl::getGlobalRegistry().get(name)->create(reg);
+      return impl::getGlobalRegistry().get(name)->create(reg, name);
     }
   }  // namespace PluginFactory
 }  // namespace edm

--- a/src/kokkos/Framework/PluginFactory.h
+++ b/src/kokkos/Framework/PluginFactory.h
@@ -17,14 +17,14 @@ namespace edm {
       public:
         virtual ~MakerBase() = default;
 
-        virtual std::unique_ptr<Worker> create(ProductRegistry& reg) const = 0;
+        virtual std::unique_ptr<Worker> create(ProductRegistry& reg, const std::string& name) const = 0;
       };
 
       template <typename T>
       class Maker : public MakerBase {
       public:
-        virtual std::unique_ptr<Worker> create(ProductRegistry& reg) const override {
-          return std::make_unique<WorkerT<T>>(reg);
+        virtual std::unique_ptr<Worker> create(ProductRegistry& reg, const std::string& name) const override {
+          return std::make_unique<WorkerT<T>>(reg, name);
         };
       };
 

--- a/src/kokkos/Framework/Profile.cc
+++ b/src/kokkos/Framework/Profile.cc
@@ -1,0 +1,11 @@
+
+#include "Framework/Profile.h"
+#include "Framework/Event.h"
+
+void beginProduce(const std::string& name, const edm::Event& event) {}
+
+void endProduce(const std::string& name, const edm::Event& event) {}
+
+void beginAcquire(const std::string& name, const edm::Event& event) {}
+
+void endAcquire(const std::string& name, const edm::Event& event) {}

--- a/src/kokkos/Framework/Profile.h
+++ b/src/kokkos/Framework/Profile.h
@@ -1,0 +1,25 @@
+
+#ifndef Profile_h
+#define Profile_h
+
+#include <string>
+
+// Functions that get called before and after the produce and acquire functions
+// get called for each module.
+// Intended to be a place to put profiling, instrumentation points, and/or task annotations.
+//
+//  The 'name' parameter is the name of the module being called.
+
+namespace edm {
+  class Event;
+};
+
+void beginProduce(const std::string& name, const edm::Event& event);
+
+void endProduce(const std::string& name, const edm::Event& event);
+
+void beginAcquire(const std::string& name, const edm::Event& event);
+
+void endAcquire(const std::string& name, const edm::Event& event);
+
+#endif


### PR DESCRIPTION
Add functions that get called before and after the acquire and produce functions. 
The body of the functions initially empty.  Eventually they can be used for task annotations or profiling timers.

Add the module name to the worker so it can be passed to the profiling functions.