### PR TITLE
[sycltest] Propagate asynchronous exception to WaitingTaskWithArenaHolder

### DIFF
--- a/src/sycltest/SYCLCore/ScopedContext.cc
+++ b/src/sycltest/SYCLCore/ScopedContext.cc
@@ -11,15 +11,15 @@ namespace cms::sycltools {
 
     void sycl_exception_handler(cl::sycl::exception_list exceptions) {
       std::ostringstream msg;
-      msg << "Caught asynchronous SYCL exception:";
+      msg << "Caught asynchronous SYCL exception(s):";
       for (auto const &exc_ptr : exceptions) {
         try {
           std::rethrow_exception(exc_ptr);
         } catch (cl::sycl::exception const &e) {
           msg << '\n' << e.what();
         }
-        throw std::runtime_error(msg.str());
       }
+      throw std::runtime_error(msg.str());
     }
 
     ScopedContextBase::ScopedContextBase(edm::StreamID streamID)

--- a/src/sycltest/SYCLCore/ScopedContext.cc
+++ b/src/sycltest/SYCLCore/ScopedContext.cc
@@ -56,9 +56,12 @@ namespace cms::sycltools {
 
     void ScopedContextHolderHelper::enqueueCallback(sycl::queue stream) {
       // TODO: make truly asynchronous
-      // TODO: propagate exception to waitingTaskHolder_
-      stream.wait();
-      waitingTaskHolder_.doneWaiting(nullptr);
+      try {
+        stream.wait_and_throw();
+        waitingTaskHolder_.doneWaiting(nullptr);
+      } catch(...) {
+        waitingTaskHolder_.doneWaiting(std::current_exception());
+      }
     }
   }  // namespace impl
 


### PR DESCRIPTION
Also aggregate messages from all the caught asynchronous exceptions in `sycl_exception_handler` (I believe this was the intention).

Tested adding an intentional error that the exception thrown via `sycl_exception_handler()` gets propagated to the mock framework.