### PR TITLE
[alpaka] Added support for Boost Fiber backend with Alpaka

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,8 @@ export EIGEN_LDFLAGS :=
 export EIGEN_NVCC_CXXFLAGS := --diag-suppress 20014
 
 BOOST_BASE := /usr
-# Minimum required version of Boost, e.g. 1.78.0
-BOOST_MIN_VERSION := 107800
+# Minimum required version of Boost, e.g. 1.79.0
+BOOST_MIN_VERSION := 107900
 # Check if an external version of Boost is present and recent enough
 ifeq ($(wildcard $(BOOST_BASE)/include/boost/version.hpp),)
 NEED_BOOST := true
@@ -151,7 +151,7 @@ BOOST_BASE := $(EXTERNAL_BASE)/boost
 endif
 export BOOST_DEPS := $(BOOST_BASE)
 export BOOST_CXXFLAGS := -isystem $(BOOST_BASE)/include
-export BOOST_LDFLAGS := -L$(BOOST_BASE)/lib
+export BOOST_LDFLAGS := -L$(BOOST_BASE)/lib -Wl,-rpath,$(BOOST_BASE)/lib -lboost_fiber -lboost_context -lboost_filesystem
 export BOOST_NVCC_CXXFLAGS :=
 
 BACKTRACE_BASE := $(EXTERNAL_BASE)/libbacktrace
@@ -542,8 +542,8 @@ external_boost: $(BOOST_BASE)
 $(BOOST_BASE): CXXFLAGS:=
 $(BOOST_BASE):
 	$(eval BOOST_TMP := $(shell mktemp -d))
-	curl -L -s -S https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2 | tar xj -C $(BOOST_TMP)
-	cd $(BOOST_TMP)/boost_1_78_0 && ./bootstrap.sh && ./b2 install --prefix=$@ --without-graph_parallel --without-mpi --without-python
+	curl -L -s -S https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2 | tar xj -C $(BOOST_TMP)
+	cd $(BOOST_TMP)/boost_1_79_0 && ./bootstrap.sh && ./b2 install --prefix=$@ --without-graph_parallel --without-mpi --without-python
 	@rm -rf $(BOOST_TMP)
 	$(eval undefine BOOST_TMP)
 

