### PR TITLE
[alpaka] Update the develop branch to 2022.03.26 / 3093418d887

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -584,7 +584,7 @@ external_alpaka: $(ALPAKA_BASE)
 
 $(ALPAKA_BASE):
 	git clone git@github.com:alpaka-group/alpaka.git -b develop $@
-	cd $@ && git checkout 343e6de3d624f3badff74a9f4d550f2869423fe8
+	cd $@ && git checkout 3093418d887a027263e0a527e94fc17603b2ccfb
 
 # Kokkos
 external_kokkos: $(KOKKOS_LIB)

--- a/src/alpaka/AlpakaCore/HostOnlyTask.h
+++ b/src/alpaka/AlpakaCore/HostOnlyTask.h
@@ -19,7 +19,7 @@ namespace alpaka {
     std::function<void()> task_;
   };
 
-  namespace traits {
+  namespace trait {
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
     //! The CUDA async queue enqueue trait specialization for "safe tasks"
@@ -57,7 +57,7 @@ namespace alpaka {
     };
 #endif  // ALPAKA_ACC_GPU_HIP_ENABLED
 
-  }  // namespace traits
+  }  // namespace trait
 
 }  // namespace alpaka
 

--- a/src/alpaka/AlpakaCore/prefixScan.h
+++ b/src/alpaka/AlpakaCore/prefixScan.h
@@ -226,7 +226,7 @@ namespace cms {
 }  // namespace cms
 
 namespace alpaka {
-  namespace traits {
+  namespace trait {
 
     //#############################################################################
     //! The trait for getting the size of the block shared dynamic memory for a kernel.
@@ -246,8 +246,7 @@ namespace alpaka {
         return static_cast<size_t>(numBlocks) * sizeof(T);
       }
     };
-
-  }  // namespace traits
+  }  // namespace trait
 }  // namespace alpaka
 
 #endif  // AlpakaCore_prefixScan_h

--- a/src/alpakatest/AlpakaCore/HostOnlyTask.h
+++ b/src/alpakatest/AlpakaCore/HostOnlyTask.h
@@ -19,7 +19,7 @@ namespace alpaka {
     std::function<void()> task_;
   };
 
-  namespace traits {
+  namespace trait {
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
     //! The CUDA async queue enqueue trait specialization for "safe tasks"
@@ -57,7 +57,7 @@ namespace alpaka {
     };
 #endif  // ALPAKA_ACC_GPU_HIP_ENABLED
 
-  }  // namespace traits
+  }  // namespace trait
 
 }  // namespace alpaka
 


### PR DESCRIPTION
Update the version of alpaka to the HEAD of the develop branch as of 2022.03.26, corresponding to the commit 3093418d887 .

Relevant changes:
  - rename the namespace `alpaka::traits` to `alpaka::trait`.