### PR TITLE
[stdpar] Port pixel triplets plugin to `stdpar`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ export CUDA_DLINKFLAGS
 endif
 
 # NVIDIA HPC SDK
-NVHPC_BASE := /opt/nvidia/hpc_sdk/Linux_x86_64/22.7
+NVHPC_BASE := /opt/nvidia/hpc_sdk/Linux_x86_64/23.1
 ifeq ($(wildcard $(NVHPC_BASE)),)
 # HPC SDK not found
 NVHPC_BASE :=

--- a/src/stdpar/plugin-PixelTriplets/BrokenLine.h
+++ b/src/stdpar/plugin-PixelTriplets/BrokenLine.h
@@ -43,7 +43,7 @@ namespace BrokenLine {
     
     \return the variance of the planar angle ((theta_0)^2 /3).
   */
-  __host__ __device__ inline double MultScatt(
+  inline double MultScatt(
       const double& length, const double B, const double R, int Layer, double slope) {
     // limit R to 20GeV...
     auto pt2 = std::min(20., B * R);
@@ -66,7 +66,7 @@ namespace BrokenLine {
     
     \return 2D rotation matrix.
   */
-  __host__ __device__ inline Rfit::Matrix2d RotationMatrix(double slope) {
+  inline Rfit::Matrix2d RotationMatrix(double slope) {
     Rfit::Matrix2d Rot;
     Rot(0, 0) = 1. / sqrt(1. + Rfit::sqr(slope));
     Rot(0, 1) = slope * Rot(0, 0);
@@ -83,7 +83,7 @@ namespace BrokenLine {
     \param y0 y coordinate of the translation vector.
     \param jacobian passed by reference in order to save stack.
   */
-  __host__ __device__ inline void TranslateKarimaki(karimaki_circle_fit& circle,
+  inline void TranslateKarimaki(karimaki_circle_fit& circle,
                                                     double x0,
                                                     double y0,
                                                     Rfit::Matrix3d& jacobian) {
@@ -121,7 +121,7 @@ namespace BrokenLine {
     \param results PreparedBrokenLineData to be filled (see description of PreparedBrokenLineData).
   */
   template <typename M3xN, typename V4, int N>
-  __host__ __device__ inline void prepareBrokenLineData(const M3xN& hits,
+  inline void prepareBrokenLineData(const M3xN& hits,
                                                         const V4& fast_fit,
                                                         const double B,
                                                         PreparedBrokenLineData<N>& results) {
@@ -175,7 +175,7 @@ namespace BrokenLine {
     \return the n-by-n matrix of the linear system
   */
   template <int N>
-  __host__ __device__ inline Rfit::MatrixNd<N> MatrixC_u(const Rfit::VectorNd<N>& w,
+  inline Rfit::MatrixNd<N> MatrixC_u(const Rfit::VectorNd<N>& w,
                                                          const Rfit::VectorNd<N>& S,
                                                          const Rfit::VectorNd<N>& VarBeta) {
     constexpr u_int n = N;
@@ -217,7 +217,7 @@ namespace BrokenLine {
   */
 
   template <typename M3xN, typename V4>
-  __host__ __device__ inline void BL_Fast_fit(const M3xN& hits, V4& result) {
+  inline void BL_Fast_fit(const M3xN& hits, V4& result) {
     constexpr uint32_t N = M3xN::ColsAtCompileTime;
     constexpr auto n = N;  // get the number of hits
 
@@ -258,7 +258,7 @@ namespace BrokenLine {
     The step 3 is the correction of the fast pre-fitted parameters for the innermost part of the track. It is first done in a comfortable coordinate system (the one in which the first hit is the origin) and then the parameters and their covariance matrix are transformed to the original coordinate system.
   */
   template <typename M3xN, typename M6xN, typename V4, int N>
-  __host__ __device__ inline void BL_Circle_fit(const M3xN& hits,
+  inline void BL_Circle_fit(const M3xN& hits,
                                                 const M6xN& hits_ge,
                                                 const V4& fast_fit,
                                                 const double B,
@@ -403,7 +403,7 @@ namespace BrokenLine {
     The step 3 is the correction of the fast pre-fitted parameters for the innermost part of the track. It is first done in a comfortable coordinate system (the one in which the first hit is the origin) and then the parameters and their covariance matrix are transformed to the original coordinate system.
   */
   template <typename V4, typename M6xN, int N>
-  __host__ __device__ inline void BL_Line_fit(const M6xN& hits_ge,
+  inline void BL_Line_fit(const M6xN& hits_ge,
                                               const V4& fast_fit,
                                               const double B,
                                               const PreparedBrokenLineData<N>& data,

--- a/src/stdpar/plugin-PixelTriplets/BrokenLine.h
+++ b/src/stdpar/plugin-PixelTriplets/BrokenLine.h
@@ -43,8 +43,7 @@ namespace BrokenLine {
     
     \return the variance of the planar angle ((theta_0)^2 /3).
   */
-  inline double MultScatt(
-      const double& length, const double B, const double R, int Layer, double slope) {
+  inline double MultScatt(const double& length, const double B, const double R, int Layer, double slope) {
     // limit R to 20GeV...
     auto pt2 = std::min(20., B * R);
     pt2 *= pt2;
@@ -83,10 +82,7 @@ namespace BrokenLine {
     \param y0 y coordinate of the translation vector.
     \param jacobian passed by reference in order to save stack.
   */
-  inline void TranslateKarimaki(karimaki_circle_fit& circle,
-                                                    double x0,
-                                                    double y0,
-                                                    Rfit::Matrix3d& jacobian) {
+  inline void TranslateKarimaki(karimaki_circle_fit& circle, double x0, double y0, Rfit::Matrix3d& jacobian) {
     double A, U, BB, C, DO, DP, uu, xi, v, mu, lambda, zeta;
     DP = x0 * cos(circle.par(0)) + y0 * sin(circle.par(0));
     DO = x0 * sin(circle.par(0)) - y0 * cos(circle.par(0)) + circle.par(1);
@@ -122,9 +118,9 @@ namespace BrokenLine {
   */
   template <typename M3xN, typename V4, int N>
   inline void prepareBrokenLineData(const M3xN& hits,
-                                                        const V4& fast_fit,
-                                                        const double B,
-                                                        PreparedBrokenLineData<N>& results) {
+                                    const V4& fast_fit,
+                                    const double B,
+                                    PreparedBrokenLineData<N>& results) {
     constexpr auto n = N;
     u_int i;
     Rfit::Vector2d d;
@@ -176,8 +172,8 @@ namespace BrokenLine {
   */
   template <int N>
   inline Rfit::MatrixNd<N> MatrixC_u(const Rfit::VectorNd<N>& w,
-                                                         const Rfit::VectorNd<N>& S,
-                                                         const Rfit::VectorNd<N>& VarBeta) {
+                                     const Rfit::VectorNd<N>& S,
+                                     const Rfit::VectorNd<N>& VarBeta) {
     constexpr u_int n = N;
     u_int i;
 
@@ -259,11 +255,11 @@ namespace BrokenLine {
   */
   template <typename M3xN, typename M6xN, typename V4, int N>
   inline void BL_Circle_fit(const M3xN& hits,
-                                                const M6xN& hits_ge,
-                                                const V4& fast_fit,
-                                                const double B,
-                                                PreparedBrokenLineData<N>& data,
-                                                karimaki_circle_fit& circle_results) {
+                            const M6xN& hits_ge,
+                            const V4& fast_fit,
+                            const double B,
+                            PreparedBrokenLineData<N>& data,
+                            karimaki_circle_fit& circle_results) {
     constexpr u_int n = N;
     u_int i;
 
@@ -404,10 +400,10 @@ namespace BrokenLine {
   */
   template <typename V4, typename M6xN, int N>
   inline void BL_Line_fit(const M6xN& hits_ge,
-                                              const V4& fast_fit,
-                                              const double B,
-                                              const PreparedBrokenLineData<N>& data,
-                                              Rfit::line_fit& line_results) {
+                          const V4& fast_fit,
+                          const double B,
+                          const PreparedBrokenLineData<N>& data,
+                          Rfit::line_fit& line_results) {
     constexpr u_int n = N;
     u_int i;
 

--- a/src/stdpar/plugin-PixelTriplets/BrokenLineFitOnGPU.cu
+++ b/src/stdpar/plugin-PixelTriplets/BrokenLineFitOnGPU.cu
@@ -5,9 +5,6 @@
 void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv, uint32_t hitsInFit, uint32_t maxNumberOfTuples) {
   assert(tuples_d);
 
-  auto blockSize = 64;
-  auto numberOfBlocks = (maxNumberOfConcurrentFits_ + blockSize - 1) / blockSize;
-
   //  Fit internals
   auto hitsGPU_ = std::make_unique<double[]>(maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix3xNd<4>) / sizeof(double));
   auto hits_geGPU_ = std::make_unique<float[]>(maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix6x4f) / sizeof(float));
@@ -16,65 +13,57 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv, uint32_t hitsInF
 
   for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
     // fit triplets
-    kernelBLFastFit<3><<<numberOfBlocks, blockSize, 0>>>(
+    kernelBLFastFit<3>(
         tuples_d, tupleMultiplicity_d, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 3, offset);
-    cudaCheck(cudaGetLastError());
 
-    kernelBLFit<3><<<numberOfBlocks, blockSize, 0>>>(tupleMultiplicity_d,
-                                                     bField_,
-                                                     outputSoa_d,
-                                                     hitsGPU_.get(),
-                                                     hits_geGPU_.get(),
-                                                     fast_fit_resultsGPU_.get(),
-                                                     3,
-                                                     offset);
-    cudaCheck(cudaGetLastError());
+    kernelBLFit<3>(tupleMultiplicity_d,
+                   bField_,
+                   outputSoa_d,
+                   hitsGPU_.get(),
+                   hits_geGPU_.get(),
+                   fast_fit_resultsGPU_.get(),
+                   3,
+                   offset);
 
     // fit quads
-    kernelBLFastFit<4><<<numberOfBlocks / 4, blockSize, 0>>>(
+    kernelBLFastFit<4>(
         tuples_d, tupleMultiplicity_d, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 4, offset);
-    cudaCheck(cudaGetLastError());
 
-    kernelBLFit<4><<<numberOfBlocks / 4, blockSize, 0>>>(tupleMultiplicity_d,
-                                                         bField_,
-                                                         outputSoa_d,
-                                                         hitsGPU_.get(),
-                                                         hits_geGPU_.get(),
-                                                         fast_fit_resultsGPU_.get(),
-                                                         4,
-                                                         offset);
-    cudaCheck(cudaGetLastError());
+    kernelBLFit<4>(tupleMultiplicity_d,
+                   bField_,
+                   outputSoa_d,
+                   hitsGPU_.get(),
+                   hits_geGPU_.get(),
+                   fast_fit_resultsGPU_.get(),
+                   4,
+                   offset);
 
     if (fit5as4_) {
       // fit penta (only first 4)
-      kernelBLFastFit<4><<<numberOfBlocks / 4, blockSize, 0>>>(
+      kernelBLFastFit<4>(
           tuples_d, tupleMultiplicity_d, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 5, offset);
-      cudaCheck(cudaGetLastError());
 
-      kernelBLFit<4><<<numberOfBlocks / 4, blockSize, 0>>>(tupleMultiplicity_d,
-                                                           bField_,
-                                                           outputSoa_d,
-                                                           hitsGPU_.get(),
-                                                           hits_geGPU_.get(),
-                                                           fast_fit_resultsGPU_.get(),
-                                                           5,
-                                                           offset);
-      cudaCheck(cudaGetLastError());
+      kernelBLFit<4>(tupleMultiplicity_d,
+                     bField_,
+                     outputSoa_d,
+                     hitsGPU_.get(),
+                     hits_geGPU_.get(),
+                     fast_fit_resultsGPU_.get(),
+                     5,
+                     offset);
     } else {
       // fit penta (all 5)
-      kernelBLFastFit<5><<<numberOfBlocks / 4, blockSize, 0>>>(
+      kernelBLFastFit<5>(
           tuples_d, tupleMultiplicity_d, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 5, offset);
-      cudaCheck(cudaGetLastError());
 
-      kernelBLFit<5><<<numberOfBlocks / 4, blockSize, 0>>>(tupleMultiplicity_d,
-                                                           bField_,
-                                                           outputSoa_d,
-                                                           hitsGPU_.get(),
-                                                           hits_geGPU_.get(),
-                                                           fast_fit_resultsGPU_.get(),
-                                                           5,
-                                                           offset);
-      cudaCheck(cudaGetLastError());
+      kernelBLFit<5>(tupleMultiplicity_d,
+                     bField_,
+                     outputSoa_d,
+                     hitsGPU_.get(),
+                     hits_geGPU_.get(),
+                     fast_fit_resultsGPU_.get(),
+                     5,
+                     offset);
     }
 
   }  // loop on concurrent fits

--- a/src/stdpar/plugin-PixelTriplets/CAConstants.h
+++ b/src/stdpar/plugin-PixelTriplets/CAConstants.h
@@ -3,8 +3,6 @@
 
 #include <cstdint>
 
-#include <cuda_runtime.h>
-
 #include "CUDACore/HistoContainer.h"
 #include "CUDACore/SimpleVector.h"
 #include "CUDACore/VecArray.h"

--- a/src/stdpar/plugin-PixelTriplets/CAHitNtupletCUDA.cc
+++ b/src/stdpar/plugin-PixelTriplets/CAHitNtupletCUDA.cc
@@ -1,4 +1,3 @@
-#include <cuda_runtime.h>
 
 #include "Framework/EventSetup.h"
 #include "Framework/Event.h"

--- a/src/stdpar/plugin-PixelTriplets/CAHitNtupletGeneratorKernels.cu
+++ b/src/stdpar/plugin-PixelTriplets/CAHitNtupletGeneratorKernels.cu
@@ -24,108 +24,63 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   // applying conbinatoric cleaning such as fishbone at this stage is too expensive
   //
 
-  auto nthTot = 64;
-  auto stride = 4;
-  auto blockSize = nthTot / stride;
-  auto numberOfBlocks = (3 * m_params.maxNumberOfDoublets_ / 4 + blockSize - 1) / blockSize;
-  auto rescale = numberOfBlocks / 65536;
-  blockSize *= (rescale + 1);
-  numberOfBlocks = (3 * m_params.maxNumberOfDoublets_ / 4 + blockSize - 1) / blockSize;
-  assert(numberOfBlocks < 65536);
-  assert(blockSize > 0 && 0 == blockSize % 16);
-  dim3 blks(1, numberOfBlocks, 1);
-  dim3 thrs(stride, blockSize, 1);
-
-  kernel_connect<<<blks, thrs, 0>>>(device_hitTuple_apc_,
-                                    device_hitToTuple_apc_,  // needed only to be reset, ready for next kernel
-                                    hh.view(),
-                                    device_theCells_.get(),
-                                    device_nCells_,
-                                    device_theCellNeighbors_.get(),
-                                    device_isOuterHitOfCell_.get(),
-                                    m_params.hardCurvCut_,
-                                    m_params.ptmin_,
-                                    m_params.CAThetaCutBarrel_,
-                                    m_params.CAThetaCutForward_,
-                                    m_params.dcaCutInnerTriplet_,
-                                    m_params.dcaCutOuterTriplet_);
-  cudaCheck(cudaGetLastError());
+  kernel_connect(device_hitTuple_apc_,
+                 device_hitToTuple_apc_,  // needed only to be reset, ready for next kernel
+                 hh.view(),
+                 device_theCells_.get(),
+                 device_nCells_,
+                 device_theCellNeighbors_.get(),
+                 device_isOuterHitOfCell_.get(),
+                 m_params.hardCurvCut_,
+                 m_params.ptmin_,
+                 m_params.CAThetaCutBarrel_,
+                 m_params.CAThetaCutForward_,
+                 m_params.dcaCutInnerTriplet_,
+                 m_params.dcaCutOuterTriplet_);
 
   if (nhits > 1 && m_params.earlyFishbone_) {
-    auto nthTot = 128;
-    auto stride = 16;
-    auto blockSize = nthTot / stride;
-    auto numberOfBlocks = (nhits + blockSize - 1) / blockSize;
-    dim3 blks(1, numberOfBlocks, 1);
-    dim3 thrs(stride, blockSize, 1);
-    gpuPixelDoublets::fishbone<<<blks, thrs, 0>>>(
+    gpuPixelDoublets::fishbone(
         hh.view(), device_theCells_.get(), device_nCells_, device_isOuterHitOfCell_.get(), nhits, false);
-    cudaCheck(cudaGetLastError());
   }
 
-  blockSize = 64;
-  numberOfBlocks = (3 * m_params.maxNumberOfDoublets_ / 4 + blockSize - 1) / blockSize;
-  kernel_find_ntuplets<<<numberOfBlocks, blockSize, 0>>>(hh.view(),
-                                                         device_theCells_.get(),
-                                                         device_nCells_,
-                                                         device_theCellTracks_.get(),
-                                                         tuples_d,
-                                                         device_hitTuple_apc_,
-                                                         quality_d,
-                                                         m_params.minHitsPerNtuplet_);
-  cudaCheck(cudaGetLastError());
+  kernel_find_ntuplets(hh.view(),
+                       device_theCells_.get(),
+                       device_nCells_,
+                       device_theCellTracks_.get(),
+                       tuples_d,
+                       device_hitTuple_apc_,
+                       quality_d,
+                       m_params.minHitsPerNtuplet_);
 
   if (m_params.doStats_)
-    kernel_mark_used<<<numberOfBlocks, blockSize, 0>>>(hh.view(), device_theCells_.get(), device_nCells_);
-  cudaCheck(cudaGetLastError());
+    kernel_mark_used(hh.view(), device_theCells_.get(), device_nCells_);
 
-#ifdef GPU_DEBUG
-  cudaDeviceSynchronize();
-  cudaCheck(cudaGetLastError());
-#endif
-
-  blockSize = 128;
-  numberOfBlocks = (HitContainer::totbins() + blockSize - 1) / blockSize;
   cms::cuda::finalizeBulk(device_hitTuple_apc_, tuples_d);
 
   // remove duplicates (tracks that share a doublet)
-  numberOfBlocks = (3 * m_params.maxNumberOfDoublets_ / 4 + blockSize - 1) / blockSize;
-  kernel_earlyDuplicateRemover<<<numberOfBlocks, blockSize, 0>>>(
-      device_theCells_.get(), device_nCells_, tuples_d, quality_d);
-  cudaCheck(cudaGetLastError());
+  kernel_earlyDuplicateRemover(device_theCells_.get(), device_nCells_, tuples_d, quality_d);
 
-  blockSize = 128;
-  numberOfBlocks = (3 * CAConstants::maxTuples() / 4 + blockSize - 1) / blockSize;
-  kernel_countMultiplicity<<<numberOfBlocks, blockSize, 0>>>(tuples_d, quality_d, device_tupleMultiplicity_.get());
+  kernel_countMultiplicity(tuples_d, quality_d, device_tupleMultiplicity_.get());
   cms::cuda::launchFinalize(device_tupleMultiplicity_.get());
-  kernel_fillMultiplicity<<<numberOfBlocks, blockSize, 0>>>(tuples_d, quality_d, device_tupleMultiplicity_.get());
-  cudaCheck(cudaGetLastError());
+  kernel_fillMultiplicity(tuples_d, quality_d, device_tupleMultiplicity_.get());
 
   if (nhits > 1 && m_params.lateFishbone_) {
-    auto nthTot = 128;
-    auto stride = 16;
-    auto blockSize = nthTot / stride;
-    auto numberOfBlocks = (nhits + blockSize - 1) / blockSize;
-    dim3 blks(1, numberOfBlocks, 1);
-    dim3 thrs(stride, blockSize, 1);
-    gpuPixelDoublets::fishbone<<<blks, thrs, 0>>>(
+    gpuPixelDoublets::fishbone(
         hh.view(), device_theCells_.get(), device_nCells_, device_isOuterHitOfCell_.get(), nhits, true);
-    cudaCheck(cudaGetLastError());
   }
 
   if (m_params.doStats_) {
-    numberOfBlocks = (std::max(nhits, m_params.maxNumberOfDoublets_) + blockSize - 1) / blockSize;
-    kernel_checkOverflows<<<numberOfBlocks, blockSize, 0>>>(tuples_d,
-                                                            device_tupleMultiplicity_.get(),
-                                                            device_hitTuple_apc_,
-                                                            device_theCells_.get(),
-                                                            device_nCells_,
-                                                            device_theCellNeighbors_.get(),
-                                                            device_theCellTracks_.get(),
-                                                            device_isOuterHitOfCell_.get(),
-                                                            nhits,
-                                                            m_params.maxNumberOfDoublets_,
-                                                            counters_);
+    kernel_checkOverflows(tuples_d,
+                          device_tupleMultiplicity_.get(),
+                          device_hitTuple_apc_,
+                          device_theCells_.get(),
+                          device_nCells_,
+                          device_theCellNeighbors_.get(),
+                          device_theCellTracks_.get(),
+                          device_isOuterHitOfCell_.get(),
+                          nhits,
+                          m_params.maxNumberOfDoublets_,
+                          counters_);
   }
 
   // free space asap
@@ -152,15 +107,12 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh) {
                                 CAConstants::maxNumOfActiveDoublets() * sizeof(GPUCACell::CellNeighbors));
 
   {
-    int threadsPerBlock = 128;
-    // at least one block!
-    int blocks = (std::max(1U, nhits) + threadsPerBlock - 1) / threadsPerBlock;
-    gpuPixelDoublets::initDoublets<<<blocks, threadsPerBlock, 0>>>(device_isOuterHitOfCell_.get(),
-                                                                   nhits,
-                                                                   device_theCellNeighbors_.get(),
-                                                                   device_theCellNeighborsContainer_,
-                                                                   device_theCellTracks_.get(),
-                                                                   device_theCellTracksContainer_);
+    gpuPixelDoublets::initDoublets(device_isOuterHitOfCell_.get(),
+                                   nhits,
+                                   device_theCellNeighbors_.get(),
+                                   device_theCellNeighborsContainer_,
+                                   device_theCellTracks_.get(),
+                                   device_theCellTracksContainer_);
   }
 
   device_theCells_ = std::make_unique<GPUCACell[]>(m_params.maxNumberOfDoublets_);
@@ -175,25 +127,18 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh) {
   if (m_params.minHitsPerNtuplet_ > 3) {
     nActualPairs = 13;
   }
-
-  assert(nActualPairs <= gpuPixelDoublets::nPairs);
-  int stride = 4;
-  int threadsPerBlock = gpuPixelDoublets::getDoubletsFromHistoMaxBlockSize / stride;
-  int blocks = (4 * nhits + threadsPerBlock - 1) / threadsPerBlock;
-  dim3 blks(1, blocks, 1);
-  dim3 thrs(stride, threadsPerBlock, 1);
-  gpuPixelDoublets::getDoubletsFromHisto<<<blks, thrs, 0>>>(device_theCells_.get(),
-                                                            device_nCells_,
-                                                            device_theCellNeighbors_.get(),
-                                                            device_theCellTracks_.get(),
-                                                            hh.view(),
-                                                            device_isOuterHitOfCell_.get(),
-                                                            nActualPairs,
-                                                            m_params.idealConditions_,
-                                                            m_params.doClusterCut_,
-                                                            m_params.doZ0Cut_,
-                                                            m_params.doPtCut_,
-                                                            m_params.maxNumberOfDoublets_);
+  gpuPixelDoublets::getDoubletsFromHisto(device_theCells_.get(),
+                                         device_nCells_,
+                                         device_theCellNeighbors_.get(),
+                                         device_theCellTracks_.get(),
+                                         hh.view(),
+                                         device_isOuterHitOfCell_.get(),
+                                         nActualPairs,
+                                         m_params.idealConditions_,
+                                         m_params.doClusterCut_,
+                                         m_params.doZ0Cut_,
+                                         m_params.doPtCut_,
+                                         m_params.maxNumberOfDoublets_);
 }
 
 void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA *tracks_d) {
@@ -210,8 +155,7 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
   }
 
   // remove duplicates (tracks that share a doublet)
-  kernel_fastDuplicateRemover(
-      device_theCells_.get(), device_nCells_, tuples_d, tracks_d);
+  kernel_fastDuplicateRemover(device_theCells_.get(), device_nCells_, tuples_d, tracks_d);
 
   if (m_params.minHitsPerNtuplet_ < 4 || m_params.doStats_) {
     // fill hit->track "map"
@@ -221,8 +165,7 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
   }
   if (m_params.minHitsPerNtuplet_ < 4) {
     // remove duplicates (tracks that share a hit)
-    kernel_tripletCleaner(
-        hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get());
+    kernel_tripletCleaner(hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get());
   }
 
   if (m_params.doStats_) {
@@ -234,11 +177,8 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
 #ifdef DUMP_GPU_TK_TUPLES
   static std::atomic<int> iev(0);
   ++iev;
-  kernel_print_found_ntuplets(
-      hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 100, iev);
+  kernel_print_found_ntuplets(hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 100, iev);
 #endif
 }
 
-void CAHitNtupletGeneratorKernelsGPU::printCounters(Counters const *counters) {
-  kernel_printCounters(counters);
-}
+void CAHitNtupletGeneratorKernelsGPU::printCounters(Counters const *counters) { kernel_printCounters(counters); }

--- a/src/stdpar/plugin-PixelTriplets/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/src/stdpar/plugin-PixelTriplets/CAHitNtupletGeneratorKernelsAlloc.h
@@ -2,8 +2,6 @@
 
 #include "CAHitNtupletGeneratorKernels.h"
 
-#include "CUDACore/cudaCheck.h"
-
 void CAHitNtupletGeneratorKernelsGPU::allocateOnGPU() {
   //////////////////////////////////////////////////////////
   // ALLOCATIONS FOR THE INTERMEDIATE RESULTS (STAYS ON WORKER)

--- a/src/stdpar/plugin-PixelTriplets/CAHitNtupletGeneratorOnGPU.h
+++ b/src/stdpar/plugin-PixelTriplets/CAHitNtupletGeneratorOnGPU.h
@@ -3,8 +3,6 @@
 
 #include <memory>
 
-#include <cuda_runtime.h>
-
 #include "CUDACore/SimpleVector.h"
 #include "CUDADataFormats/PixelTrack.h"
 #include "CUDADataFormats/TrackingRecHit2D.h"

--- a/src/stdpar/plugin-PixelTriplets/FitResult.h
+++ b/src/stdpar/plugin-PixelTriplets/FitResult.h
@@ -4,7 +4,6 @@
 #include <cmath>
 #include <cstdint>
 
-#include <cuda_runtime.h>
 #include <Eigen/Core>
 #include <Eigen/Eigenvalues>
 

--- a/src/stdpar/plugin-PixelTriplets/FitUtils.h
+++ b/src/stdpar/plugin-PixelTriplets/FitUtils.h
@@ -79,9 +79,7 @@ namespace Rfit {
     \return z component of the cross product.
   */
 
-  inline double cross2D(const Vector2d& a, const Vector2d& b) {
-    return a.x() * b.y() - a.y() * b.x();
-  }
+  inline double cross2D(const Vector2d& a, const Vector2d& b) { return a.x() * b.y() - a.y() * b.x(); }
 
   /*!
    *  load error in CMSSW format to our formalism

--- a/src/stdpar/plugin-PixelTriplets/FitUtils.h
+++ b/src/stdpar/plugin-PixelTriplets/FitUtils.h
@@ -53,7 +53,7 @@ namespace Rfit {
   using u_int = unsigned int;
 
   template <class C>
-  __host__ __device__ void printIt(C* m, const char* prefix = "") {
+  void printIt(C* m, const char* prefix = "") {
 #ifdef RFIT_DEBUG
     for (u_int r = 0; r < m->rows(); ++r) {
       for (u_int c = 0; c < m->cols(); ++c) {
@@ -79,7 +79,7 @@ namespace Rfit {
     \return z component of the cross product.
   */
 
-  __host__ __device__ inline double cross2D(const Vector2d& a, const Vector2d& b) {
+  inline double cross2D(const Vector2d& a, const Vector2d& b) {
     return a.x() * b.y() - a.y() * b.x();
   }
 
@@ -88,7 +88,7 @@ namespace Rfit {
    *  
    */
   template <typename M6xNf, typename M2Nd>
-  __host__ __device__ void loadCovariance2D(M6xNf const& ge, M2Nd& hits_cov) {
+  void loadCovariance2D(M6xNf const& ge, M2Nd& hits_cov) {
     // Index numerology:
     // i: index of the hits/point (0,..,3)
     // j: index of space component (x,y,z)
@@ -120,7 +120,7 @@ namespace Rfit {
   }
 
   template <typename M6xNf, typename M3xNd>
-  __host__ __device__ void loadCovariance(M6xNf const& ge, M3xNd& hits_cov) {
+  void loadCovariance(M6xNf const& ge, M3xNd& hits_cov) {
     // Index numerology:
     // i: index of the hits/point (0,..,3)
     // j: index of space component (x,y,z)
@@ -173,7 +173,7 @@ namespace Rfit {
     \param B magnetic field in Gev/cm/c unit.
     \param error flag for errors computation.
   */
-  __host__ __device__ inline void par_uvrtopak(circle_fit& circle, const double B, const bool error) {
+  inline void par_uvrtopak(circle_fit& circle, const double B, const bool error) {
     Vector3d par_pak;
     const double temp0 = circle.par.head(2).squaredNorm();
     const double temp1 = sqrt(temp0);
@@ -196,7 +196,7 @@ namespace Rfit {
     \param circle_uvr parameter (X0,Y0,R), covariance matrix to
     be transformed and particle charge.
   */
-  __host__ __device__ inline void fromCircleToPerigee(circle_fit& circle) {
+  inline void fromCircleToPerigee(circle_fit& circle) {
     Vector3d par_pak;
     const double temp0 = circle.par.head(2).squaredNorm();
     const double temp1 = sqrt(temp0);
@@ -218,7 +218,7 @@ namespace Rfit {
   // from   //!<(phi,Tip,q/pt,cotan(theta)),Zip)
   // to q/p,dx/dz,dy/dz,x,z
   template <typename VI5, typename MI5, typename VO5, typename MO5>
-  __host__ __device__ inline void transformToPerigeePlane(VI5 const& ip, MI5 const& icov, VO5& op, MO5& ocov) {
+  inline void transformToPerigeePlane(VI5 const& ip, MI5 const& icov, VO5& op, MO5& ocov) {
     auto sinTheta2 = 1. / (1. + ip(3) * ip(3));
     auto sinTheta = std::sqrt(sinTheta2);
     auto cosTheta = ip(3) * sinTheta;

--- a/src/stdpar/plugin-PixelTriplets/GPUCACell.h
+++ b/src/stdpar/plugin-PixelTriplets/GPUCACell.h
@@ -42,12 +42,12 @@ public:
   GPUCACell() = default;
 
   __forceinline__ void init(CellNeighborsVector& cellNeighbors,
-                                       CellTracksVector& cellTracks,
-                                       Hits const& hh,
-                                       int layerPairId,
-                                       int doubletId,
-                                       hindex_type innerHitId,
-                                       hindex_type outerHitId) {
+                            CellTracksVector& cellTracks,
+                            Hits const& hh,
+                            int layerPairId,
+                            int doubletId,
+                            hindex_type innerHitId,
+                            hindex_type outerHitId) {
     theInnerHitId = innerHitId;
     theOuterHitId = outerHitId;
     theDoubletId = doubletId;
@@ -74,7 +74,8 @@ public:
         auto outer_as_int{reinterpret_cast<ptrAsInt>(theOuterNeighbors)};
         std::atomic_ref<ptrAsInt> r{outer_as_int};
         ptrAsInt zero = reinterpret_cast<ptrAsInt>(&cellNeighbors[0]);
-        r.compare_exchange_strong(zero, reinterpret_cast<ptrAsInt>(&cellNeighbors[i]));  // if fails we cannot give "i" back...
+        r.compare_exchange_strong(
+            zero, reinterpret_cast<ptrAsInt>(&cellNeighbors[i]));  // if fails we cannot give "i" back...
       } else
         return -1;
     }
@@ -89,7 +90,8 @@ public:
         auto track_as_int{reinterpret_cast<ptrAsInt>(theTracks)};
         std::atomic_ref<ptrAsInt> r{track_as_int};
         ptrAsInt zero = reinterpret_cast<ptrAsInt>(&cellTracks[0]);
-        r.compare_exchange_strong(zero, reinterpret_cast<ptrAsInt>(&cellTracks[i]));  // if fails we cannot give "i" back...
+        r.compare_exchange_strong(zero,
+                                  reinterpret_cast<ptrAsInt>(&cellTracks[i]));  // if fails we cannot give "i" back...
       } else
         return -1;
     }
@@ -129,13 +131,13 @@ public:
   }
 
   bool check_alignment(Hits const& hh,
-                                  GPUCACell const& otherCell,
-                                  const float ptmin,
-                                  const float hardCurvCut,
-                                  const float CAThetaCutBarrel,
-                                  const float CAThetaCutForward,
-                                  const float dcaCutInnerTriplet,
-                                  const float dcaCutOuterTriplet) const {
+                       GPUCACell const& otherCell,
+                       const float ptmin,
+                       const float hardCurvCut,
+                       const float CAThetaCutBarrel,
+                       const float CAThetaCutForward,
+                       const float dcaCutInnerTriplet,
+                       const float dcaCutOuterTriplet) const {
     // detIndex of the layerStart for the Phase1 Pixel Detector:
     // [BPX1, BPX2, BPX3, BPX4,  FP1,  FP2,  FP3,  FN1,  FN2,  FN3, LAST_VALID]
     // [   0,   96,  320,  672, 1184, 1296, 1408, 1520, 1632, 1744,       1856]
@@ -178,9 +180,9 @@ public:
   }
 
   inline bool dcaCut(Hits const& hh,
-                                GPUCACell const& otherCell,
-                                const float region_origin_radius_plus_tolerance,
-                                const float maxCurv) const {
+                     GPUCACell const& otherCell,
+                     const float region_origin_radius_plus_tolerance,
+                     const float maxCurv) const {
     auto x1 = otherCell.get_inner_x(hh);
     auto y1 = otherCell.get_inner_y(hh);
 
@@ -199,13 +201,13 @@ public:
   }
 
   __forceinline__ static bool dcaCutH(float x1,
-                                                 float y1,
-                                                 float x2,
-                                                 float y2,
-                                                 float x3,
-                                                 float y3,
-                                                 const float region_origin_radius_plus_tolerance,
-                                                 const float maxCurv) {
+                                      float y1,
+                                      float x2,
+                                      float y2,
+                                      float x3,
+                                      float y3,
+                                      const float region_origin_radius_plus_tolerance,
+                                      const float maxCurv) {
     CircleEq<float> eq(x1, y1, x2, y2, x3, y3);
 
     if (eq.curvature() > maxCurv)
@@ -270,14 +272,14 @@ public:
   // the visit of the graph based on the neighborhood connections between cells.
   template <int DEPTH>
   inline void find_ntuplets(Hits const& hh,
-                                       GPUCACell* __restrict__ cells,
-                                       CellTracksVector& cellTracks,
-                                       HitContainer& foundNtuplets,
-                                       cms::cuda::AtomicPairCounter& apc,
-                                       Quality* __restrict__ quality,
-                                       TmpTuple& tmpNtuplet,
-                                       const unsigned int minHitsPerNtuplet,
-                                       bool startAt0) const {
+                            GPUCACell* __restrict__ cells,
+                            CellTracksVector& cellTracks,
+                            HitContainer& foundNtuplets,
+                            cms::cuda::AtomicPairCounter& apc,
+                            Quality* __restrict__ quality,
+                            TmpTuple& tmpNtuplet,
+                            const unsigned int minHitsPerNtuplet,
+                            bool startAt0) const {
     // the building process for a track ends if:
     // it has no right neighbor
     // it has no compatible neighbor
@@ -341,14 +343,14 @@ private:
 
 template <>
 inline void GPUCACell::find_ntuplets<0>(Hits const& hh,
-                                                   GPUCACell* __restrict__ cells,
-                                                   CellTracksVector& cellTracks,
-                                                   HitContainer& foundNtuplets,
-                                                   cms::cuda::AtomicPairCounter& apc,
-                                                   Quality* __restrict__ quality,
-                                                   TmpTuple& tmpNtuplet,
-                                                   const unsigned int minHitsPerNtuplet,
-                                                   bool startAt0) const {
+                                        GPUCACell* __restrict__ cells,
+                                        CellTracksVector& cellTracks,
+                                        HitContainer& foundNtuplets,
+                                        cms::cuda::AtomicPairCounter& apc,
+                                        Quality* __restrict__ quality,
+                                        TmpTuple& tmpNtuplet,
+                                        const unsigned int minHitsPerNtuplet,
+                                        bool startAt0) const {
   printf("ERROR: GPUCACell::find_ntuplets reached full depth!\n");
 #ifdef __CUDA_ARCH__
   __trap();

--- a/src/stdpar/plugin-PixelTriplets/RiemannFit.h
+++ b/src/stdpar/plugin-PixelTriplets/RiemannFit.h
@@ -62,12 +62,12 @@ namespace Rfit {
 
   template <typename V4, typename VNd1, typename VNd2, int N>
   inline auto Scatter_cov_line(Matrix2d const* cov_sz,
-                                                   const V4& fast_fit,
-                                                   VNd1 const& s_arcs,
-                                                   VNd2 const& z_values,
-                                                   const double theta,
-                                                   const double B,
-                                                   MatrixNd<N>& ret) {
+                               const V4& fast_fit,
+                               VNd1 const& s_arcs,
+                               VNd2 const& z_values,
+                               const double theta,
+                               const double B,
+                               MatrixNd<N>& ret) {
 #ifdef RFIT_DEBUG
     Rfit::printIt(&s_arcs, "Scatter_cov_line - s_arcs: ");
 #endif
@@ -122,10 +122,7 @@ namespace Rfit {
     negligible).
  */
   template <typename M2xN, typename V4, int N>
-  inline MatrixNd<N> Scatter_cov_rad(const M2xN& p2D,
-                                                         const V4& fast_fit,
-                                                         VectorNd<N> const& rad,
-                                                         double B) {
+  inline MatrixNd<N> Scatter_cov_rad(const M2xN& p2D, const V4& fast_fit, VectorNd<N> const& rad, double B) {
     constexpr u_int n = N;
     double p_t = std::min(20., fast_fit(2) * B);  // limit pt to avoid too small error!!!
     double p_2 = p_t * p_t * (1. + 1. / (fast_fit(3) * fast_fit(3)));
@@ -170,9 +167,7 @@ namespace Rfit {
 */
 
   template <typename M2xN, int N>
-  inline Matrix2Nd<N> cov_radtocart(const M2xN& p2D,
-                                                        const MatrixNd<N>& cov_rad,
-                                                        const VectorNd<N>& rad) {
+  inline Matrix2Nd<N> cov_radtocart(const M2xN& p2D, const MatrixNd<N>& cov_rad, const VectorNd<N>& rad) {
 #ifdef RFIT_DEBUG
     printf("Address of p2D: %p\n", &p2D);
 #endif
@@ -207,9 +202,7 @@ namespace Rfit {
     \warning correlation between different point are not computed.
 */
   template <typename M2xN, int N>
-  inline VectorNd<N> cov_carttorad(const M2xN& p2D,
-                                                       const Matrix2Nd<N>& cov_cart,
-                                                       const VectorNd<N>& rad) {
+  inline VectorNd<N> cov_carttorad(const M2xN& p2D, const Matrix2Nd<N>& cov_cart, const VectorNd<N>& rad) {
     constexpr u_int n = N;
     VectorNd<N> cov_rad;
     const VectorNd<N> rad_inv2 = rad.cwiseInverse().array().square();
@@ -239,9 +232,9 @@ namespace Rfit {
 */
   template <typename M2xN, typename V4, int N>
   inline VectorNd<N> cov_carttorad_prefit(const M2xN& p2D,
-                                                              const Matrix2Nd<N>& cov_cart,
-                                                              V4& fast_fit,
-                                                              const VectorNd<N>& rad) {
+                                          const Matrix2Nd<N>& cov_cart,
+                                          V4& fast_fit,
+                                          const VectorNd<N>& rad) {
     constexpr u_int n = N;
     VectorNd<N> cov_rad;
     for (u_int i = 0; i < n; ++i) {
@@ -455,11 +448,11 @@ namespace Rfit {
 */
   template <typename M2xN, typename V4, int N>
   inline circle_fit Circle_fit(const M2xN& hits2D,
-                                                   const Matrix2Nd<N>& hits_cov2D,
-                                                   const V4& fast_fit,
-                                                   const VectorNd<N>& rad,
-                                                   const double B,
-                                                   const bool error) {
+                               const Matrix2Nd<N>& hits_cov2D,
+                               const V4& fast_fit,
+                               const VectorNd<N>& rad,
+                               const double B,
+                               const bool error) {
 #ifdef RFIT_DEBUG
     printf("circle_fit - enter\n");
 #endif
@@ -784,11 +777,11 @@ namespace Rfit {
 
   template <typename M3xN, typename M6xN, typename V4>
   inline line_fit Line_fit(const M3xN& hits,
-                                               const M6xN& hits_ge,
-                                               const circle_fit& circle,
-                                               const V4& fast_fit,
-                                               const double B,
-                                               const bool error) {
+                           const M6xN& hits_ge,
+                           const circle_fit& circle,
+                           const V4& fast_fit,
+                           const double B,
+                           const bool error) {
     constexpr uint32_t N = M3xN::ColsAtCompileTime;
     constexpr auto n = N;
     double theta = -circle.q * atan(fast_fit(3));

--- a/src/stdpar/plugin-PixelTriplets/RiemannFit.h
+++ b/src/stdpar/plugin-PixelTriplets/RiemannFit.h
@@ -30,7 +30,7 @@ namespace Rfit {
  */
 
   template <typename VNd1, typename VNd2>
-  __host__ __device__ inline void computeRadLenUniformMaterial(const VNd1& length_values, VNd2& rad_lengths) {
+  inline void computeRadLenUniformMaterial(const VNd1& length_values, VNd2& rad_lengths) {
     // Radiation length of the pixel detector in the uniform assumption, with
     // 0.06 rad_len at 16 cm
     constexpr double XX_0_inv = 0.06 / 16.;
@@ -61,7 +61,7 @@ namespace Rfit {
  */
 
   template <typename V4, typename VNd1, typename VNd2, int N>
-  __host__ __device__ inline auto Scatter_cov_line(Matrix2d const* cov_sz,
+  inline auto Scatter_cov_line(Matrix2d const* cov_sz,
                                                    const V4& fast_fit,
                                                    VNd1 const& s_arcs,
                                                    VNd2 const& z_values,
@@ -122,7 +122,7 @@ namespace Rfit {
     negligible).
  */
   template <typename M2xN, typename V4, int N>
-  __host__ __device__ inline MatrixNd<N> Scatter_cov_rad(const M2xN& p2D,
+  inline MatrixNd<N> Scatter_cov_rad(const M2xN& p2D,
                                                          const V4& fast_fit,
                                                          VectorNd<N> const& rad,
                                                          double B) {
@@ -170,7 +170,7 @@ namespace Rfit {
 */
 
   template <typename M2xN, int N>
-  __host__ __device__ inline Matrix2Nd<N> cov_radtocart(const M2xN& p2D,
+  inline Matrix2Nd<N> cov_radtocart(const M2xN& p2D,
                                                         const MatrixNd<N>& cov_rad,
                                                         const VectorNd<N>& rad) {
 #ifdef RFIT_DEBUG
@@ -207,7 +207,7 @@ namespace Rfit {
     \warning correlation between different point are not computed.
 */
   template <typename M2xN, int N>
-  __host__ __device__ inline VectorNd<N> cov_carttorad(const M2xN& p2D,
+  inline VectorNd<N> cov_carttorad(const M2xN& p2D,
                                                        const Matrix2Nd<N>& cov_cart,
                                                        const VectorNd<N>& rad) {
     constexpr u_int n = N;
@@ -238,7 +238,7 @@ namespace Rfit {
     orthogonal system.
 */
   template <typename M2xN, typename V4, int N>
-  __host__ __device__ inline VectorNd<N> cov_carttorad_prefit(const M2xN& p2D,
+  inline VectorNd<N> cov_carttorad_prefit(const M2xN& p2D,
                                                               const Matrix2Nd<N>& cov_cart,
                                                               V4& fast_fit,
                                                               const VectorNd<N>& rad) {
@@ -274,7 +274,7 @@ namespace Rfit {
 */
 
   template <int N>
-  __host__ __device__ inline VectorNd<N> Weight_circle(const MatrixNd<N>& cov_rad_inv) {
+  inline VectorNd<N> Weight_circle(const MatrixNd<N>& cov_rad_inv) {
     return cov_rad_inv.colwise().sum().transpose();
   }
 
@@ -287,7 +287,7 @@ namespace Rfit {
     \return q int 1 or -1.
 */
   template <typename M2xN>
-  __host__ __device__ inline int32_t Charge(const M2xN& p2D, const Vector3d& par_uvr) {
+  inline int32_t Charge(const M2xN& p2D, const Vector3d& par_uvr) {
     return ((p2D(0, 1) - p2D(0, 0)) * (par_uvr.y() - p2D(1, 0)) - (p2D(1, 1) - p2D(1, 0)) * (par_uvr.x() - p2D(0, 0)) >
             0)
                ? -1
@@ -309,7 +309,7 @@ namespace Rfit {
     For this optimization the matrix type must be known at compiling time.
 */
 
-  __host__ __device__ inline Vector3d min_eigen3D(const Matrix3d& A, double& chi2) {
+  inline Vector3d min_eigen3D(const Matrix3d& A, double& chi2) {
 #ifdef RFIT_DEBUG
     printf("min_eigen3D - enter\n");
 #endif
@@ -334,7 +334,7 @@ namespace Rfit {
     speed up in  single precision.
 */
 
-  __host__ __device__ inline Vector3d min_eigen3D_fast(const Matrix3d& A) {
+  inline Vector3d min_eigen3D_fast(const Matrix3d& A) {
     Eigen::SelfAdjointEigenSolver<Matrix3f> solver(3);
     solver.computeDirect(A.cast<float>());
     int min_index;
@@ -352,7 +352,7 @@ namespace Rfit {
     significantly in single precision.
 */
 
-  __host__ __device__ inline Vector2d min_eigen2D(const Matrix2d& A, double& chi2) {
+  inline Vector2d min_eigen2D(const Matrix2d& A, double& chi2) {
     Eigen::SelfAdjointEigenSolver<Matrix2d> solver(2);
     solver.computeDirect(A);
     int min_index;
@@ -374,7 +374,7 @@ namespace Rfit {
 */
 
   template <typename M3xN, typename V4>
-  __host__ __device__ inline void Fast_fit(const M3xN& hits, V4& result) {
+  inline void Fast_fit(const M3xN& hits, V4& result) {
     constexpr uint32_t N = M3xN::ColsAtCompileTime;
     constexpr auto n = N;  // get the number of hits
     printIt(&hits, "Fast_fit - hits: ");
@@ -454,7 +454,7 @@ namespace Rfit {
     scattering.
 */
   template <typename M2xN, typename V4, int N>
-  __host__ __device__ inline circle_fit Circle_fit(const M2xN& hits2D,
+  inline circle_fit Circle_fit(const M2xN& hits2D,
                                                    const Matrix2Nd<N>& hits_cov2D,
                                                    const V4& fast_fit,
                                                    const VectorNd<N>& rad,
@@ -783,7 +783,7 @@ namespace Rfit {
  */
 
   template <typename M3xN, typename M6xN, typename V4>
-  __host__ __device__ inline line_fit Line_fit(const M3xN& hits,
+  inline line_fit Line_fit(const M3xN& hits,
                                                const M6xN& hits_ge,
                                                const circle_fit& circle,
                                                const V4& fast_fit,

--- a/src/stdpar/plugin-PixelTriplets/RiemannFitOnGPU.cu
+++ b/src/stdpar/plugin-PixelTriplets/RiemannFitOnGPU.cu
@@ -7,9 +7,6 @@
 void HelixFitOnGPU::launchRiemannKernels(HitsView const *hv, uint32_t nhits, uint32_t maxNumberOfTuples) {
   assert(tuples_d);
 
-  auto blockSize = 64;
-  auto numberOfBlocks = (maxNumberOfConcurrentFits_ + blockSize - 1) / blockSize;
-
   //  Fit internals
   auto hitsGPU_ = std::make_unique<double[]>(maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix3xNd<4>) / sizeof(double));
   auto hits_geGPU_ = std::make_unique<float[]>(maxNumberOfConcurrentFits_ * sizeof(Rfit::Matrix6x4f) / sizeof(float));
@@ -20,109 +17,97 @@ void HelixFitOnGPU::launchRiemannKernels(HitsView const *hv, uint32_t nhits, uin
 
   for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
     // triplets
-    kernelFastFit<3><<<numberOfBlocks, blockSize, 0>>>(
+    kernelFastFit<3>(
         tuples_d, tupleMultiplicity_d, 3, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), offset);
-    cudaCheck(cudaGetLastError());
 
-    kernelCircleFit<3><<<numberOfBlocks, blockSize, 0>>>(tupleMultiplicity_d,
-                                                         3,
-                                                         bField_,
-                                                         hitsGPU_.get(),
-                                                         hits_geGPU_.get(),
-                                                         fast_fit_resultsGPU_.get(),
-                                                         circle_fit_resultsGPU_,
-                                                         offset);
-    cudaCheck(cudaGetLastError());
+    kernelCircleFit<3>(tupleMultiplicity_d,
+                       3,
+                       bField_,
+                       hitsGPU_.get(),
+                       hits_geGPU_.get(),
+                       fast_fit_resultsGPU_.get(),
+                       circle_fit_resultsGPU_,
+                       offset);
 
-    kernelLineFit<3><<<numberOfBlocks, blockSize, 0>>>(tupleMultiplicity_d,
-                                                       3,
-                                                       bField_,
-                                                       outputSoa_d,
-                                                       hitsGPU_.get(),
-                                                       hits_geGPU_.get(),
-                                                       fast_fit_resultsGPU_.get(),
-                                                       circle_fit_resultsGPU_,
-                                                       offset);
-    cudaCheck(cudaGetLastError());
+    kernelLineFit<3>(tupleMultiplicity_d,
+                     3,
+                     bField_,
+                     outputSoa_d,
+                     hitsGPU_.get(),
+                     hits_geGPU_.get(),
+                     fast_fit_resultsGPU_.get(),
+                     circle_fit_resultsGPU_,
+                     offset);
 
     // quads
-    kernelFastFit<4><<<numberOfBlocks / 4, blockSize, 0>>>(
+    kernelFastFit<4>(
         tuples_d, tupleMultiplicity_d, 4, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), offset);
-    cudaCheck(cudaGetLastError());
 
-    kernelCircleFit<4><<<numberOfBlocks / 4, blockSize, 0>>>(tupleMultiplicity_d,
-                                                             4,
-                                                             bField_,
-                                                             hitsGPU_.get(),
-                                                             hits_geGPU_.get(),
-                                                             fast_fit_resultsGPU_.get(),
-                                                             circle_fit_resultsGPU_,
-                                                             offset);
-    cudaCheck(cudaGetLastError());
+    kernelCircleFit<4>(tupleMultiplicity_d,
+                       4,
+                       bField_,
+                       hitsGPU_.get(),
+                       hits_geGPU_.get(),
+                       fast_fit_resultsGPU_.get(),
+                       circle_fit_resultsGPU_,
+                       offset);
 
-    kernelLineFit<4><<<numberOfBlocks / 4, blockSize, 0>>>(tupleMultiplicity_d,
-                                                           4,
-                                                           bField_,
-                                                           outputSoa_d,
-                                                           hitsGPU_.get(),
-                                                           hits_geGPU_.get(),
-                                                           fast_fit_resultsGPU_.get(),
-                                                           circle_fit_resultsGPU_,
-                                                           offset);
-    cudaCheck(cudaGetLastError());
+    kernelLineFit<4>(tupleMultiplicity_d,
+                     4,
+                     bField_,
+                     outputSoa_d,
+                     hitsGPU_.get(),
+                     hits_geGPU_.get(),
+                     fast_fit_resultsGPU_.get(),
+                     circle_fit_resultsGPU_,
+                     offset);
 
     if (fit5as4_) {
       // penta
-      kernelFastFit<4><<<numberOfBlocks / 4, blockSize, 0>>>(
+      kernelFastFit<4>(
           tuples_d, tupleMultiplicity_d, 5, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), offset);
-      cudaCheck(cudaGetLastError());
 
-      kernelCircleFit<4><<<numberOfBlocks / 4, blockSize, 0>>>(tupleMultiplicity_d,
-                                                               5,
-                                                               bField_,
-                                                               hitsGPU_.get(),
-                                                               hits_geGPU_.get(),
-                                                               fast_fit_resultsGPU_.get(),
-                                                               circle_fit_resultsGPU_,
-                                                               offset);
-      cudaCheck(cudaGetLastError());
+      kernelCircleFit<4>(tupleMultiplicity_d,
+                         5,
+                         bField_,
+                         hitsGPU_.get(),
+                         hits_geGPU_.get(),
+                         fast_fit_resultsGPU_.get(),
+                         circle_fit_resultsGPU_,
+                         offset);
 
-      kernelLineFit<4><<<numberOfBlocks / 4, blockSize, 0>>>(tupleMultiplicity_d,
-                                                             5,
-                                                             bField_,
-                                                             outputSoa_d,
-                                                             hitsGPU_.get(),
-                                                             hits_geGPU_.get(),
-                                                             fast_fit_resultsGPU_.get(),
-                                                             circle_fit_resultsGPU_,
-                                                             offset);
-      cudaCheck(cudaGetLastError());
+      kernelLineFit<4>(tupleMultiplicity_d,
+                       5,
+                       bField_,
+                       outputSoa_d,
+                       hitsGPU_.get(),
+                       hits_geGPU_.get(),
+                       fast_fit_resultsGPU_.get(),
+                       circle_fit_resultsGPU_,
+                       offset);
     } else {
       // penta all 5
-      kernelFastFit<5><<<numberOfBlocks / 4, blockSize, 0>>>(
+      kernelFastFit<5>(
           tuples_d, tupleMultiplicity_d, 5, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), offset);
-      cudaCheck(cudaGetLastError());
 
-      kernelCircleFit<5><<<numberOfBlocks / 4, blockSize, 0>>>(tupleMultiplicity_d,
-                                                               5,
-                                                               bField_,
-                                                               hitsGPU_.get(),
-                                                               hits_geGPU_.get(),
-                                                               fast_fit_resultsGPU_.get(),
-                                                               circle_fit_resultsGPU_,
-                                                               offset);
-      cudaCheck(cudaGetLastError());
+      kernelCircleFit<5>(tupleMultiplicity_d,
+                         5,
+                         bField_,
+                         hitsGPU_.get(),
+                         hits_geGPU_.get(),
+                         fast_fit_resultsGPU_.get(),
+                         circle_fit_resultsGPU_,
+                         offset);
 
-      kernelLineFit<5><<<numberOfBlocks / 4, blockSize, 0>>>(tupleMultiplicity_d,
-                                                             5,
-                                                             bField_,
-                                                             outputSoa_d,
-                                                             hitsGPU_.get(),
-                                                             hits_geGPU_.get(),
-                                                             fast_fit_resultsGPU_.get(),
-                                                             circle_fit_resultsGPU_,
-                                                             offset);
-      cudaCheck(cudaGetLastError());
+      kernelLineFit<5>(tupleMultiplicity_d,
+                       5,
+                       bField_,
+                       outputSoa_d,
+                       hitsGPU_.get(),
+                       hits_geGPU_.get(),
+                       fast_fit_resultsGPU_.get(),
+                       circle_fit_resultsGPU_,
+                       offset);
     }
   }
 }

--- a/src/stdpar/plugin-PixelTriplets/gpuFishbone.h
+++ b/src/stdpar/plugin-PixelTriplets/gpuFishbone.h
@@ -17,26 +17,25 @@
 
 namespace gpuPixelDoublets {
 
-void fishbone(GPUCACell::Hits const* __restrict__ hhp,
-                           GPUCACell* cells,
-                           uint32_t const* __restrict__ nCells,
-                           GPUCACell::OuterHitOfCell const* __restrict__ isOuterHitOfCell,
-                           uint32_t nHits,
-                           bool checkTrack) {
+  void fishbone(GPUCACell::Hits const* __restrict__ hhp,
+                GPUCACell* cells,
+                uint32_t const* __restrict__ nCells,
+                GPUCACell::OuterHitOfCell const* __restrict__ isOuterHitOfCell,
+                uint32_t nHits,
+                bool checkTrack) {
     constexpr auto maxCellsPerHit = GPUCACell::maxCellsPerHit;
 
-  
-  auto iter{std::views::iota(0U, nHits)};
-  std::for_each(std::execution::par, std::ranges::cbegin(iter), std::ranges::cend(iter), [=](const auto idy) {
-    auto const& hh = *hhp;
-    // auto layer = [&](uint16_t id) { return hh.cpeParams().layer(id); };
+    auto iter{std::views::iota(0U, nHits)};
+    std::for_each(std::execution::par, std::ranges::cbegin(iter), std::ranges::cend(iter), [=](const auto idy) {
+      auto const& hh = *hhp;
+      // auto layer = [&](uint16_t id) { return hh.cpeParams().layer(id); };
 
-    // x run faster...
+      // x run faster...
 
-    float x[maxCellsPerHit], y[maxCellsPerHit], z[maxCellsPerHit], n[maxCellsPerHit];
-    uint16_t d[maxCellsPerHit];  // uint8_t l[maxCellsPerHit];
-    uint32_t cc[maxCellsPerHit];
-    //for (int idy = firstY, nt = nHits; idy < nt; idy += gridDim.y * blockDim.y) {
+      float x[maxCellsPerHit], y[maxCellsPerHit], z[maxCellsPerHit], n[maxCellsPerHit];
+      uint16_t d[maxCellsPerHit];  // uint8_t l[maxCellsPerHit];
+      uint32_t cc[maxCellsPerHit];
+      //for (int idy = firstY, nt = nHits; idy < nt; idy += gridDim.y * blockDim.y) {
       auto const& vc = isOuterHitOfCell[idy];
       auto s = vc.size();
       if (s < 2)
@@ -85,7 +84,7 @@ void fishbone(GPUCACell::Hits const* __restrict__ hhp,
           }
         }  //cj
       }    // ci
-    });      // hits
+    });    // hits
   }
 }  // namespace gpuPixelDoublets
 

--- a/src/stdpar/plugin-PixelTriplets/gpuPixelDoublets.h
+++ b/src/stdpar/plugin-PixelTriplets/gpuPixelDoublets.h
@@ -68,11 +68,11 @@ namespace gpuPixelDoublets {
   using CellTracksVector = CAConstants::CellTracksVector;
 
   void initDoublets(GPUCACell::OuterHitOfCell* isOuterHitOfCell,
-                               int nHits,
-                               CellNeighborsVector* cellNeighbors,
-                               CellNeighbors* cellNeighborsContainer,
-                               CellTracksVector* cellTracks,
-                               CellTracks* cellTracksContainer) {
+                    int nHits,
+                    CellNeighborsVector* cellNeighbors,
+                    CellNeighbors* cellNeighborsContainer,
+                    CellTracksVector* cellTracks,
+                    CellTracks* cellTracksContainer) {
     assert(isOuterHitOfCell);
     auto iter{std::views::iota(0, nHits)};
     std::for_each(std::execution::par, std::ranges::cbegin(iter), std::ranges::cend(iter), [=](const auto i) {
@@ -89,19 +89,17 @@ namespace gpuPixelDoublets {
   }
 
   void getDoubletsFromHisto(GPUCACell* cells,
-                                uint32_t* nCells,
-                                CellNeighborsVector* cellNeighbors,
-                                CellTracksVector* cellTracks,
-                                TrackingRecHit2DSOAView const* __restrict__ hhp,
-                                GPUCACell::OuterHitOfCell* isOuterHitOfCell,
-                                int nPairs,
-                                bool ideal_cond,
-                                bool doClusterCut,
-                                bool doZ0Cut,
-                                bool doPtCut,
-                                uint32_t maxNumOfDoublets) {
-
-
+                            uint32_t* nCells,
+                            CellNeighborsVector* cellNeighbors,
+                            CellTracksVector* cellTracks,
+                            TrackingRecHit2DSOAView const* __restrict__ hhp,
+                            GPUCACell::OuterHitOfCell* isOuterHitOfCell,
+                            int nPairs,
+                            bool ideal_cond,
+                            bool doClusterCut,
+                            bool doZ0Cut,
+                            bool doPtCut,
+                            uint32_t maxNumOfDoublets) {
     using Hist = TrackingRecHit2DSOAView::Hist;
 
     auto iter{std::views::iota(0U, hhp->nHits() * 4)};
@@ -138,160 +136,160 @@ namespace gpuPixelDoublets {
       // x runs faster
       uint32_t pairLayerId = 0;  // cannot go backward
       for (auto j = 0; j < ntot; ++j) {
-      while (j >= innerLayerCumulativeSize[pairLayerId++])
-        ;
-      --pairLayerId;  // move to lower_bound ??
+        while (j >= innerLayerCumulativeSize[pairLayerId++])
+          ;
+        --pairLayerId;  // move to lower_bound ??
 
-      assert(pairLayerId < nPairs);
-      assert(j < innerLayerCumulativeSize[pairLayerId]);
-      assert(0 == pairLayerId || j >= innerLayerCumulativeSize[pairLayerId - 1]);
+        assert(pairLayerId < nPairs);
+        assert(j < innerLayerCumulativeSize[pairLayerId]);
+        assert(0 == pairLayerId || j >= innerLayerCumulativeSize[pairLayerId - 1]);
 
-      uint8_t inner = layerPairs[2 * pairLayerId];
-      uint8_t outer = layerPairs[2 * pairLayerId + 1];
-      assert(outer > inner);
+        uint8_t inner = layerPairs[2 * pairLayerId];
+        uint8_t outer = layerPairs[2 * pairLayerId + 1];
+        assert(outer > inner);
 
-      auto hoff = Hist::histOff(outer);
+        auto hoff = Hist::histOff(outer);
 
-      auto i = (0 == pairLayerId) ? j : j - innerLayerCumulativeSize[pairLayerId - 1];
-      i += offsets[inner];
+        auto i = (0 == pairLayerId) ? j : j - innerLayerCumulativeSize[pairLayerId - 1];
+        i += offsets[inner];
 
-      // printf("Hit in Layer %d %d %d %d\n", i, inner, pairLayerId, j);
+        // printf("Hit in Layer %d %d %d %d\n", i, inner, pairLayerId, j);
 
-      assert(i >= offsets[inner]);
-      assert(i < offsets[inner + 1]);
+        assert(i >= offsets[inner]);
+        assert(i < offsets[inner + 1]);
 
-      // found hit corresponding to our cuda thread, now do the job
-      auto mi = hh.detectorIndex(i);
-      if (mi > 2000)
-        return;  // invalid
+        // found hit corresponding to our cuda thread, now do the job
+        auto mi = hh.detectorIndex(i);
+        if (mi > 2000)
+          return;  // invalid
 
-      /* maybe clever, not effective when zoCut is on
+        /* maybe clever, not effective when zoCut is on
       auto bpos = (mi%8)/4;  // if barrel is 1 for z>0
       auto fpos = (outer>3) & (outer<7);
       if ( ((inner<3) & (outer>3)) && bpos!=fpos) continue;
       */
 
-      auto mez = hh.zGlobal(i);
+        auto mez = hh.zGlobal(i);
 
-      if (mez < minz[pairLayerId] || mez > maxz[pairLayerId])
-        return;
+        if (mez < minz[pairLayerId] || mez > maxz[pairLayerId])
+          return;
 
-      int16_t mes = -1;  // make compiler happy
-      if (doClusterCut) {
-        // if ideal treat inner ladder as outer
-        if (inner == 0)
-          assert(mi < 96);
-        isOuterLadder = ideal_cond ? true : 0 == (mi / 8) % 2;  // only for B1/B2/B3 B4 is opposite, FPIX:noclue...
+        int16_t mes = -1;  // make compiler happy
+        if (doClusterCut) {
+          // if ideal treat inner ladder as outer
+          if (inner == 0)
+            assert(mi < 96);
+          isOuterLadder = ideal_cond ? true : 0 == (mi / 8) % 2;  // only for B1/B2/B3 B4 is opposite, FPIX:noclue...
 
-        // in any case we always test mes>0 ...
-        mes = inner > 0 || isOuterLadder ? hh.clusterSizeY(i) : -1;
+          // in any case we always test mes>0 ...
+          mes = inner > 0 || isOuterLadder ? hh.clusterSizeY(i) : -1;
 
-        if (inner == 0 && outer > 3)  // B1 and F1
-          if (mes > 0 && mes < minYsizeB1)
-            return;                 // only long cluster  (5*8)
-        if (inner == 1 && outer > 3)  // B2 and F1
-          if (mes > 0 && mes < minYsizeB2)
-            return;
-      }
-      auto mep = hh.iphi(i);
-      auto mer = hh.rGlobal(i);
-
-      // all cuts: true if fails
-      constexpr float z0cut = 12.f;      // cm
-      constexpr float hardPtCut = 0.5f;  // GeV
-      constexpr float minRadius =
-          hardPtCut * 87.78f;  // cm (1 GeV track has 1 GeV/c / (e * 3.8T) ~ 87 cm radius in a 3.8T field)
-      constexpr float minRadius2T4 = 4.f * minRadius * minRadius;
-      auto ptcut = [&](int j, int16_t idphi) {
-        auto r2t4 = minRadius2T4;
-        auto ri = mer;
-        auto ro = hh.rGlobal(j);
-        auto dphi = short2phi(idphi);
-        return dphi * dphi * (r2t4 - ri * ro) > (ro - ri) * (ro - ri);
-      };
-      auto z0cutoff = [&](int j) {
-        auto zo = hh.zGlobal(j);
-        auto ro = hh.rGlobal(j);
-        auto dr = ro - mer;
-        return dr > maxr[pairLayerId] || dr < 0 || std::abs((mez * ro - mer * zo)) > z0cut * dr;
-      };
-
-      auto zsizeCut = [&](int j) {
-        auto onlyBarrel = outer < 4;
-        auto so = hh.clusterSizeY(j);
-        auto dy = inner == 0 ? maxDYsize12 : maxDYsize;
-        // in the barrel cut on difference in size
-        // in the endcap on the prediction on the first layer (actually in the barrel only: happen to be safe for endcap as well)
-        // FIXME move pred cut to z0cutoff to optmize loading of and computaiton ...
-        auto zo = hh.zGlobal(j);
-        auto ro = hh.rGlobal(j);
-        return onlyBarrel ? mes > 0 && so > 0 && std::abs(so - mes) > dy
-                          : (inner < 4) && mes > 0 &&
-                                std::abs(mes - int(std::abs((mez - zo) / (mer - ro)) * dzdrFact + 0.5f)) > maxDYPred;
-      };
-
-      auto iphicut = phicuts[pairLayerId];
-
-      auto kl = Hist::bin(int16_t(mep - iphicut));
-      auto kh = Hist::bin(int16_t(mep + iphicut));
-      auto incr = [](auto& k) { return k = (k + 1) % Hist::nbins(); };
-      // bool piWrap = std::abs(kh-kl) > Hist::nbins()/2;
-
-#ifdef GPU_DEBUG
-      int tot = 0;
-      int nmin = 0;
-      int tooMany = 0;
-#endif
-
-      auto khh = kh;
-      incr(khh);
-      for (auto kk = kl; kk != khh; incr(kk)) {
-#ifdef GPU_DEBUG
-        if (kk != kl && kk != kh)
-          nmin += hist.size(kk + hoff);
-#endif
-        auto const* __restrict__ p = hist.begin(kk + hoff);
-        auto const* __restrict__ e = hist.end(kk + hoff);
-        for (; p < e; ++p) {
-          auto oi = *p;
-          assert(oi >= offsets[outer]);
-          assert(oi < offsets[outer + 1]);
-          auto mo = hh.detectorIndex(oi);
-          if (mo > 2000)
-            continue;  //    invalid
-
-          if (doZ0Cut && z0cutoff(oi))
-            continue;
-
-          auto mop = hh.iphi(oi);
-          uint16_t idphi = std::min(std::abs(int16_t(mop - mep)), std::abs(int16_t(mep - mop)));
-          if (idphi > iphicut)
-            continue;
-
-          if (doClusterCut && zsizeCut(oi))
-            continue;
-          if (doPtCut && ptcut(oi, idphi))
-            continue;
-
-          std::atomic_ref<uint32_t> ar_nCells{*nCells};
-          auto ind = ar_nCells++;
-          if (ind >= maxNumOfDoublets) {
-            ar_nCells--;
-            break;
-          }  // move to SimpleVector??
-          // int layerPairId, int doubletId, int innerHitId, int outerHitId)
-          cells[ind].init(*cellNeighbors, *cellTracks, hh, pairLayerId, ind, i, oi);
-          isOuterHitOfCell[oi].push_back(ind);
-#ifdef GPU_DEBUG
-          if (isOuterHitOfCell[oi].full())
-            ++tooMany;
-          ++tot;
-#endif
+          if (inner == 0 && outer > 3)  // B1 and F1
+            if (mes > 0 && mes < minYsizeB1)
+              return;                   // only long cluster  (5*8)
+          if (inner == 1 && outer > 3)  // B2 and F1
+            if (mes > 0 && mes < minYsizeB2)
+              return;
         }
-      }
+        auto mep = hh.iphi(i);
+        auto mer = hh.rGlobal(i);
+
+        // all cuts: true if fails
+        constexpr float z0cut = 12.f;      // cm
+        constexpr float hardPtCut = 0.5f;  // GeV
+        constexpr float minRadius =
+            hardPtCut * 87.78f;  // cm (1 GeV track has 1 GeV/c / (e * 3.8T) ~ 87 cm radius in a 3.8T field)
+        constexpr float minRadius2T4 = 4.f * minRadius * minRadius;
+        auto ptcut = [&](int j, int16_t idphi) {
+          auto r2t4 = minRadius2T4;
+          auto ri = mer;
+          auto ro = hh.rGlobal(j);
+          auto dphi = short2phi(idphi);
+          return dphi * dphi * (r2t4 - ri * ro) > (ro - ri) * (ro - ri);
+        };
+        auto z0cutoff = [&](int j) {
+          auto zo = hh.zGlobal(j);
+          auto ro = hh.rGlobal(j);
+          auto dr = ro - mer;
+          return dr > maxr[pairLayerId] || dr < 0 || std::abs((mez * ro - mer * zo)) > z0cut * dr;
+        };
+
+        auto zsizeCut = [&](int j) {
+          auto onlyBarrel = outer < 4;
+          auto so = hh.clusterSizeY(j);
+          auto dy = inner == 0 ? maxDYsize12 : maxDYsize;
+          // in the barrel cut on difference in size
+          // in the endcap on the prediction on the first layer (actually in the barrel only: happen to be safe for endcap as well)
+          // FIXME move pred cut to z0cutoff to optmize loading of and computaiton ...
+          auto zo = hh.zGlobal(j);
+          auto ro = hh.rGlobal(j);
+          return onlyBarrel ? mes > 0 && so > 0 && std::abs(so - mes) > dy
+                            : (inner < 4) && mes > 0 &&
+                                  std::abs(mes - int(std::abs((mez - zo) / (mer - ro)) * dzdrFact + 0.5f)) > maxDYPred;
+        };
+
+        auto iphicut = phicuts[pairLayerId];
+
+        auto kl = Hist::bin(int16_t(mep - iphicut));
+        auto kh = Hist::bin(int16_t(mep + iphicut));
+        auto incr = [](auto& k) { return k = (k + 1) % Hist::nbins(); };
+        // bool piWrap = std::abs(kh-kl) > Hist::nbins()/2;
+
 #ifdef GPU_DEBUG
-      if (tooMany > 0)
-        printf("OuterHitOfCell full for %d in layer %d/%d, %d,%d %d\n", i, inner, outer, nmin, tot, tooMany);
+        int tot = 0;
+        int nmin = 0;
+        int tooMany = 0;
+#endif
+
+        auto khh = kh;
+        incr(khh);
+        for (auto kk = kl; kk != khh; incr(kk)) {
+#ifdef GPU_DEBUG
+          if (kk != kl && kk != kh)
+            nmin += hist.size(kk + hoff);
+#endif
+          auto const* __restrict__ p = hist.begin(kk + hoff);
+          auto const* __restrict__ e = hist.end(kk + hoff);
+          for (; p < e; ++p) {
+            auto oi = *p;
+            assert(oi >= offsets[outer]);
+            assert(oi < offsets[outer + 1]);
+            auto mo = hh.detectorIndex(oi);
+            if (mo > 2000)
+              continue;  //    invalid
+
+            if (doZ0Cut && z0cutoff(oi))
+              continue;
+
+            auto mop = hh.iphi(oi);
+            uint16_t idphi = std::min(std::abs(int16_t(mop - mep)), std::abs(int16_t(mep - mop)));
+            if (idphi > iphicut)
+              continue;
+
+            if (doClusterCut && zsizeCut(oi))
+              continue;
+            if (doPtCut && ptcut(oi, idphi))
+              continue;
+
+            std::atomic_ref<uint32_t> ar_nCells{*nCells};
+            auto ind = ar_nCells++;
+            if (ind >= maxNumOfDoublets) {
+              ar_nCells--;
+              break;
+            }  // move to SimpleVector??
+            // int layerPairId, int doubletId, int innerHitId, int outerHitId)
+            cells[ind].init(*cellNeighbors, *cellTracks, hh, pairLayerId, ind, i, oi);
+            isOuterHitOfCell[oi].push_back(ind);
+#ifdef GPU_DEBUG
+            if (isOuterHitOfCell[oi].full())
+              ++tooMany;
+            ++tot;
+#endif
+          }
+        }
+#ifdef GPU_DEBUG
+        if (tooMany > 0)
+          printf("OuterHitOfCell full for %d in layer %d/%d, %d,%d %d\n", i, inner, outer, nmin, tot, tooMany);
 #endif
       }
     });  // loop in block...

--- a/src/stdpar/plugin-PixelVertexFinding/gpuFitVertices.h
+++ b/src/stdpar/plugin-PixelVertexFinding/gpuFitVertices.h
@@ -44,9 +44,9 @@ namespace gpuVertexFinder {
     auto foundClusters = nvFinal;
 
     // zero
-    std::fill(zv, zv + foundClusters, 0);
-    std::fill(wv, wv + foundClusters, 0);
-    std::fill(chi2, chi2 + foundClusters, 0);
+    std::fill(std::execution::par, zv, zv + foundClusters, 0);
+    std::fill(std::execution::par, wv, wv + foundClusters, 0);
+    std::fill(std::execution::par, chi2, chi2 + foundClusters, 0);
 
     // only for test
     std::unique_ptr<int> noise_p{std::make_unique<int>(0)};

--- a/src/stdpar/plugin-PixelVertexFinding/gpuSplitVertices.h
+++ b/src/stdpar/plugin-PixelVertexFinding/gpuSplitVertices.h
@@ -34,14 +34,14 @@ namespace gpuVertexFinder {
     assert(pdata);
     assert(zt);
     constexpr int MAXTK = 512;
-    auto it_sp{std::make_unique<uint32_t[]>(MAXTK)};  // track index
-    auto it{it_sp.get()};
-    auto zz_sp{std::make_unique<float[]>(MAXTK)};  // z pos
-    auto zz{zz_sp.get()};
-    auto newV_sp{std::make_unique<uint8_t[]>(MAXTK)};  // 0 or 1
-    auto newV{newV_sp.get()};
-    auto ww_sp{std::make_unique<float[]>(MAXTK)};  // z weight
-    auto ww{ww_sp.get()};
+    auto it_sp{std::make_unique<uint32_t[]>(MAXTK * nvFinal)};  // track index
+    auto pit{it_sp.get()};
+    auto zz_sp{std::make_unique<float[]>(MAXTK * nvFinal)};  // z pos
+    auto pzz{zz_sp.get()};
+    auto newV_sp{std::make_unique<uint8_t[]>(MAXTK * nvFinal)};  // 0 or 1
+    auto pnewV{newV_sp.get()};
+    auto ww_sp{std::make_unique<float[]>(MAXTK * nvFinal)};  // z weight
+    auto pww{ww_sp.get()};
 
     auto iter{std::views::iota(0U, nvFinal)};
     // one vertex per thread
@@ -55,6 +55,10 @@ namespace gpuVertexFinder {
       if (nn[kv] >= MAXTK)
         return;  // too bad FIXME
 
+      auto it = &pit[MAXTK * kv];
+      auto zz = &pzz[MAXTK * kv];
+      auto newV = &pnewV[MAXTK * kv];
+      auto ww = &pww[MAXTK * kv];
       uint32_t nq{0};  // number of track for this vertex
 
       // copy to local
@@ -75,7 +79,7 @@ namespace gpuVertexFinder {
       int maxiter = 20;
       // kt-min....
       bool more = true;
-      while (__syncthreads_or(more)) {
+      while (more) {
         more = false;
         znew[0] = 0;
         znew[1] = 0;


### PR DESCRIPTION
Port`plugin-PixelTriplets` to `std::par`. There are still some bugs that need to be fixed when running the application but all the modules have been ported to stdpar and compiles using nvhpc 23.1.