### PR TITLE
[alpaka] add non-cached pinned host buffers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -604,7 +604,7 @@ external_alpaka: $(ALPAKA_BASE)
 
 $(ALPAKA_BASE):
 	git clone git@github.com:alpaka-group/alpaka.git -b develop $@
-	cd $@ && git checkout 540397c4297719fcd76a704ee49b2318174782a4
+	cd $@ && git checkout b518e8c943a816eba06c3e12c0a7e1b58c8faedc
 
 # Kokkos
 external_kokkos: $(KOKKOS_LIB)

--- a/src/alpaka/AlpakaCore/CachingAllocator.h
+++ b/src/alpaka/AlpakaCore/CachingAllocator.h
@@ -321,8 +321,8 @@ namespace cms::alpakatools {
         // allocate device memory
         return alpaka::allocBuf<std::byte, size_t>(device_, bytes);
       } else if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
-        // allocate pinned host memory
-        return alpaka::allocMappedBuf<std::byte, size_t>(device_, alpaka::getDev(queue), bytes);
+        // allocate pinned host memory accessible by the queue's platform
+        return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<Queue>>, std::byte, size_t>(device_, bytes);
       } else {
         // unsupported combination
         static_assert(std::is_same_v<Device, alpaka::Dev<Queue>> or std::is_same_v<Device, alpaka::DevCpu>,

--- a/src/alpaka/AlpakaCore/alpakaMemory.h
+++ b/src/alpaka/AlpakaCore/alpakaMemory.h
@@ -96,6 +96,26 @@ namespace cms::alpakatools {
     return alpaka::allocBuf<std::remove_extent_t<T>, Idx>(host, Vec1D{std::extent_v<T>});
   }
 
+  // non-cached, pinned, scalar and 1-dimensional host buffers
+  // the memory is pinned according to the device associated to the platform
+
+  template <typename T, typename TPlatform>
+  std::enable_if_t<not std::is_array_v<T>, host_buffer<T>> make_host_buffer() {
+    return alpaka::allocMappedBuf<TPlatform, T, Idx>(host, Scalar{});
+  }
+
+  template <typename T, typename TPlatform>
+  std::enable_if_t<cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
+  make_host_buffer(Extent extent) {
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, Vec1D{extent});
+  }
+
+  template <typename T, typename TPlatform>
+  std::enable_if_t<cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
+  make_host_buffer() {
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, Vec1D{std::extent_v<T>});
+  }
+
   // potentially cached, pinned, scalar and 1-dimensional host buffers, associated to a work queue
   // the memory is pinned according to the device associated to the queue
 

--- a/src/alpaka/AlpakaCore/alpakaMemory.h
+++ b/src/alpaka/AlpakaCore/alpakaMemory.h
@@ -104,7 +104,7 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<T, Idx>(host, queue, Scalar{});
     } else {
-      return alpaka::allocMappedBuf<T, Idx>(host, alpaka::getDev(queue), Scalar{});
+      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, T, Idx>(host, Scalar{});
     }
   }
 
@@ -114,7 +114,7 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{extent});
     } else {
-      return alpaka::allocMappedBuf<std::remove_extent_t<T>, Idx>(host, alpaka::getDev(queue), Vec1D{extent});
+      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(host, Vec1D{extent});
     }
   }
 
@@ -124,7 +124,7 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{std::extent_v<T>});
     } else {
-      return alpaka::allocMappedBuf<std::remove_extent_t<T>, Idx>(host, alpaka::getDev(queue), Vec1D{std::extent_v<T>});
+      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(host, Vec1D{std::extent_v<T>});
     }
   }
 

