### PR TITLE
[openmp] Replace deprecated C++ library function

### DIFF
--- a/src/openmp/Geometry/phase1PixelTopology.h
+++ b/src/openmp/Geometry/phase1PixelTopology.h
@@ -52,7 +52,7 @@ namespace phase1PixelTopology {
 
   template <class Function, std::size_t... Indices>
   constexpr auto map_to_array_helper(Function f, std::index_sequence<Indices...>)
-      -> std::array<typename std::result_of<Function(std::size_t)>::type, sizeof...(Indices)> {
+      -> std::array<typename std::invoke_result<Function, std::size_t>::type, sizeof...(Indices)> {
     return {{f(Indices)...}};
   }
 


### PR DESCRIPTION
Replace 'result_of' with 'invoke_result'.

The warning
```
/home/mdewing/hep/patatrack/pixeltrack-standalone/src/openmp/Geometry/phase1PixelTopology.h:55:35: warning: 'result_of<unsigned char (*(unsigned long))(unsigned int)>' is deprecated: use 'std::invoke_result' instead [-Wdeprecated-declarations]
      -> std::array<typename std::result_of<Function(std::size_t)>::type, sizeof...(Indices)> {
                                  ^
/home/mdewing/hep/patatrack/pixeltrack-standalone/src/openmp/Geometry/phase1PixelTopology.h:99:57: note: in instantiation of function template specialization 'phase1PixelTopology::map_to_array<116, unsigned char (*)(unsigned int)>' requested here
  constexpr std::array<uint8_t, layerIndexSize> layer = map_to_array<layerIndexSize>(findLayerFromCompact);
                                                        ^
/soft/compilers/gcc/12.2.0/x86_64-suse-linux/lib/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/type_traits:2597:9: note: 'result_of<unsigned char (*(unsigned long))(unsigned int)>' has been explicitly marked deprecated here
    { } _GLIBCXX17_DEPRECATED_SUGGEST("std::invoke_result");
        ^
/soft/compilers/gcc/12.2.0/x86_64-suse-linux/lib/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/x86_64-pc-linux-gnu/bits/c++config.h:120:45: note: expanded from macro '_GLIBCXX17_DEPRECATED_SUGGEST'
# define _GLIBCXX17_DEPRECATED_SUGGEST(ALT) _GLIBCXX_DEPRECATED_SUGGEST(ALT)
                                            ^
/soft/compilers/gcc/12.2.0/x86_64-suse-linux/lib/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/x86_64-pc-linux-gnu/bits/c++config.h:96:19: note: expanded from macro '_GLIBCXX_DEPRECATED_SUGGEST'
  __attribute__ ((__deprecated__ ("use '" ALT "' instead")))
```