--- a/src/alpaka/AlpakaCore/AllocatorPolicy.h
+++ b/src/alpaka/AlpakaCore/AllocatorPolicy.h
@@ -14,7 +14,7 @@ namespace cms::alpakatools {
   template <typename TDev>
   constexpr inline AllocatorPolicy allocator_policy = AllocatorPolicy::Synchronous;
 
-#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLED
   template <>
   constexpr inline AllocatorPolicy allocator_policy<alpaka::DevCpu> =
 #if !defined ALPAKA_DISABLE_CACHING_ALLOCATOR
@@ -22,7 +22,7 @@ namespace cms::alpakatools {
 #else
       AllocatorPolicy::Synchronous;
 #endif
-#endif  // defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#endif  // defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLED
 
 #if defined ALPAKA_ACC_GPU_CUDA_ENABLED
   template <>

--- a/src/alpaka/AlpakaCore/alpakaConfig.h
+++ b/src/alpaka/AlpakaCore/alpakaConfig.h
@@ -111,6 +111,29 @@ namespace alpaka_serial_sync {
 #define ALPAKA_ACCELERATOR_NAMESPACE alpaka_serial_sync
 #endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_SYNC_BACKEND
 
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_PRESENT
+namespace alpaka_fibers_sync {
+  using namespace alpaka_common;
+
+  using Platform = alpaka::PltfCpu;
+  using Device = alpaka::DevCpu;
+  using Queue = alpaka::QueueCpuBlocking;
+  using Event = alpaka::EventCpu;
+
+  template <typename TDim>
+  using Acc = alpaka::AccCpuFibers<TDim, Idx>;
+  using Acc1D = Acc<Dim1D>;
+  using Acc2D = Acc<Dim2D>;
+  using Acc3D = Acc<Dim3D>;
+
+}  // namespace alpaka_fibers_sync
+
+#endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_SYNC_BACKEND
+#define ALPAKA_ACCELERATOR_NAMESPACE alpaka_fibers_sync
+#endif  // ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_SYNC_BACKEND
+
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_PRESENT
 namespace alpaka_tbb_async {
   using namespace alpaka_common;

--- a/src/alpaka/AlpakaCore/alpakaFwd.h
+++ b/src/alpaka/AlpakaCore/alpakaFwd.h
@@ -86,6 +86,9 @@ namespace alpaka {
   class AccCpuSerial;
 
   template <typename TDim, typename TIdx>
+  class AccCpuFibers;
+
+  template <typename TDim, typename TIdx>
   class AccCpuTbbBlocks;
 
   template <typename TDim, typename TIdx>

--- a/src/alpaka/AlpakaCore/backend.h
+++ b/src/alpaka/AlpakaCore/backend.h
@@ -1,10 +1,10 @@
 #ifndef AlpakaCore_backend_h
 #define AlpakaCore_backend_h
 
-enum class Backend { SERIAL, TBB, CUDA, HIP };
+enum class Backend { SERIAL, FIBERS, TBB, CUDA, HIP };
 
 inline std::string const& name(Backend backend) {
-  static const std::string names[] = {"serial_sync", "tbb_async", "cuda_async", "rocm_async"};
+  static const std::string names[] = {"serial_sync", "fibers_sync", "tbb_async", "cuda_async", "rocm_async"};
   return names[static_cast<int>(backend)];
 }
 

--- a/src/alpaka/AlpakaCore/initialise.h
+++ b/src/alpaka/AlpakaCore/initialise.h
@@ -12,6 +12,9 @@ namespace cms::alpakatools {
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT
   extern template void initialise<alpaka_serial_sync::Platform>();
 #endif
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_PRESENT
+  extern template void initialise<alpaka_fibers_sync::Platform>();
+#endif
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_PRESENT
   extern template void initialise<alpaka_tbb_async::Platform>();
 #endif

--- a/src/alpaka/AlpakaDataFormats/TrackingRecHit2DSoAView.h
+++ b/src/alpaka/AlpakaDataFormats/TrackingRecHit2DSoAView.h
@@ -21,6 +21,10 @@ namespace alpaka_tbb_async {
   class TrackingRecHit2DAlpaka;
 }
 
+namespace alpaka_fibers_sync {
+  class TrackingRecHit2DAlpaka;
+}
+
 namespace alpaka_serial_sync {
   class TrackingRecHit2DAlpaka;
 }
@@ -38,6 +42,7 @@ public:
   friend class alpaka_cuda_async::TrackingRecHit2DAlpaka;
   friend class alpaka_rocm_async::TrackingRecHit2DAlpaka;
   friend class alpaka_tbb_async::TrackingRecHit2DAlpaka;
+  friend class alpaka_fibers_sync::TrackingRecHit2DAlpaka;
   friend class alpaka_serial_sync::TrackingRecHit2DAlpaka;
 
   ALPAKA_FN_ACC ALPAKA_FN_INLINE uint32_t nHits() const { return m_nHits; }

--- a/src/alpaka/Makefile
+++ b/src/alpaka/Makefile
@@ -9,6 +9,7 @@ test_cpu: $(TARGET)
 	@echo
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --serial
+	$(TARGET) --maxEvents 2 --fibers
 	$(TARGET) --maxEvents 2 --tbb
 	@echo "Succeeded"
 test_nvidiagpu: $(TARGET)
@@ -31,7 +32,7 @@ EXE_DEP := $(EXE_OBJ:$.o=$.d)
 
 LIBNAMES := $(filter-out plugin-% bin test Makefile% plugins.txt%,$(wildcard *))
 PLUGINNAMES := $(patsubst plugin-%,%,$(filter plugin-%,$(wildcard *)))
-MY_CXXFLAGS := -I$(TARGET_DIR) -DLIB_DIR=$(LIB_DIR)/$(TARGET_NAME) -DALPAKA_HOST_ONLY -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT -DALPAKA_ACC_CPU_B_TBB_T_SEQ_PRESENT
+MY_CXXFLAGS := -I$(TARGET_DIR) -DLIB_DIR=$(LIB_DIR)/$(TARGET_NAME) -DALPAKA_HOST_ONLY -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT -DALPAKA_ACC_CPU_B_SEQ_T_FIBERS_PRESENT -DALPAKA_ACC_CPU_B_TBB_T_SEQ_PRESENT
 ifdef CUDA_BASE
 MY_CXXFLAGS += -DALPAKA_ACC_GPU_CUDA_PRESENT -DALPAKA_ACC_GPU_CUDA_ONLY_MODE
 endif
@@ -60,6 +61,12 @@ $(1)_SERIAL_DEP := $$($(1)_SERIAL_OBJ:$.o=$.d)
 $(1)_SERIAL_LIB := $(LIB_DIR)/$(TARGET_NAME)/lib$(1)_serial.so
 LIBS += $$($(1)_SERIAL_LIB)
 $(1)_SERIAL_LDFLAGS := -l$(1)_serial
+# fibers backend
+$(1)_FIBERS_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.fibers.o))
+$(1)_FIBERS_DEP := $$($(1)_FIBERS_OBJ:$.o=$.d)
+$(1)_FIBERS_LIB := $(LIB_DIR)/$(TARGET_NAME)/lib$(1)_fibers.so
+LIBS += $$($(1)_FIBERS_LIB)
+$(1)_FIBERS_LDFLAGS := -l$(1)_fibers
 # TBB backend
 $(1)_TBB_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.tbb.o))
 $(1)_TBB_DEP := $$($(1)_TBB_OBJ:$.o=$.d)
@@ -86,7 +93,7 @@ LIBS += $$($(1)_ROCM_LIB)
 $(1)_ROCM_LDFLAGS := -l$(1)_rocm
 endif
 endif # if PORTABLE_SRC is not empty
-ALL_DEPENDS += $$($(1)_DEP) $$($(1)_SERIAL_DEP) $$($(1)_TBB_DEP) $$($(1)_CUDA_DEP) $$($(1)_ROCM_DEP)
+ALL_DEPENDS += $$($(1)_DEP) $$($(1)_SERIAL_DEP) $$($(1)_FIBERS_DEP) $$($(1)_TBB_DEP) $$($(1)_CUDA_DEP) $$($(1)_ROCM_DEP)
 endef
 $(foreach lib,$(LIBNAMES),$(eval $(call LIB_template,$(lib))))
 
@@ -107,6 +114,12 @@ $(1)_SERIAL_DEP := $$($(1)_SERIAL_OBJ:$.o=$.d)
 $(1)_SERIAL_LIB := $(LIB_DIR)/$(TARGET_NAME)/plugin$(1)_serial.so
 PLUGINS += $$($(1)_SERIAL_LIB)
 PLUGINNAMES += $(1)_serial
+# fibers backend
+$(1)_FIBERS_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.fibers.o))
+$(1)_FIBERS_DEP := $$($(1)_FIBERS_OBJ:$.o=$.d)
+$(1)_FIBERS_LIB := $(LIB_DIR)/$(TARGET_NAME)/plugin$(1)_fibers.so
+PLUGINS += $$($(1)_FIBERS_LIB)
+PLUGINNAMES += $(1)_fibers
 # TBB backend
 $(1)_TBB_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.tbb.o))
 $(1)_TBB_DEP := $$($(1)_TBB_OBJ:$.o=$.d)