--- a/src/alpaka/CondFormats/alpaka/PixelCPEFast.h
+++ b/src/alpaka/CondFormats/alpaka/PixelCPEFast.h
@@ -13,9 +13,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class PixelCPEFast {
   public:
     PixelCPEFast(std::string const &path)
-        : m_commonParamsGPU(cms::alpakatools::make_host_buffer<pixelCPEforGPU::CommonParams>()),
-          m_layerGeometry(cms::alpakatools::make_host_buffer<pixelCPEforGPU::LayerGeometry>()),
-          m_averageGeometry(cms::alpakatools::make_host_buffer<pixelCPEforGPU::AverageGeometry>())
+        : m_commonParamsGPU(cms::alpakatools::make_host_buffer<pixelCPEforGPU::CommonParams, Platform>()),
+          m_layerGeometry(cms::alpakatools::make_host_buffer<pixelCPEforGPU::LayerGeometry, Platform>()),
+          m_averageGeometry(cms::alpakatools::make_host_buffer<pixelCPEforGPU::AverageGeometry, Platform>())
 
     {
       std::ifstream in(path, std::ios::binary);

--- a/src/alpaka/CondFormats/alpaka/SiPixelFedCablingMapGPUWrapper.h
+++ b/src/alpaka/CondFormats/alpaka/SiPixelFedCablingMapGPUWrapper.h
@@ -17,7 +17,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     explicit SiPixelFedCablingMapGPUWrapper(SiPixelFedCablingMapGPU cablingMap, std::vector<unsigned char> modToUnp)
         : modToUnpDefault_(modToUnp.size()),
-          cablingMapHost_{cms::alpakatools::make_host_buffer<SiPixelFedCablingMapGPU>()},
+          cablingMapHost_{cms::alpakatools::make_host_buffer<SiPixelFedCablingMapGPU, Platform>()},
           hasQuality_{true} {
       std::memcpy(cablingMapHost_.data(), &cablingMap, sizeof(SiPixelFedCablingMapGPU));
       std::copy(modToUnp.begin(), modToUnp.end(), modToUnpDefault_.begin());

--- a/src/alpaka/CondFormats/alpaka/SiPixelGainCalibrationForHLTGPU.h
+++ b/src/alpaka/CondFormats/alpaka/SiPixelGainCalibrationForHLTGPU.h
@@ -15,7 +15,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     using DecodingStructure = SiPixelGainForHLTonGPU::DecodingStructure;
 
     SiPixelGainCalibrationForHLTGPU(SiPixelGainForHLTonGPU gain, std::vector<DecodingStructure> gainData)
-        : gainForHLTonHost_{cms::alpakatools::make_host_buffer<SiPixelGainForHLTonGPU>()},
+        : gainForHLTonHost_{cms::alpakatools::make_host_buffer<SiPixelGainForHLTonGPU, Platform>()},
           gainData_(gainData),
           numDecodingStructures_(gainData.size()) {
       *gainForHLTonHost_ = gain;

--- a/src/alpaka/plugin-BeamSpotProducer/alpaka/BeamSpotToAlpaka.cc
+++ b/src/alpaka/plugin-BeamSpotProducer/alpaka/BeamSpotToAlpaka.cc
@@ -26,7 +26,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   BeamSpotToAlpaka::BeamSpotToAlpaka(edm::ProductRegistry& reg)
       : bsPutToken_{reg.produces<cms::alpakatools::Product<Queue, BeamSpotAlpaka>>()},
-        bsHost_{cms::alpakatools::make_host_buffer<BeamSpotPOD>()} {}
+        bsHost_{cms::alpakatools::make_host_buffer<BeamSpotPOD, Platform>()} {}
 
   void BeamSpotToAlpaka::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     *bsHost_ = iSetup.get<BeamSpotPOD>();

--- a/src/alpaka/plugin-PixelTrackFitting/alpaka/PixelTrackSoAFromAlpaka.cc
+++ b/src/alpaka/plugin-PixelTrackFitting/alpaka/PixelTrackSoAFromAlpaka.cc
@@ -34,7 +34,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   PixelTrackSoAFromAlpaka::PixelTrackSoAFromAlpaka(edm::ProductRegistry& reg)
       : tokenDevice_(reg.consumes<cms::alpakatools::Product<Queue, PixelTrackAlpaka>>()),
         tokenHost_(reg.produces<PixelTrackHost>()),
-        soa_{cms::alpakatools::make_host_buffer<pixelTrack::TrackSoA>()} {}
+        soa_{cms::alpakatools::make_host_buffer<pixelTrack::TrackSoA, Platform>()} {}
 
   void PixelTrackSoAFromAlpaka::acquire(edm::Event const& iEvent,
                                         edm::EventSetup const& iSetup,

--- a/src/alpaka/plugin-PixelVertexFinding/alpaka/PixelVertexSoAFromAlpaka.cc
+++ b/src/alpaka/plugin-PixelVertexFinding/alpaka/PixelVertexSoAFromAlpaka.cc
@@ -36,7 +36,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   PixelVertexSoAFromAlpaka::PixelVertexSoAFromAlpaka(edm::ProductRegistry& reg)
       : tokenDevice_(reg.consumes<cms::alpakatools::Product<Queue, ZVertexAlpaka>>()),
         tokenHost_(reg.produces<ZVertexHost>()),
-        soa_(cms::alpakatools::make_host_buffer<ZVertexSoA>()) {}
+        soa_(cms::alpakatools::make_host_buffer<ZVertexSoA, Platform>()) {}
 
   void PixelVertexSoAFromAlpaka::acquire(edm::Event const& iEvent,
                                          edm::EventSetup const& iSetup,

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.cc
@@ -35,8 +35,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   namespace pixelgpudetails {
 
     SiPixelRawToClusterGPUKernel::WordFedAppender::WordFedAppender()
-        : word_{cms::alpakatools::make_host_buffer<unsigned int[]>(MAX_FED_WORDS)},
-          fedId_{cms::alpakatools::make_host_buffer<unsigned char[]>(MAX_FED_WORDS)} {}
+        : word_{cms::alpakatools::make_host_buffer<unsigned int[], Platform>(MAX_FED_WORDS)},
+          fedId_{cms::alpakatools::make_host_buffer<unsigned char[], Platform>(MAX_FED_WORDS)} {}
 
     void SiPixelRawToClusterGPUKernel::WordFedAppender::initializeWordFed(int fedId,
                                                                           unsigned int wordCounterGPU,

--- a/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.h
+++ b/src/alpaka/plugin-SiPixelClusterizer/alpaka/SiPixelRawToClusterGPUKernel.h
@@ -169,7 +169,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         cms::alpakatools::host_buffer<unsigned char[]> fedId_;
       };
 
-      SiPixelRawToClusterGPUKernel() : nModules_Clusters_h{cms::alpakatools::make_host_buffer<uint32_t[]>(2u)} {}
+      SiPixelRawToClusterGPUKernel() : nModules_Clusters_h{cms::alpakatools::make_host_buffer<uint32_t[], Platform>(2u)} {}
 
       ~SiPixelRawToClusterGPUKernel() = default;
 

--- a/src/alpakatest/AlpakaCore/CachingAllocator.h
+++ b/src/alpakatest/AlpakaCore/CachingAllocator.h
@@ -321,8 +321,8 @@ namespace cms::alpakatools {
         // allocate device memory
         return alpaka::allocBuf<std::byte, size_t>(device_, bytes);
       } else if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
-        // allocate pinned host memory
-        return alpaka::allocMappedBuf<std::byte, size_t>(device_, alpaka::getDev(queue), bytes);
+        // allocate pinned host memory accessible by the queue's platform
+        return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<Queue>>, std::byte, size_t>(device_, bytes);
       } else {
         // unsupported combination
         static_assert(std::is_same_v<Device, alpaka::Dev<Queue>> or std::is_same_v<Device, alpaka::DevCpu>,

--- a/src/alpakatest/AlpakaCore/alpakaMemory.h
+++ b/src/alpakatest/AlpakaCore/alpakaMemory.h
@@ -96,6 +96,26 @@ namespace cms::alpakatools {
     return alpaka::allocBuf<std::remove_extent_t<T>, Idx>(host, Vec1D{std::extent_v<T>});
   }
 
+  // non-cached, pinned, scalar and 1-dimensional host buffers
+  // the memory is pinned according to the device associated to the platform
+
+  template <typename T, typename TPlatform>
+  std::enable_if_t<not std::is_array_v<T>, host_buffer<T>> make_host_buffer() {
+    return alpaka::allocMappedBuf<TPlatform, T, Idx>(host, Scalar{});
+  }
+
+  template <typename T, typename TPlatform>
+  std::enable_if_t<cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
+  make_host_buffer(Extent extent) {
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, Vec1D{extent});
+  }
+
+  template <typename T, typename TPlatform>
+  std::enable_if_t<cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
+  make_host_buffer() {
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, Vec1D{std::extent_v<T>});
+  }
+
   // potentially cached, pinned, scalar and 1-dimensional host buffers, associated to a work queue
   // the memory is pinned according to the device associated to the queue
 

--- a/src/alpakatest/AlpakaCore/alpakaMemory.h
+++ b/src/alpakatest/AlpakaCore/alpakaMemory.h
@@ -104,7 +104,7 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<T, Idx>(host, queue, Scalar{});
     } else {
-      return alpaka::allocMappedBuf<T, Idx>(host, alpaka::getDev(queue), Scalar{});
+      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, T, Idx>(host, Scalar{});
     }
   }
 
@@ -114,7 +114,7 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{extent});
     } else {
-      return alpaka::allocMappedBuf<std::remove_extent_t<T>, Idx>(host, alpaka::getDev(queue), Vec1D{extent});
+      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(host, Vec1D{extent});
     }
   }
 
@@ -124,7 +124,7 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{std::extent_v<T>});
     } else {
-      return alpaka::allocMappedBuf<std::remove_extent_t<T>, Idx>(host, alpaka::getDev(queue), Vec1D{std::extent_v<T>});
+      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(host, Vec1D{std::extent_v<T>});
     }
   }
 


### PR DESCRIPTION
Add non-cached, pinned, host buffers, and use them instead of pageable memory to recover a performance close to that of native CUDA.