### PR TITLE
[alpaka] Minor fixes

### DIFF
--- a/src/alpaka/AlpakaCore/alpakaWorkDiv.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDiv.h
@@ -4,6 +4,8 @@
 #include <algorithm>
 #include <utility>
 
+#include <alpaka/alpaka.hpp>
+
 #include "AlpakaCore/alpakaConfig.h"
 
 using namespace alpaka_common;

--- a/src/alpaka/test/alpaka/prefixScan_t.cc
+++ b/src/alpaka/test/alpaka/prefixScan_t.cc
@@ -114,8 +114,6 @@ int main() {
 
   const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
   const Device device(alpaka::getDevByIdx<Platform>(0u));
-  const Vec1D size(1u);
-
   Queue queue(device);
 
   // WARP PREFIXSCAN (OBVIOUSLY GPU-ONLY)

--- a/src/alpakatest/AlpakaCore/alpakaWorkDiv.h
+++ b/src/alpakatest/AlpakaCore/alpakaWorkDiv.h
@@ -4,6 +4,8 @@
 #include <algorithm>
 #include <utility>
 
+#include <alpaka/alpaka.hpp>
+
 #include "AlpakaCore/alpakaConfig.h"
 
 using namespace alpaka_common;

--- a/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
+++ b/src/alpakatest/plugin-Test1/alpaka/alpakaAlgo1.cc
@@ -90,7 +90,7 @@ namespace {
      Obviously not optimized (and contains printf anyway), incorporated to verify results.
   */
   namespace debug {
-    constexpr float TOLERANCE_RATIO = 0.01;
+    [[maybe_unused]] constexpr float TOLERANCE_RATIO = 0.01;
 
     struct verifyVectorAdd {
       template <typename T_Acc, typename T_Data>

--- a/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
+++ b/src/alpakatest/plugin-Test2/alpaka/alpakaAlgo2.cc
@@ -90,7 +90,7 @@ namespace {
      Obviously not optimized (and contains printf anyway), incorporated to verify results.
   */
   namespace debug {
-    constexpr float TOLERANCE_RATIO = 0.01;
+    [[maybe_unused]] constexpr float TOLERANCE_RATIO = 0.01;
 
     struct verifyVectorAdd {
       template <typename T_Acc, typename T_Data>


### PR DESCRIPTION
`alpaka`:
  - add  a missing `#include` directive;
  - remove unused variable.

`alpakatest`:
  - add  a missing `#include` directive;
  - silence warnings about unused variables.