@@ -133,7 +146,7 @@ PLUGINS += $$($(1)_ROCM_LIB)
 PLUGINNAMES += $(1)_rocm
 endif
 endif # if PORTABLE_SRC is not empty
-ALL_DEPENDS += $$($(1)_DEP) $$($(1)_SERIAL_DEP) $$($(1)_TBB_DEP) $$($(1)_CUDA_DEP) $$($(1)_ROCM_DEP)
+ALL_DEPENDS += $$($(1)_DEP) $$($(1)_SERIAL_DEP) $$($(1)_FIBERS_DEP) $$($(1)_TBB_DEP) $$($(1)_CUDA_DEP) $$($(1)_ROCM_DEP)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 
@@ -143,9 +156,13 @@ TESTS_PORTABLE_SRC := $(wildcard $(TARGET_DIR)/test/alpaka/*.cc)
 TESTS_SERIAL_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.serial.o))
 TESTS_SERIAL_DEP := $(TESTS_SERIAL_OBJ:$.o=$.d)
 TESTS_SERIAL_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.serial,$(TESTS_PORTABLE_SRC))
+# fibers backend
+TESTS_FIBERS_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.fibers.o))
+TESTS_FIBERS_DEP := $(TESTS_FIBERS_OBJ:$.o=$.d)
+TESTS_FIBERS_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.fibers,$(TESTS_PORTABLE_SRC))
 # TBB backend
-TESTS_TBB_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=tbb.serial.o))
-TESTS_TBB_DEP := $(TESTS_SERIAL_OBJ:$.o=$.d)
+TESTS_TBB_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.tbb.o))
+TESTS_TBB_DEP := $(TESTS_TBB_OBJ:$.o=$.d)
 TESTS_TBB_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.tbb,$(TESTS_PORTABLE_SRC))
 # CUDA backend
 ifdef CUDA_BASE
@@ -161,10 +178,10 @@ TESTS_ROCM_DEP := $(TESTS_ROCM_OBJ:$.o=$.d)
 TESTS_ROCM_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.rocm,$(TESTS_PORTABLE_SRC))
 endif
 #
-TESTS_EXE := $(TESTS_SERIAL_EXE) $(TESTS_TBB_EXE) $(TESTS_CUDA_EXE) $(TESTS_ROCM_EXE)
-ALL_DEPENDS += $(TESTS_SERIAL_DEP) $(TESTS_TBB_DEP) $(TESTS_CUDA_DEP) $(TESTS_ROCM_DEP)
+TESTS_EXE := $(TESTS_SERIAL_EXE) $(TESTS_FIBERS_EXE) $(TESTS_TBB_EXE) $(TESTS_CUDA_EXE) $(TESTS_ROCM_EXE)
+ALL_DEPENDS += $(TESTS_SERIAL_DEP) $(TESTS_FIBERS_DEP) $(TESTS_TBB_DEP) $(TESTS_CUDA_DEP) $(TESTS_ROCM_DEP)
 # Needed to keep the unit test object files after building $(TARGET)
-.SECONDARY: $(TESTS_SERIAL_OBJ) $(TESTS_TBB_OBJ) $(TESTS_CUDA_OBJ) $(TESTS_CUDADLINK) $(TESTS_ROCM_OBJ)
+.SECONDARY: $(TESTS_SERIAL_OBJ) $(TESTS_FIBERS_OBJ) $(TESTS_TBB_OBJ) $(TESTS_CUDA_OBJ) $(TESTS_CUDADLINK) $(TESTS_ROCM_OBJ)
 
 define RUNTEST_template
 run_$(1): $(1)
@@ -175,6 +192,7 @@ run_$(1): $(1)
 test_$(2): run_$(1)
 endef
 $(foreach test,$(TESTS_SERIAL_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
+$(foreach test,$(TESTS_FIBERS_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
 $(foreach test,$(TESTS_TBB_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
 $(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),nvidiagpu)))
 $(foreach test,$(TESTS_ROCM_EXE),$(eval $(call RUNTEST_template,$(test),amdgpu)))
@@ -187,7 +205,7 @@ $(LIB_DIR)/$(TARGET_NAME)/plugins.txt: $(PLUGINS)
 
 $(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS) $(LIB_DIR)/$(TARGET_NAME)/plugins.txt | $(TESTS_EXE)
 	# Link all libraries, also the "portable" ones
-	$(CXX) $(EXE_OBJ) $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(foreach lib,$(LIBNAMES),$($(lib)_LDFLAGS) $($(lib)_SERIAL_LDFLAGS) $($(lib)_TBB_LDFLAGS) $($(lib)_CUDA_LDFLAGS) $($(lib)_ROCM_LDFLAGS)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
+	$(CXX) $(EXE_OBJ) $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(foreach lib,$(LIBNAMES),$($(lib)_LDFLAGS) $($(lib)_SERIAL_LDFLAGS) $($(lib)_FIBERS_LDFLAGS) $($(lib)_TBB_LDFLAGS) $($(lib)_CUDA_LDFLAGS) $($(lib)_ROCM_LDFLAGS)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
 
 define BUILD_template
 $(OBJ_DIR)/$(2)/%.cc.o: $(SRC_DIR)/$(2)/%.cc
@@ -206,6 +224,10 @@ $$($(1)_LIB): $$($(1)_OBJ) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_DEPS)) 
 $$($(1)_SERIAL_LIB): $$($(1)_SERIAL_OBJ) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_DEPS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LIB)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_SERIAL_LIB))
 	@[ -d $$(@D) ] || mkdir -p $$(@D)
 	$(CXX) $$($(1)_SERIAL_OBJ) $(LDFLAGS) -shared $(SO_LDFLAGS) $(LIB_LDFLAGS) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LDFLAGS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_SERIAL_LDFLAGS)) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_LDFLAGS)) -o $$@
+
+$$($(1)_FIBERS_LIB): $$($(1)_FIBERS_OBJ) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_DEPS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LIB)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_FIBERS_LIB))
+	@[ -d $$(@D) ] || mkdir -p $$(@D)
+	$(CXX) $$($(1)_FIBERS_OBJ) $(LDFLAGS) -shared $(SO_LDFLAGS) $(LIB_LDFLAGS) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LDFLAGS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_FIBERS_LDFLAGS)) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_LDFLAGS)) -o $$@
 
 $$($(1)_TBB_LIB): $$($(1)_TBB_OBJ) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_DEPS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LIB)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_TBB_LIB))
 	@[ -d $$(@D) ] || mkdir -p $$(@D)
@@ -229,6 +251,16 @@ $(OBJ_DIR)/$(2)/alpaka/%.cc.serial.o: $(SRC_DIR)/$(2)/alpaka/%.cc
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$$$//' \
 	      -e '/^$$$$/ d' -e 's/$$$$/ :/' -e 's/ *//' < $(OBJ_DIR)/$(2)/alpaka/$$*.cc.serial.d.tmp >> $(OBJ_DIR)/$(2)/alpaka/$$*.cc.serial.d; \
 	  rm $(OBJ_DIR)/$(2)/alpaka/$$*.cc.serial.d.tmp
+
+# Portable code, for fibers backend
+$(OBJ_DIR)/$(2)/alpaka/%.cc.fibers.o: $(SRC_DIR)/$(2)/alpaka/%.cc
+	@[ -d $$(@D) ] || mkdir -p $$(@D)
+	$(CXX) $(CXXFLAGS) $(MY_CXXFLAGS) -DALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLED -DALPAKA_ACC_CPU_B_SEQ_T_FIBERS_SYNC_BACKEND $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_CXXFLAGS)) -c $$< -o $$@ -MMD
+	@cp $(OBJ_DIR)/$(2)/alpaka/$$*.cc.fibers.d $(OBJ_DIR)/$(2)/alpaka/$$*.cc.fibers.d.tmp; \
+	  sed 's#\($(2)/alpaka/$$*\)\.o[ :]*#\1.o \1.d : #g' < $(OBJ_DIR)/$(2)/alpaka/$$*.cc.fibers.d.tmp > $(OBJ_DIR)/$(2)/alpaka/$$*.cc.fibers.d; \
+	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$$$//' \
+	      -e '/^$$$$/ d' -e 's/$$$$/ :/' -e 's/ *//' < $(OBJ_DIR)/$(2)/alpaka/$$*.cc.fibers.d.tmp >> $(OBJ_DIR)/$(2)/alpaka/$$*.cc.fibers.d; \
+	  rm $(OBJ_DIR)/$(2)/alpaka/$$*.cc.fibers.d.tmp
 
 # Portable code, for TBB backend
 $(OBJ_DIR)/$(2)/alpaka/%.cc.tbb.o: $(SRC_DIR)/$(2)/alpaka/%.cc
