### PR TITLE
[openmp] Add offload to SiPixelClusterizer and update build for NVHPC compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ ifeq ($(OPENMP_COMPILER), LLVM)
   # HIP
   #export OPENMP_TARGETS := -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdhsa-amd-amdhsa  -march=gfx900
   export OPENMP_CXXFLAGS := -fopenmp-version=51 -foffload-lto -O2 -fPIC -std=c++17 -fopenmp $(OPENMP_TARGETS) -fopenmp-offload-mandatory $(OPENMP_EIGEN_CXXFLAGS) --gcc-toolchain=$(GCC_TOOLCHAIN)
-  export OPENMP_LDFLAGS := $(LDFLAGS) -foffload-lto -O2 --gcc-toolchain=$(GCC_TOOLCHAIN)
+  export OPENMP_LDFLAGS := $(LDFLAGS) -foffload-lto -O2 --gcc-toolchain=$(GCC_TOOLCHAIN) -fopenmp $(OPENMP_TARGETS)
 else ifeq ($(OPENMP_COMPILER), AMD)
   $(error "aompcc not supported")
   # aompcc doesn't support C++ files with .cc suffix
@@ -335,7 +335,7 @@ else ifeq ($(OPENMP_COMPILER), INTEL)
   export OPENMP_CXXFLAGS := -fiopenmp -fopenmp-targets=spir64 -std=c++17 -fPIC $(OPENMP_EIGEN_CXXFLAGS)
 else ifeq ($(OPENMP_COMPILER), NVIDIA)
   export OPENMP_CXX := nvc++
-  export OPENMP_CXXFLAGS := -mp=gpu
+  export OPENMP_CXXFLAGS := -mp=gpu -gpu=cc80 -std=c++17 -fPIC --gcc-toolchain=$(GCC_TOOLCHAIN) $(OPENMP_EIGEN_CXXFLAGS)
 endif
 
 

--- a/src/openmp/DataFormats/SOARotation.h
+++ b/src/openmp/DataFormats/SOARotation.h
@@ -76,7 +76,7 @@ private:
 template <class T>
 class SOAFrame {
 public:
-  constexpr inline SOAFrame() {}
+  constexpr inline SOAFrame() : px(0), py(0), pz(0) {}
 
   constexpr inline SOAFrame(T ix, T iy, T iz, SOARotation<T> const &irot) : px(ix), py(iy), pz(iz), rot(irot) {}
 

--- a/src/openmp/Makefile
+++ b/src/openmp/Makefile
@@ -83,7 +83,7 @@ $(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS) $(LIB_DIR)/$(TARGET_NAME)/plugins.txt |
 define BUILD_template
 $(OBJ_DIR)/$(2)/%.cc.o: $(SRC_DIR)/$(2)/%.cc
 	@[ -d $$(@D) ] || mkdir -p $$(@D)
-	$(OPENMP_CXX) $(OPENMP_CXXFLAGS) $(MY_CXXFLAGS) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_CXXFLAGS)) -c $$< -o $$@ -MMD
+	$(OPENMP_CXX) $(OPENMP_CXXFLAGS) $(MY_CXXFLAGS) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_CXXFLAGS)) -c $$< -o $$@ -MMD -MF $$(@:%.o=%.d)
 	@cp $(OBJ_DIR)/$(2)/$$*.cc.d $(OBJ_DIR)/$(2)/$$*.cc.d.tmp; \
 	  sed 's#\($(2)/$$*\)\.o[ :]*#\1.o \1.d : #g' < $(OBJ_DIR)/$(2)/$$*.cc.d.tmp > $(OBJ_DIR)/$(2)/$$*.cc.d; \
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$$$//' \
@@ -105,7 +105,7 @@ $(foreach lib,$(PLUGINNAMES),$(eval $(call BUILD_template,$(lib),$(TARGET_NAME)/
 
 $(OBJ_DIR)/$(TARGET_NAME)/bin/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/bin/%.cc
 	@[ -d $(@D) ] || mkdir -p $(@D)
-	$(OPENMP_CXX) $(OPENMP_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+	$(OPENMP_CXX) $(OPENMP_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD -MF $(@:%.o=%.d)
 	@cp $(@D)/$*.cc.d $(@D)/$*.cc.d.tmp; \
 	  sed 's#\($(TARGET_NAME)/$*\)\.o[ :]*#\1.o \1.d : #g' < $(@D)/$*.cc.d.tmp > $(@D)/$*.cc.d; \
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
@@ -115,7 +115,7 @@ $(OBJ_DIR)/$(TARGET_NAME)/bin/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/bin/%.cc
 # Tests
 $(OBJ_DIR)/$(TARGET_NAME)/test/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/test/%.cc
 	@[ -d $(@D) ] || mkdir -p $(@D)
-	$(OPENMP_CXX) $(OPENMP_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+	$(OPENMP_CXX) $(OPENMP_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD -MF $(@:%.o=%.d)
 	@cp $(@D)/$*.cc.d $(@D)/$*.cc.d.tmp; \
 	  sed 's#\($(TARGET_NAME)/$*\)\.o[ :]*#\1.o \1.d : #g' < $(@D)/$*.cc.d.tmp > $(@D)/$*.cc.d; \
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \


### PR DESCRIPTION
Add openmp offload to three routines in SiPixelClusterizer.

Update the build to work with the NVHPC compiler.


The code runs and passes validation when compiled with LLVM.  
The code fails with assertion failures when compiled with NVHPC (22.7)