### PR TITLE
[alpaka] Update the develop branch to 2022.08.15 / 540397c4297

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -603,7 +603,7 @@ external_alpaka: $(ALPAKA_BASE)
 
 $(ALPAKA_BASE):
 	git clone git@github.com:alpaka-group/alpaka.git -b develop $@
-	cd $@ && git checkout 879b95ffce2da499c9cc6e12d4cfd5545effa701
+	cd $@ && git checkout 540397c4297719fcd76a704ee49b2318174782a4
 
 # Kokkos
 external_kokkos: $(KOKKOS_LIB)


### PR DESCRIPTION
Update the version of alpaka to the HEAD of the develop branch as of 2022.08.15,
corresponding to the commit 540397c4297 .

Major changes:
  - use CUDART_VERSION instead of BOOST_LANG_CUDA;
  - implement const buffers with the ViewConst adaptor;
  - ensure that tasks submitted to async CPU queues are completed even
    after the queue is destroyed;
  - use a callback thread instead of launching a new thread for each
    CUDA asynchronous host function;
  - update and refactor HIP/CUDA atomic implementations.

Other changes:
  - add missing template parameters;
  - add braces around aggregate initializer;
  - added demangled type names;
  - introduce alpaka::math::constants.
  - update and clean up Update SysInfo.hpp.

Update the supported host compilers:
  - add support for gcc 12;
  - drop support for clang 5.

Various bug fixes.