@@ -285,6 +317,20 @@ $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.serial.o: $(SRC_DIR)/$(TARGET_NAME)/t
 $(TEST_DIR)/$(TARGET_NAME)/%.serial: $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.serial.o | $(LIBS)
 	@[ -d $(@D) ] || mkdir -p $(@D)
 	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(foreach lib,$(LIBNAMES),$($(lib)_LDFLAGS) $($(lib)_SERIAL_LDFLAGS)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
+
+# Fibers backend
+$(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.fibers.o: $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) $(MY_CXXFLAGS) -DALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLED -DALPAKA_ACC_CPU_B_SEQ_T_FIBERS_SYNC_BACKEND $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+	@cp $(@D)/$*.cc.fibers.d $(@D)/$*.cc.fibers.d.tmp; \
+	  sed 's#\($(TARGET_NAME)/$*\)\.o[ :]*#\1.o \1.d : #g' < $(@D)/$*.cc.fibers.d.tmp > $(@D)/$*.cc.fibers.d; \
+	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+	      -e '/^$$/ d' -e 's/$$/ :/' -e 's/ *//' < $(@D)/$*.cc.fibers.d.tmp >> $(@D)/$*.cc.fibers.d; \
+	  rm $(@D)/$*.cc.fibers.d.tmp
+
+$(TEST_DIR)/$(TARGET_NAME)/%.fibers: $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.fibers.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(foreach lib,$(LIBNAMES),$($(lib)_LDFLAGS) $($(lib)_FIBERS_LDFLAGS)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
 
 # TBB backend
 $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.tbb.o: $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc

--- a/src/alpaka/bin/main.cc
+++ b/src/alpaka/bin/main.cc
@@ -29,6 +29,9 @@ namespace {
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT
         << "[--serial] "
 #endif
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_PRESENT
+        << "[--fibers] "
+#endif
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_PRESENT
         << "[--tbb] "
 #endif
@@ -43,6 +46,9 @@ namespace {
         << "Options\n"
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT
         << " --serial            Use CPU Serial backend\n"
+#endif
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_PRESENT
+        << " --fibers            Use CPU Fibers backend\n"
 #endif
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_PRESENT
         << " --tbb               Use CPU TBB backend\n"
@@ -140,6 +146,12 @@ int main(int argc, char** argv) {
       getOptionalArgument(args, i, weight);
       backends.insert_or_assign(Backend::SERIAL, weight);
 #endif
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_PRESENT
+    } else if (*i == "--fibers") {
+      float weight = 1.;
+      getOptionalArgument(args, i, weight);
+      backends.insert_or_assign(Backend::FIBERS, weight);
+#endif
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_PRESENT
     } else if (*i == "--tbb") {
       float weight = 1.;
@@ -206,6 +218,11 @@ int main(int argc, char** argv) {
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT
   if (backends.find(Backend::SERIAL) != backends.end()) {
     cms::alpakatools::initialise<alpaka_serial_sync::Platform>();
+  }
+#endif
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_PRESENT
+  if (backends.find(Backend::FIBERS) != backends.end()) {
+    cms::alpakatools::initialise<alpaka_fibers_sync::Platform>();
   }
 #endif
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_PRESENT

--- a/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelRecHits.cc
+++ b/src/alpaka/plugin-SiPixelRecHits/alpaka/PixelRecHits.cc
@@ -81,7 +81,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       alpaka::wait(queue);
 #endif
 
-#if defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ASYNC_BACKEND && defined ALPAKA_DISABLE_CACHING_ALLOCATOR
+#if (defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ASYNC_BACKEND || defined ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_SYNC_BACKEND) && defined ALPAKA_DISABLE_CACHING_ALLOCATOR
       // FIXME this is required to keep the host buffer inside hits_d alive; it could be removed once the host buffers are also stream-ordered
       alpaka::wait(queue);
 #endif

--- a/src/alpaka/plugin-Validation/alpaka/HistoValidator.cc
+++ b/src/alpaka/plugin-Validation/alpaka/HistoValidator.cc
@@ -218,6 +218,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   void HistoValidator::endJob() {
 #if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_SYNC_BACKEND
     std::ofstream out("histograms_alpaka_serial.txt");
+#elif defined ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_SYNC_BACKEND
+    std::ofstream out("histograms_alpaka_fibers.txt");
 #elif defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ASYNC_BACKEND
     std::ofstream out("histograms_alpaka_tbb.txt");
 #elif defined ALPAKA_ACC_GPU_CUDA_ASYNC_BACKEND


### PR DESCRIPTION
This PR adds the support for Boost Fiber backend with Alpaka and fixes some typos in the alpaka `Makefile`. As for now, the backend has poor performance with respect to the `serial` backend, but it might be worth having it for future tests and developments (this is also under discussion in the alpaka team).

Currently, for the management of the work division we set the number of threads to 1, and the elements per thread to N (i.e. 32). Currently debugging the fiber backend in order run with N number of threads (i.e. 32) and the 1 element per thread.

<img width="1259" alt="throughput_analysis" src="https://user-images.githubusercontent.com/41752419/170266234-f2d985b2-9f7e-4995-a695-54b664011071.png">

