### PR TITLE
[stdpar] Port SiPixelRecHits

### DIFF
--- a/src/stdpar/CUDACore/portableAtomicOp.h
+++ b/src/stdpar/CUDACore/portableAtomicOp.h
@@ -12,7 +12,7 @@
 
 namespace cms::cuda {
 
-  template <std::floating_point T, typename Tp = std::add_pointer_t<T>>
+  template <std::totally_ordered T, typename Tp = std::add_pointer_t<T>>
   T atomicAdd(Tp address, T val) {
 #ifdef __NVCOMPILER
     // We need to check if execution space is device or host, ::atomicAdd is undefined in host execution space
@@ -45,6 +45,28 @@ namespace cms::cuda {
     std::atomic_ref<T> pa{*address};
     T old{pa.load()};
     while (!pa.compare_exchange_weak(old, std::min(old, val)))
+      ;
+    return old;
+#endif
+  }
+
+  template <std::totally_ordered T, typename Tp = std::add_pointer_t<T>>
+  T atomicMax(Tp address, T val) {
+#ifdef __NVCOMPILER
+    // We need to check if execution space is device or host, ::atomicMin is undefined in host execution space
+    if target (nv::target::is_device) {
+      return ::atomicMax(address, val);
+    } else {
+      std::atomic_ref<T> pa{*address};
+      T old{pa.load()};
+      while (!pa.compare_exchange_weak(old, std::max(old, val)))
+        ;
+      return old;
+    }
+#else
+    std::atomic_ref<T> pa{*address};
+    T old{pa.load()};
+    while (!pa.compare_exchange_weak(old, std::max(old, val)))
       ;
     return old;
 #endif

--- a/src/stdpar/plugin-SiPixelRecHits/PixelRecHits.cu
+++ b/src/stdpar/plugin-SiPixelRecHits/PixelRecHits.cu
@@ -4,11 +4,7 @@
 #include <execution>
 #include <ranges>
 
-// CUDA runtime
-#include <cuda_runtime.h>
-
 // CMSSW headers
-#include "CUDACore/cudaCheck.h"
 #include "plugin-SiPixelClusterizer/SiPixelRawToClusterGPUKernel.h"  // !
 #include "plugin-SiPixelClusterizer/gpuClusteringConstants.h"        // !
 
@@ -24,21 +20,14 @@ namespace pixelgpudetails {
     auto nHits = clusters_d.nClusters();
     TrackingRecHit2D hits_d(nHits, cpeParams, clusters_d.clusModuleStart());
 
-    int threadsPerBlock = 128;
     int blocks = digis_d.nModules();  // active modules (with digis)
 
 #ifdef GPU_DEBUG
-    std::cout << "launching getHits kernel for " << blocks << " blocks" << std::endl;
+    std::cout << "launching getHits kernel for " << blocks << " modules" << std::endl;
 #endif
     if (blocks)  // protect from empty events
-      gpuPixelRecHits::getHits<<<blocks, threadsPerBlock, 0>>>(
+      gpuPixelRecHits::getHits(
           cpeParams, bs_d.data(), digis_d.view(), digis_d.nDigis(), clusters_d.view(), hits_d.view());
-    cudaCheck(cudaGetLastError());
-#ifdef GPU_DEBUG
-    cudaDeviceSynchronize();
-    cudaCheck(cudaGetLastError());
-#endif
-
     // assuming full warp of threads is better than a smaller number...
     if (nHits) {
       //Get pointers to pass to the device
@@ -53,14 +42,7 @@ namespace pixelgpudetails {
 
     if (nHits) {
       cms::cuda::fillManyFromVector(hits_d.phiBinner(), 10, hits_d.iphi(), hits_d.hitsLayerStart(), nHits, 256);
-      cudaCheck(cudaGetLastError());
     }
-
-#ifdef GPU_DEBUG
-    cudaDeviceSynchronize();
-    cudaCheck(cudaGetLastError());
-#endif
-
     return hits_d;
   }
 

--- a/src/stdpar/plugin-SiPixelRecHits/PixelRecHits.cu
+++ b/src/stdpar/plugin-SiPixelRecHits/PixelRecHits.cu
@@ -27,7 +27,7 @@ namespace pixelgpudetails {
 #endif
     if (blocks)  // protect from empty events
       gpuPixelRecHits::getHits(
-          cpeParams, bs_d.data(), digis_d.view(), digis_d.nDigis(), clusters_d.view(), hits_d.view());
+          cpeParams, bs_d.data(), digis_d.view(), digis_d.nDigis(), clusters_d.view(), hits_d.view(), blocks);
     // assuming full warp of threads is better than a smaller number...
     if (nHits) {
       //Get pointers to pass to the device

--- a/src/stdpar/plugin-SiPixelRecHits/SiPixelRecHitCUDA.cc
+++ b/src/stdpar/plugin-SiPixelRecHits/SiPixelRecHitCUDA.cc
@@ -1,4 +1,3 @@
-#include <cuda_runtime.h>
 #include <utility>
 
 #include "CUDADataFormats/BeamSpot.h"
@@ -49,7 +48,6 @@ void SiPixelRecHitCUDA::produce(edm::Event& iEvent, const edm::EventSetup& es) {
     std::cout << "Clusters/Hits Overflow " << nHits << " >= " << TrackingRecHit2DSOAView::maxHits() << std::endl;
   }
   auto recHits2D{gpuAlgo_.makeHitsAsync(digis, clusters, bs, fcpe.get())};
-  cudaDeviceSynchronize();
   iEvent.emplace(tokenHit_, std::move(recHits2D));
 }
 

--- a/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
+++ b/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
@@ -1,14 +1,18 @@
 #ifndef RecoLocalTracker_SiPixelRecHits_plugins_gpuPixelRecHits_h
 #define RecoLocalTracker_SiPixelRecHits_plugins_gpuPixelRecHits_h
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
+#include <execution>
 #include <limits>
+#include <memory>
+#include <ranges>
 
 #include "CUDADataFormats/BeamSpot.h"
 #include "CUDADataFormats/TrackingRecHit2D.h"
 #include "DataFormats/approx_atan2.h"
-#include "CUDACore/cuda_assert.h"
+#include "CUDACore/portableAtomicOp.h"
 #include "CondFormats/pixelCPEforGPU.h"
 
 namespace gpuPixelRecHits {
@@ -27,197 +31,184 @@ namespace gpuPixelRecHits {
 
     assert(phits);
     assert(cpeParams);
-    assert(nModules > 0)
-
-    auto& hits = *phits;
-
-    auto const digis = *pdigis;  // the copy is intentional!
-    auto const& clusters = *pclusters;
-
-    // copy average geometry corrected by beamspot . FIXME (move it somewhere else???)
-    if (0 == blockIdx.x) {
-      auto& agc = hits.averageGeometry();
-      auto const& ag = cpeParams->averageGeometry();
-      for (int il = threadIdx.x, nl = TrackingRecHit2DSOAView::AverageGeometry::numberOfLaddersInBarrel; il < nl;
-           il += blockDim.x) {
-        agc.ladderZ[il] = ag.ladderZ[il] - bs->z;
-        agc.ladderX[il] = ag.ladderX[il] - bs->x;
-        agc.ladderY[il] = ag.ladderY[il] - bs->y;
-        agc.ladderR[il] = sqrt(agc.ladderX[il] * agc.ladderX[il] + agc.ladderY[il] * agc.ladderY[il]);
-        agc.ladderMinZ[il] = ag.ladderMinZ[il] - bs->z;
-        agc.ladderMaxZ[il] = ag.ladderMaxZ[il] - bs->z;
-      }
-      if (0 == threadIdx.x) {
-        agc.endCapZ[0] = ag.endCapZ[0] - bs->z;
-        agc.endCapZ[1] = ag.endCapZ[1] - bs->z;
-        //         printf("endcapZ %f %f\n",agc.endCapZ[0],agc.endCapZ[1]);
-      }
-    }
+    assert(nModules > 0);
 
     // to be moved in common namespace...
     constexpr uint16_t InvId = 9999;  // must be > MaxNumModules
     constexpr int32_t MaxHitsInIter = pixelCPEforGPU::MaxHitsInIter;
-
     using ClusParams = pixelCPEforGPU::ClusParams;
 
     // as usual one block per module
-    __shared__ ClusParams clusParams;
+    auto clusParams{std::make_unique<ClusParams[]>(nModules)};
+    ClusParams *clusParams_d{clusParams.get()};
 
-    auto me = clusters.moduleId(blockIdx.x);
-    int nclus = clusters.clusInModule(me);
+    // copy average geometry corrected by beamspot . FIXME (move it somewhere else???)
+    auto iter{std::views::iota(0u, TrackingRecHit2DSOAView::AverageGeometry::numberOfLaddersInBarrel)};
+    std::for_each(std::execution::par, std::ranges::cbegin(iter), std::ranges::cend(iter), [=](const auto il) {
+      auto& agc = phits->averageGeometry();
+      auto const& ag = cpeParams->averageGeometry();
+      agc.ladderZ[il] = ag.ladderZ[il] - bs->z;
+      agc.ladderX[il] = ag.ladderX[il] - bs->x;
+      agc.ladderY[il] = ag.ladderY[il] - bs->y;
+      agc.ladderR[il] = sqrt(agc.ladderX[il] * agc.ladderX[il] + agc.ladderY[il] * agc.ladderY[il]);
+      agc.ladderMinZ[il] = ag.ladderMinZ[il] - bs->z;
+      agc.ladderMaxZ[il] = ag.ladderMaxZ[il] - bs->z;
+    });
+    auto& agc = phits->averageGeometry();
+    auto const& ag = cpeParams->averageGeometry();
+    agc.endCapZ[0] = ag.endCapZ[0] - bs->z;
+    agc.endCapZ[1] = ag.endCapZ[1] - bs->z;
+    //         printf("endcapZ %f %f\n",agc.endCapZ[0],agc.endCapZ[1]);
+    auto iterModules{std::views::iota(0u, nModules)};
+    std::for_each(std::execution::par, std::ranges::cbegin(iterModules), std::ranges::cend(iterModules), [=](const auto moduleIdx) {
+      auto const& clusters = *pclusters;
+      auto me = clusters.moduleId(moduleIdx);
+      int nclus = clusters.clusInModule(me);
+      auto& clusterParamsRef = clusParams_d[moduleIdx];
+      if (0 == nclus)
+        return;
+      auto& hits = *phits;
 
-    if (0 == nclus)
-      return;
-
-#ifdef GPU_DEBUG
-    // TODO: Does not compile with nvc++ 22.7
-    if (threadIdx.x == 0) {
-      auto k = clusters.moduleStart(1 + blockIdx.x);
+      auto const digis = *pdigis;  // the copy is intentional!
+  #ifdef GPU_DEBUG
+      auto k = clusters.moduleStart(1 + moduleIdx);
       while (digis.moduleInd(k) == InvId)
         ++k;
       assert(digis.moduleInd(k) == me);
-    }
-#endif
+  #endif
 
-#ifdef GPU_DEBUG
-    if (me % 100 == 1)
-      if (threadIdx.x == 0)
-        printf("hitbuilder: %d clusters in module %d. will write at %d\n", nclus, me, clusters.clusModuleStart(me));
-#endif
+  #ifdef GPU_DEBUG
+      if (me % 100 == 1)
+          printf("hitbuilder: %d clusters in module %d. will write at %d\n", nclus, me, clusters.clusModuleStart(me));
+  #endif
 
-    for (int startClus = 0, endClus = nclus; startClus < endClus; startClus += MaxHitsInIter) {
-      auto first = clusters.moduleStart(1 + blockIdx.x);
+      for (int startClus = 0, endClus = nclus; startClus < endClus; startClus += MaxHitsInIter) {
+        auto first = clusters.moduleStart(1 + moduleIdx);
 
-      int nClusInIter = std::min(MaxHitsInIter, endClus - startClus);
-      int lastClus = startClus + nClusInIter;
-      assert(nClusInIter <= nclus);
-      assert(nClusInIter > 0);
-      assert(lastClus <= nclus);
+        int nClusInIter = std::min(MaxHitsInIter, endClus - startClus);
+        int lastClus = startClus + nClusInIter;
+        assert(nClusInIter <= nclus);
+        assert(nClusInIter > 0);
+        assert(lastClus <= nclus);
 
-      assert(nclus > MaxHitsInIter || (0 == startClus && nClusInIter == nclus && lastClus == nclus));
+        assert(nclus > MaxHitsInIter || (0 == startClus && nClusInIter == nclus && lastClus == nclus));
 
-      // init
-      for (int ic = threadIdx.x; ic < nClusInIter; ic += blockDim.x) {
-        clusParams.minRow[ic] = std::numeric_limits<uint32_t>::max();
-        clusParams.maxRow[ic] = 0;
-        clusParams.minCol[ic] = std::numeric_limits<uint32_t>::max();
-        clusParams.maxCol[ic] = 0;
-        clusParams.charge[ic] = 0;
-        clusParams.Q_f_X[ic] = 0;
-        clusParams.Q_l_X[ic] = 0;
-        clusParams.Q_f_Y[ic] = 0;
-        clusParams.Q_l_Y[ic] = 0;
-      }
+        // init
+        //TODO: memset
+        for (int ic = 0; ic < nClusInIter; ++ic) {
+          clusterParamsRef.minRow[ic] = std::numeric_limits<uint32_t>::max();
+          clusterParamsRef.maxRow[ic] = 0;
+          clusterParamsRef.minCol[ic] = std::numeric_limits<uint32_t>::max();
+          clusterParamsRef.maxCol[ic] = 0;
+          clusterParamsRef.charge[ic] = 0;
+          clusterParamsRef.Q_f_X[ic] = 0;
+          clusterParamsRef.Q_l_X[ic] = 0;
+          clusterParamsRef.Q_f_Y[ic] = 0;
+          clusterParamsRef.Q_l_Y[ic] = 0;
+        }
 
-      first += threadIdx.x;
+        // one thead per "digi"
 
-      __syncthreads();
+        for (int i = first; i < numElements; ++i) {
+          auto id = digis.moduleInd(i);
+          if (id == InvId)
+            continue;  // not valid
+          if (id != me)
+            break;  // end of module
+          auto cl = digis.clus(i);
+          if (cl < startClus || cl >= lastClus)
+            continue;
+          uint32_t x = digis.xx(i);
+          uint32_t y = digis.yy(i);
+          cl -= startClus;
+          assert(cl >= 0);
+          assert(cl < MaxHitsInIter);
 
-      // one thead per "digi"
+          cms::cuda::atomicMin(&(clusterParamsRef.minRow[cl]), x);
+          cms::cuda::atomicMax(&(clusterParamsRef.maxRow[cl]), x);
+          cms::cuda::atomicMin(&(clusterParamsRef.minCol[cl]), y);
+          cms::cuda::atomicMax(&(clusterParamsRef.maxCol[cl]), y);
+        }
 
-      for (int i = first; i < numElements; i += blockDim.x) {
-        auto id = digis.moduleInd(i);
-        if (id == InvId)
-          continue;  // not valid
-        if (id != me)
-          break;  // end of module
-        auto cl = digis.clus(i);
-        if (cl < startClus || cl >= lastClus)
-          continue;
-        auto x = digis.xx(i);
-        auto y = digis.yy(i);
-        cl -= startClus;
-        assert(cl >= 0);
-        assert(cl < MaxHitsInIter);
-        atomicMin(&clusParams.minRow[cl], x);
-        atomicMax(&clusParams.maxRow[cl], x);
-        atomicMin(&clusParams.minCol[cl], y);
-        atomicMax(&clusParams.maxCol[cl], y);
-      }
+        // pixmx is not available in the binary dumps
+        //auto pixmx = cpeParams->detParams(me).pixmx;
+        auto pixmx = std::numeric_limits<uint16_t>::max();
+        for (int i = first; i < numElements; ++i) {
+          auto id = digis.moduleInd(i);
+          if (id == InvId)
+            continue;  // not valid
+          if (id != me)
+            break;  // end of module
+          auto cl = digis.clus(i);
+          if (cl < startClus || cl >= lastClus)
+            continue;
+          cl -= startClus;
+          assert(cl >= 0);
+          assert(cl < MaxHitsInIter);
+          auto x = digis.xx(i);
+          auto y = digis.yy(i);
+          int32_t ch = std::min(digis.adc(i), pixmx);
+          cms::cuda::atomicAdd(&clusterParamsRef.charge[cl], ch);
+          if (clusterParamsRef.minRow[cl] == x)
+            cms::cuda::atomicAdd(&clusterParamsRef.Q_f_X[cl], ch);
+          if (clusterParamsRef.maxRow[cl] == x)
+            cms::cuda::atomicAdd(&clusterParamsRef.Q_l_X[cl], ch);
+          if (clusterParamsRef.minCol[cl] == y)
+            cms::cuda::atomicAdd(&clusterParamsRef.Q_f_Y[cl], ch);
+          if (clusterParamsRef.maxCol[cl] == y)
+            cms::cuda::atomicAdd(&clusterParamsRef.Q_l_Y[cl], ch);
+        }
 
-      __syncthreads();
+        // next one cluster per thread...
 
-      // pixmx is not available in the binary dumps
-      //auto pixmx = cpeParams->detParams(me).pixmx;
-      auto pixmx = std::numeric_limits<uint16_t>::max();
-      for (int i = first; i < numElements; i += blockDim.x) {
-        auto id = digis.moduleInd(i);
-        if (id == InvId)
-          continue;  // not valid
-        if (id != me)
-          break;  // end of module
-        auto cl = digis.clus(i);
-        if (cl < startClus || cl >= lastClus)
-          continue;
-        cl -= startClus;
-        assert(cl >= 0);
-        assert(cl < MaxHitsInIter);
-        auto x = digis.xx(i);
-        auto y = digis.yy(i);
-        auto ch = std::min(digis.adc(i), pixmx);
-        atomicAdd(&clusParams.charge[cl], ch);
-        if (clusParams.minRow[cl] == x)
-          atomicAdd(&clusParams.Q_f_X[cl], ch);
-        if (clusParams.maxRow[cl] == x)
-          atomicAdd(&clusParams.Q_l_X[cl], ch);
-        if (clusParams.minCol[cl] == y)
-          atomicAdd(&clusParams.Q_f_Y[cl], ch);
-        if (clusParams.maxCol[cl] == y)
-          atomicAdd(&clusParams.Q_l_Y[cl], ch);
-      }
+        first = clusters.clusModuleStart(me) + startClus;
 
-      __syncthreads();
+        for (int ic = 0; ic < nClusInIter; ++ic) {
+          auto h = first + ic;  // output index in global memory
 
-      // next one cluster per thread...
+          // this cannot happen anymore
+          if (h >= TrackingRecHit2DSOAView::maxHits())
+            break;  // overflow...
+          assert(h < hits.nHits());
+          assert(h < clusters.clusModuleStart(me + 1));
 
-      first = clusters.clusModuleStart(me) + startClus;
+          pixelCPEforGPU::position(cpeParams->commonParams(), cpeParams->detParams(me), clusterParamsRef, ic);
+          pixelCPEforGPU::errorFromDB(cpeParams->commonParams(), cpeParams->detParams(me), clusterParamsRef, ic);
 
-      for (int ic = threadIdx.x; ic < nClusInIter; ic += blockDim.x) {
-        auto h = first + ic;  // output index in global memory
+          // store it
 
-        // this cannot happen anymore
-        if (h >= TrackingRecHit2DSOAView::maxHits())
-          break;  // overflow...
-        assert(h < hits.nHits());
-        assert(h < clusters.clusModuleStart(me + 1));
+          hits.charge(h) = clusterParamsRef.charge[ic];
 
-        pixelCPEforGPU::position(cpeParams->commonParams(), cpeParams->detParams(me), clusParams, ic);
-        pixelCPEforGPU::errorFromDB(cpeParams->commonParams(), cpeParams->detParams(me), clusParams, ic);
+          hits.detectorIndex(h) = me;
 
-        // store it
+          float xl, yl;
+          hits.xLocal(h) = xl = clusterParamsRef.xpos[ic];
+          hits.yLocal(h) = yl = clusterParamsRef.ypos[ic];
 
-        hits.charge(h) = clusParams.charge[ic];
+          hits.clusterSizeX(h) = clusterParamsRef.xsize[ic];
+          hits.clusterSizeY(h) = clusterParamsRef.ysize[ic];
 
-        hits.detectorIndex(h) = me;
+          hits.xerrLocal(h) = clusterParamsRef.xerr[ic] * clusterParamsRef.xerr[ic];
+          hits.yerrLocal(h) = clusterParamsRef.yerr[ic] * clusterParamsRef.yerr[ic];
 
-        float xl, yl;
-        hits.xLocal(h) = xl = clusParams.xpos[ic];
-        hits.yLocal(h) = yl = clusParams.ypos[ic];
+          // keep it local for computations
+          float xg, yg, zg;
+          // to global and compute phi...
+          cpeParams->detParams(me).frame.toGlobal(xl, yl, xg, yg, zg);
+          // here correct for the beamspot...
+          xg -= bs->x;
+          yg -= bs->y;
+          zg -= bs->z;
 
-        hits.clusterSizeX(h) = clusParams.xsize[ic];
-        hits.clusterSizeY(h) = clusParams.ysize[ic];
+          hits.xGlobal(h) = xg;
+          hits.yGlobal(h) = yg;
+          hits.zGlobal(h) = zg;
 
-        hits.xerrLocal(h) = clusParams.xerr[ic] * clusParams.xerr[ic];
-        hits.yerrLocal(h) = clusParams.yerr[ic] * clusParams.yerr[ic];
-
-        // keep it local for computations
-        float xg, yg, zg;
-        // to global and compute phi...
-        cpeParams->detParams(me).frame.toGlobal(xl, yl, xg, yg, zg);
-        // here correct for the beamspot...
-        xg -= bs->x;
-        yg -= bs->y;
-        zg -= bs->z;
-
-        hits.xGlobal(h) = xg;
-        hits.yGlobal(h) = yg;
-        hits.zGlobal(h) = zg;
-
-        hits.rGlobal(h) = std::sqrt(xg * xg + yg * yg);
-        hits.iphi(h) = unsafe_atan2s<7>(yg, xg);
-      }
-      __syncthreads();
-    }  // end loop on batches
+          hits.rGlobal(h) = std::sqrt(xg * xg + yg * yg);
+          hits.iphi(h) = unsafe_atan2s<7>(yg, xg);
+        }
+      }  // end loop on batches
+    });
   }
 
 }  // namespace gpuPixelRecHits

--- a/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
+++ b/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
@@ -18,7 +18,8 @@ namespace gpuPixelRecHits {
                           SiPixelDigis::DeviceConstView const* __restrict__ pdigis,
                           int numElements,
                           SiPixelClusters::DeviceConstView const* __restrict__ pclusters,
-                          TrackingRecHit2DSOAView* phits) {
+                          TrackingRecHit2DSOAView* phits,
+                          uint32_t nModules) {
     // FIXME
     // the compiler seems NOT to optimize loads from views (even in a simple test case)
     // The whole gimnastic here of copying or not is a pure heuristic exercise that seems to produce the fastest code with the above signature
@@ -26,6 +27,7 @@ namespace gpuPixelRecHits {
 
     assert(phits);
     assert(cpeParams);
+    assert(nModules > 0)
 
     auto& hits = *phits;
 

--- a/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
+++ b/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
@@ -125,10 +125,10 @@ namespace gpuPixelRecHits {
               assert(cl >= 0);
               assert(cl < MaxHitsInIter);
 
-              cms::cuda::atomicMin(&(clusterParamsRef.minRow[cl]), x);
-              cms::cuda::atomicMax(&(clusterParamsRef.maxRow[cl]), x);
-              cms::cuda::atomicMin(&(clusterParamsRef.minCol[cl]), y);
-              cms::cuda::atomicMax(&(clusterParamsRef.maxCol[cl]), y);
+              clusterParamsRef.minRow[cl] = std::min(clusterParamsRef.minRow[cl], x);
+              clusterParamsRef.maxRow[cl] = std::max(clusterParamsRef.maxRow[cl], x);
+              clusterParamsRef.minCol[cl] = std::min(clusterParamsRef.minCol[cl], x);
+              clusterParamsRef.maxCol[cl] = std::max(clusterParamsRef.maxCol[cl], x);
             }
 
             // pixmx is not available in the binary dumps
@@ -149,15 +149,15 @@ namespace gpuPixelRecHits {
               auto x = digis.xx(i);
               auto y = digis.yy(i);
               int32_t ch = std::min(digis.adc(i), pixmx);
-              cms::cuda::atomicAdd(&clusterParamsRef.charge[cl], ch);
+              clusterParamsRef.charge[cl] += ch;
               if (clusterParamsRef.minRow[cl] == x)
-                cms::cuda::atomicAdd(&clusterParamsRef.Q_f_X[cl], ch);
+                clusterParamsRef.Q_f_X[cl] += ch;
               if (clusterParamsRef.maxRow[cl] == x)
-                cms::cuda::atomicAdd(&clusterParamsRef.Q_l_X[cl], ch);
+                clusterParamsRef.Q_l_X[cl] += ch;
               if (clusterParamsRef.minCol[cl] == y)
-                cms::cuda::atomicAdd(&clusterParamsRef.Q_f_Y[cl], ch);
+                clusterParamsRef.Q_f_Y[cl] += ch;
               if (clusterParamsRef.maxCol[cl] == y)
-                cms::cuda::atomicAdd(&clusterParamsRef.Q_l_Y[cl], ch);
+                clusterParamsRef.Q_l_Y[cl] += ch;
             }
 
             // next one cluster per thread...

--- a/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
+++ b/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
@@ -98,8 +98,10 @@ namespace gpuPixelRecHits {
             assert(nclus > MaxHitsInIter || (0 == startClus && nClusInIter == nclus && lastClus == nclus));
 
             // init
-            std::fill(clusterParamsRef.minRow, clusterParamsRef.minRow + nClusInIter, std::numeric_limits<uint32_t>::max());
-            std::fill(clusterParamsRef.minCol, clusterParamsRef.minCol + nClusInIter, std::numeric_limits<uint32_t>::max());
+            std::fill(
+                clusterParamsRef.minRow, clusterParamsRef.minRow + nClusInIter, std::numeric_limits<uint32_t>::max());
+            std::fill(
+                clusterParamsRef.minCol, clusterParamsRef.minCol + nClusInIter, std::numeric_limits<uint32_t>::max());
             std::fill(clusterParamsRef.maxRow, clusterParamsRef.maxRow + nClusInIter, 0);
             std::fill(clusterParamsRef.maxCol, clusterParamsRef.maxCol + nClusInIter, 0);
             std::fill(clusterParamsRef.charge, clusterParamsRef.charge + nClusInIter, 0);

--- a/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
+++ b/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
@@ -13,7 +13,7 @@
 
 namespace gpuPixelRecHits {
 
-  __global__ void getHits(pixelCPEforGPU::ParamsOnGPU const* __restrict__ cpeParams,
+  void getHits(pixelCPEforGPU::ParamsOnGPU const* __restrict__ cpeParams,
                           BeamSpotPOD const* __restrict__ bs,
                           SiPixelDigis::DeviceConstView const* __restrict__ pdigis,
                           int numElements,

--- a/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
+++ b/src/stdpar/plugin-SiPixelRecHits/gpuPixelRecHits.h
@@ -98,18 +98,15 @@ namespace gpuPixelRecHits {
             assert(nclus > MaxHitsInIter || (0 == startClus && nClusInIter == nclus && lastClus == nclus));
 
             // init
-            //TODO: memset
-            for (int ic = 0; ic < nClusInIter; ++ic) {
-              clusterParamsRef.minRow[ic] = std::numeric_limits<uint32_t>::max();
-              clusterParamsRef.maxRow[ic] = 0;
-              clusterParamsRef.minCol[ic] = std::numeric_limits<uint32_t>::max();
-              clusterParamsRef.maxCol[ic] = 0;
-              clusterParamsRef.charge[ic] = 0;
-              clusterParamsRef.Q_f_X[ic] = 0;
-              clusterParamsRef.Q_l_X[ic] = 0;
-              clusterParamsRef.Q_f_Y[ic] = 0;
-              clusterParamsRef.Q_l_Y[ic] = 0;
-            }
+            std::fill(clusterParamsRef.minRow, clusterParamsRef.minRow + nClusInIter, std::numeric_limits<uint32_t>::max());
+            std::fill(clusterParamsRef.minCol, clusterParamsRef.minCol + nClusInIter, std::numeric_limits<uint32_t>::max());
+            std::fill(clusterParamsRef.maxRow, clusterParamsRef.maxRow + nClusInIter, 0);
+            std::fill(clusterParamsRef.maxCol, clusterParamsRef.maxCol + nClusInIter, 0);
+            std::fill(clusterParamsRef.charge, clusterParamsRef.charge + nClusInIter, 0);
+            std::fill(clusterParamsRef.Q_f_X, clusterParamsRef.Q_f_X + nClusInIter, 0);
+            std::fill(clusterParamsRef.Q_l_X, clusterParamsRef.Q_l_X + nClusInIter, 0);
+            std::fill(clusterParamsRef.Q_f_Y, clusterParamsRef.Q_f_Y + nClusInIter, 0);
+            std::fill(clusterParamsRef.Q_l_Y, clusterParamsRef.Q_l_Y + nClusInIter, 0);
 
             // one thead per "digi"
 


### PR DESCRIPTION
## Changes
Port `plugin-SiPixelRecHits` to `std::par`. There is only one Kernel to port, `getHits` uses a threading model of one thread block per detector module.  Current `std::par` implementation does a `std::for_each` call, with one iteration per module so each module will be processed by a single thread. 