### PR TITLE
`std::par` implementation of `plugin-PixelVertexFinding`

### DIFF
--- a/src/stdpar/CUDACore/portableAtomicOp.h
+++ b/src/stdpar/CUDACore/portableAtomicOp.h
@@ -12,7 +12,7 @@
 
 namespace cms::cuda {
 
-  template <std::floating_point T, typename Tp = std::add_pointer_t<T>>
+  template <std::totally_ordered T, typename Tp = std::add_pointer_t<T>>
   T atomicAdd(Tp address, T val) {
 #ifdef __NVCOMPILER
     // We need to check if execution space is device or host, ::atomicAdd is undefined in host execution space

--- a/src/stdpar/plugin-PixelVertexFinding/PixelVertexProducerCUDA.cc
+++ b/src/stdpar/plugin-PixelVertexFinding/PixelVertexProducerCUDA.cc
@@ -46,7 +46,6 @@ void PixelVertexProducerCUDA::produce(edm::Event& iEvent, const edm::EventSetup&
   assert(tracks);
   //move unique_ptr into local variable
   auto vertices{m_gpuAlgo.makeAsync(tracks, m_ptMin)};
-  cudaDeviceSynchronize();  //wait for the device to finish kernels
   //We now move the unique_ptr into the event
   iEvent.emplace(tokenVertex_, std::move(vertices));
 }

--- a/src/stdpar/plugin-PixelVertexFinding/gpuSortByPt2.h
+++ b/src/stdpar/plugin-PixelVertexFinding/gpuSortByPt2.h
@@ -9,7 +9,6 @@
 #include <cstdint>
 
 #include "CUDACore/HistoContainer.h"
-#include "CUDACore/cuda_assert.h"
 #include "CUDACore/portableAtomicOp.h"
 
 #include "gpuVertexFinder.h"

--- a/src/stdpar/plugin-PixelVertexFinding/gpuVertexFinderImpl.h
+++ b/src/stdpar/plugin-PixelVertexFinding/gpuVertexFinderImpl.h
@@ -17,12 +17,12 @@ namespace gpuVertexFinder {
   void loadTracks(TkSoA const* ptracks, ZVertexSoA* soa, WorkSpace* pws, float ptMin) {
     assert(ptracks);
     assert(soa);
-    auto const& tracks = *ptracks;
-    auto const& fit = tracks.stateAtBS;
-    auto const* quality = tracks.qualityData();
 
     auto iter{std::views::iota(0, TkSoA::stride())};
     std::for_each(std::execution::par, std::ranges::cbegin(iter), std::ranges::cend(iter), [=](const auto idx) {
+      auto const& tracks = *ptracks;
+      auto const& fit = tracks.stateAtBS;
+      auto const* quality = tracks.qualityData();
       auto nHits = tracks.nHits(idx);
       if (nHits == 0)
         return;  // this is a guard: maybe we need to move to nTracks...

--- a/src/stdpar/plugin-PixelVertexFinding/gpuVertexFinderImpl.h
+++ b/src/stdpar/plugin-PixelVertexFinding/gpuVertexFinderImpl.h
@@ -1,4 +1,8 @@
+#include <algorithm>
 #include <atomic>
+#include <execution>
+#include <ranges>
+#include <memory>
 #include "CUDACore/cudaCheck.h"
 
 #include "gpuClusterTracksByDensity.h"
@@ -10,31 +14,31 @@
 
 namespace gpuVertexFinder {
 
-  __global__ void loadTracks(TkSoA const* ptracks, ZVertexSoA* soa, WorkSpace* pws, float ptMin) {
+  void loadTracks(TkSoA const* ptracks, ZVertexSoA* soa, WorkSpace* pws, float ptMin) {
     assert(ptracks);
     assert(soa);
     auto const& tracks = *ptracks;
     auto const& fit = tracks.stateAtBS;
     auto const* quality = tracks.qualityData();
 
-    auto first = blockIdx.x * blockDim.x + threadIdx.x;
-    for (int idx = first, nt = TkSoA::stride(); idx < nt; idx += gridDim.x * blockDim.x) {
+    auto iter{std::views::iota(0, TkSoA::stride())};
+    std::for_each(std::execution::par, std::ranges::cbegin(iter), std::ranges::cend(iter), [=](const auto idx) {
       auto nHits = tracks.nHits(idx);
       if (nHits == 0)
-        break;  // this is a guard: maybe we need to move to nTracks...
+        return;  // this is a guard: maybe we need to move to nTracks...
 
       // initialize soa...
       soa->idv[idx] = -1;
 
       if (nHits < 4)
-        continue;  // no triplets
+        return;  // no triplets
       if (quality[idx] != trackQuality::loose)
-        continue;
+        return;
 
       auto pt = tracks.pt(idx);
 
       if (pt < ptMin)
-        continue;
+        return;
 
       auto& data = *pws;
       std::atomic_ref<uint32_t> inc{data.ntrks};
@@ -43,39 +47,8 @@ namespace gpuVertexFinder {
       data.zt[it] = tracks.zip(idx);
       data.ezt2[it] = fit.covariance(idx)(14);
       data.ptt2[it] = pt * pt;
-    }
+    });
   }
-
-// #define THREE_KERNELS
-#ifndef THREE_KERNELS
-  __global__ void vertexFinderOneKernel(gpuVertexFinder::ZVertices* pdata,
-                                        gpuVertexFinder::WorkSpace* pws,
-                                        int minT,      // min number of neighbours to be "seed"
-                                        float eps,     // max absolute distance to cluster
-                                        float errmax,  // max error to be "seed"
-                                        float chi2max  // max normalized distance to cluster,
-  ) {
-    fitVertices(pdata, pws, 50.);
-    __syncthreads();
-    splitVertices(pdata, pws, 9.f);
-    __syncthreads();
-    fitVertices(pdata, pws, 5000.);
-  }
-#else
-  __global__ void vertexFinderKernel1(gpuVertexFinder::ZVertices* pdata,
-                                      gpuVertexFinder::WorkSpace* pws,
-                                      int minT,      // min number of neighbours to be "seed"
-                                      float eps,     // max absolute distance to cluster
-                                      float errmax,  // max error to be "seed"
-                                      float chi2max  // max normalized distance to cluster,
-  ) {
-    fitVertices(pdata, pws, 50.);
-  }
-
-  __global__ void vertexFinderKernel2(gpuVertexFinder::ZVertices* pdata, gpuVertexFinder::WorkSpace* pws) {
-    fitVertices(pdata, pws, 5000.);
-  }
-#endif
 
   ZVertex Producer::makeAsync(TkSoA const* tksoa, float ptMin) const {
     // std::cout << "producing Vertices on GPU" << std::endl;
@@ -87,50 +60,19 @@ namespace gpuVertexFinder {
     auto ws = std::make_unique<WorkSpace>();
 
     init(soa, ws.get());
-    auto blockSize = 128;
-    auto numberOfBlocks = (TkSoA::stride() + blockSize - 1) / blockSize;
-    loadTracks<<<numberOfBlocks, blockSize, 0>>>(tksoa, soa, ws.get(), ptMin);
-    cudaCheck(cudaGetLastError());
-    if (oneKernel_) {
-      // implemented only for density clustesrs
-#ifndef THREE_KERNELS
+    loadTracks(tksoa, soa, ws.get(), ptMin);
+    if (useDensity_ || oneKernel_) {
       clusterTracksByDensity(soa, ws.get(), minT, eps, errmax, chi2max);
-      vertexFinderOneKernel<<<1, 1024 - 256, 0>>>(soa, ws.get(), minT, eps, errmax, chi2max);
-      // moved the call out of cuda kernel as sortByPt2 is calling stdpar algorithms
-      cudaDeviceSynchronize();
-      sortByPt2(soa, ws.get());
-#else
-      clusterTracksByDensity(soa, ws.get(), minT, eps, errmax, chi2max);
-      vertexFinderKernel1<<<1, 1024 - 256, 0>>>(soa, ws.get(), minT, eps, errmax, chi2max);
-      cudaCheck(cudaGetLastError());
-      // one block per vertex...
-      splitVerticesKernel<<<1024, 128, 0>>>(soa, ws.get(), 9.f);
-      cudaCheck(cudaGetLastError());
-      vertexFinderKernel2<<<1, 1024 - 256, 0>>>(soa, ws.get());
-      // moved the call out of cuda kernel as sortByPt2 is calling stdpar algorithms
-      cudaDeviceSynchronize();
-      sortByPt2(soa, ws.get());
-#endif
-    } else {  // five kernels
-      if (useDensity_) {
-        clusterTracksByDensity(soa, ws.get(), minT, eps, errmax, chi2max);
-      } else if (useDBSCAN_) {
-        clusterTracksDBSCAN(soa, ws.get(), minT, eps, errmax, chi2max);
-      } else if (useIterative_) {
-        clusterTracksIterative(soa, ws.get(), minT, eps, errmax, chi2max);
-      }
-      cudaCheck(cudaGetLastError());
-      fitVerticesKernel<<<1, 1024 - 256, 0>>>(soa, ws.get(), 50.);
-      cudaCheck(cudaGetLastError());
-      // one block per vertex...
-      splitVerticesKernel<<<1024, 128, 0>>>(soa, ws.get(), 9.f);
-      cudaCheck(cudaGetLastError());
-      fitVerticesKernel<<<1, 1024 - 256, 0>>>(soa, ws.get(), 5000.);
-      cudaCheck(cudaGetLastError());
-
-      sortByPt2(soa, ws.get());
+    } else if (useDBSCAN_) {
+      clusterTracksDBSCAN(soa, ws.get(), minT, eps, errmax, chi2max);
+    } else if (useIterative_) {
+      clusterTracksIterative(soa, ws.get(), minT, eps, errmax, chi2max);
     }
-    cudaCheck(cudaGetLastError());
+    fitVertices(soa, ws.get(), 50.);
+    splitVertices(soa, ws.get(), 9.f);
+    fitVertices(soa, ws.get(), 5000.);
+
+    sortByPt2(soa, ws.get());
 
     return vertices;
   }

--- a/src/stdpar/test/VertexFinder_t.h
+++ b/src/stdpar/test/VertexFinder_t.h
@@ -162,7 +162,7 @@ int main() {
       cudaDeviceSynchronize();
 
 #ifdef ONE_KERNEL
-      vertexFinderOneKernel<<<1, 512 + 256>>>(onGPU_d.get(), ws_d.get(), kk, par[0], par[1], par[2]);
+      vertexFinderOneKernel(onGPU_d.get(), ws_d.get(), kk, par[0], par[1], par[2]);
       sortByPt2(onGPU_d.get(), ws_d.get());
 #else
       CLUSTERIZE(onGPU_d.get(), ws_d.get(), kk, par[0], par[1], par[2]);
@@ -172,7 +172,7 @@ int main() {
       cudaCheck(cudaGetLastError());
       cudaDeviceSynchronize();
 
-      gpuVertexFinder::fitVerticesKernel<<<1, 1024 - 256>>>(onGPU_d.get(), ws_d.get(), 50.f);
+      gpuVertexFinder::fitVertices(onGPU_d.get(), ws_d.get(), 50.f);
       cudaCheck(cudaGetLastError());
       cudaCheck(cudaMemcpy(&nv, LOC_ONGPU(nvFinal), sizeof(uint32_t), cudaMemcpyDeviceToHost));
 
@@ -234,7 +234,7 @@ int main() {
       }
 
 #if defined(__NVCOMPILER) || defined(__CUDACC__)
-      gpuVertexFinder::fitVerticesKernel<<<1, 1024 - 256>>>(onGPU_d.get(), ws_d.get(), 50.f);
+      gpuVertexFinder::fitVertices(onGPU_d.get(), ws_d.get(), 50.f);
       cudaCheck(cudaMemcpy(&nv, LOC_ONGPU(nvFinal), sizeof(uint32_t), cudaMemcpyDeviceToHost));
       cudaCheck(cudaMemcpy(nn, LOC_ONGPU(ndof), nv * sizeof(int32_t), cudaMemcpyDeviceToHost));
       cudaCheck(cudaMemcpy(chi2, LOC_ONGPU(chi2), nv * sizeof(float), cudaMemcpyDeviceToHost));
@@ -254,7 +254,7 @@ int main() {
 
 #if defined(__NVCOMPILER) || defined(__CUDACC__)
       // one vertex per block!!!
-      gpuVertexFinder::splitVerticesKernel<<<1024, 64>>>(onGPU_d.get(), ws_d.get(), 9.f);
+      gpuVertexFinder::splitVertices(onGPU_d.get(), ws_d.get(), 9.f);
       cudaCheck(cudaMemcpy(&nv, LOC_WS(nvIntermediate), sizeof(uint32_t), cudaMemcpyDeviceToHost));
 #else
       gridDim.x = 1;
@@ -266,7 +266,7 @@ int main() {
       std::cout << "after split " << nv << std::endl;
 
 #if defined(__NVCOMPILER) || defined(__CUDACC__)
-      gpuVertexFinder::fitVerticesKernel<<<1, 1024 - 256>>>(onGPU_d.get(), ws_d.get(), 5000.f);
+      gpuVertexFinder::fitVertices(onGPU_d.get(), ws_d.get(), 5000.f);
       cudaCheck(cudaGetLastError());
 
       sortByPt2(onGPU_d.get(), ws_d.get());


### PR DESCRIPTION
Port of `plugin-PixelVertexFinding` to `std::par`.

The original CUDA threading model was to process one module per thread block for most kernels. Parallel algorithms don't currently allow to express this model; as single execution of a `std::for_each` lambda will map to one thread so we now have one thread per module. 

There is still an issue when compiling `gpuVertexFinder::loadTracks`, `nvc++` hangs and never finishes