### PR TITLE
[OpenMP] Initial port of PixelVertexFinding

### DIFF
--- a/src/openmp/plugin-PixelVertexFinding/gpuClusterTracksByDensity.h
+++ b/src/openmp/plugin-PixelVertexFinding/gpuClusterTracksByDensity.h
@@ -53,7 +53,6 @@ namespace gpuVertexFinder {
     assert(zt);
 
 
-// Incomplete list
 #pragma omp target enter data map(to: zt[:MAXTRACKS], ezt2[:MAXTRACKS], izt[:MAXTRACKS], nn[:MAXTRACKS]) \
                           map(alloc: iv[:MAXTRACKS])
 

--- a/src/openmp/plugin-PixelVertexFinding/gpuClusterTracksByDensity.h
+++ b/src/openmp/plugin-PixelVertexFinding/gpuClusterTracksByDensity.h
@@ -228,7 +228,6 @@ namespace gpuVertexFinder {
       iv[i] = -iv[i] - 1;
     }
 
-// incomplete list
 #pragma omp target exit data map(delete: zt[:MAXTRACKS],ezt2[:MAXTRACKS],izt[:MAXTRACKS])  map(from:iv[:MAXTRACKS],nn[:MAXTRACKS])
 
     nvIntermediate = nvFinal = foundClusters;

--- a/src/openmp/plugin-PixelVertexFinding/gpuFitVertices.h
+++ b/src/openmp/plugin-PixelVertexFinding/gpuFitVertices.h
@@ -101,14 +101,14 @@ namespace gpuVertexFinder {
     }
 
 
-#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
-                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
+//#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
+//                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
 
 
 
     // compute chi2
 // For an AMD target, adding this loop will result in an assertion gpuSplitVertices.h:66 in event 6
-//#pragma omp target teams distribute parallel for
+#pragma omp target teams distribute parallel for
     for (uint32_t i = 0; i < nt; i++) {
       if (iv[i] > 9990)
         continue;
@@ -120,10 +120,10 @@ namespace gpuVertexFinder {
         continue;
       }
 
-//#pragma omp atomic update
+#pragma omp atomic update
       chi2[iv[i]] += c2;
 
-//#pragma omp atomic update
+#pragma omp atomic update
       nn[iv[i]]++;
       //atomicAdd(&chi2[iv[i]], c2);
       //atomicAdd(&nn[iv[i]], 1);
@@ -131,13 +131,13 @@ namespace gpuVertexFinder {
 //#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
 //                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
 
-//#pragma omp target teams distribute parallel for
+#pragma omp target teams distribute parallel for
     for (uint32_t i = 0; i < foundClusters; i++)
       if (nn[i] > 0)
         wv[i] *= float(nn[i]) / chi2[i];
 
-//#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
-//                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
+#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
+                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
 
     if (verbose)
       printf("found %d proto clusters ", foundClusters);

--- a/src/openmp/plugin-PixelVertexFinding/gpuFitVertices.h
+++ b/src/openmp/plugin-PixelVertexFinding/gpuFitVertices.h
@@ -18,6 +18,9 @@ namespace gpuVertexFinder {
   ) {
     constexpr bool verbose = false;  // in principle the compiler should optmize out if false
 
+    constexpr uint32_t MAXTRACKS = WorkSpace::MAXTRACKS;
+    constexpr uint32_t MAXVTX = WorkSpace::MAXVTX;
+
     auto& __restrict__ data = *pdata;
     auto& __restrict__ ws = *pws;
     auto nt = ws.ntrks;
@@ -38,8 +41,14 @@ namespace gpuVertexFinder {
     assert(nvFinal <= nvIntermediate);
     nvFinal = nvIntermediate;
     auto foundClusters = nvFinal;
+    //printf("foundClusters = %d MAXVTX = %d\n",foundClusters,MAXVTX);
+
+#pragma omp target enter data map(alloc:zv[:MAXVTX], wv[:MAXVTX], chi2[:MAXVTX], nn[:MAXTRACKS]) \
+                       map(to:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
 
     // zero
+//#pragma omp target teams distribute parallel for map(from:zv[:MAXVTX], wv[:MAXVTX], chi2[:MAXVTX])
+#pragma omp target teams distribute parallel for
     for (uint32_t i = 0; i < foundClusters; i++) {
       zv[i] = 0;
       wv[i] = 0;
@@ -51,28 +60,55 @@ namespace gpuVertexFinder {
     if (verbose)
       noise = 0;
 
-    // compute cluster location
+// Do assertion checks on CPU
     for (uint32_t i = 0; i < nt; i++) {
-      if (iv[i] > 9990) {
-        if (verbose)
-          atomicAdd(&noise, 1);
+      if (iv[i] > 9990)
         continue;
-      }
       assert(iv[i] >= 0);
       assert(iv[i] < int(foundClusters));
-      auto w = 1.f / ezt2[i];
-      atomicAdd(&zv[iv[i]], zt[i] * w);
-      atomicAdd(&wv[iv[i]], w);
     }
 
+    // compute cluster location
+//#pragma omp target teams distribute parallel for map(to:iv[:MAXTRACKS],ezt2[:MAXTRACKS],zt[:MAXTRACKS]) map(tofrom:zv[:MAXVTX],wv[:MAXVTX])
+#pragma omp target teams distribute parallel for
+    for (uint32_t i = 0; i < nt; i++) {
+      if (iv[i] > 9990) {
+        //if (verbose)
+        //  atomicAdd(&noise, 1);
+        continue;
+      }
+      // Will fail at runtime - kernel argument misamtch - when targeting AMD using LLVM
+      //assert(iv[i] >= 0);
+      //assert(iv[i] < int(foundClusters));
+      auto w = 1.f / ezt2[i];
+#pragma omp atomic update
+      zv[iv[i]] += zt[i] * w;
+#pragma omp atomic update
+      wv[iv[i]] +=  w;
+    }
+
+//#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
+//                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
+
     // reuse nn
+#pragma omp target teams distribute parallel for
     for (uint32_t i = 0; i < foundClusters; i++) {
-      assert(wv[i] > 0.f);
+       // If this assertion is included in this offloaded loop, it fails validation (for events 19,40,41,53,...)
+       //  on an AMD target
+      //assert(wv[i] > 0.f);
       zv[i] /= wv[i];
       nn[i] = -1;  // ndof
     }
 
+
+#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
+                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
+
+
+
     // compute chi2
+// For an AMD target, adding this loop will result in an assertion gpuSplitVertices.h:66 in event 6
+//#pragma omp target teams distribute parallel for
     for (uint32_t i = 0; i < nt; i++) {
       if (iv[i] > 9990)
         continue;
@@ -83,13 +119,25 @@ namespace gpuVertexFinder {
         iv[i] = 9999;
         continue;
       }
-      atomicAdd(&chi2[iv[i]], c2);
-      atomicAdd(&nn[iv[i]], 1);
-    }
 
+//#pragma omp atomic update
+      chi2[iv[i]] += c2;
+
+//#pragma omp atomic update
+      nn[iv[i]]++;
+      //atomicAdd(&chi2[iv[i]], c2);
+      //atomicAdd(&nn[iv[i]], 1);
+    }
+//#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
+//                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
+
+//#pragma omp target teams distribute parallel for
     for (uint32_t i = 0; i < foundClusters; i++)
       if (nn[i] > 0)
         wv[i] *= float(nn[i]) / chi2[i];
+
+//#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
+//                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
 
     if (verbose)
       printf("found %d proto clusters ", foundClusters);

--- a/src/openmp/plugin-PixelVertexFinding/gpuFitVertices.h
+++ b/src/openmp/plugin-PixelVertexFinding/gpuFitVertices.h
@@ -87,9 +87,6 @@ namespace gpuVertexFinder {
       wv[iv[i]] +=  w;
     }
 
-//#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
-//                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
-
     // reuse nn
 #pragma omp target teams distribute parallel for
     for (uint32_t i = 0; i < foundClusters; i++) {
@@ -100,9 +97,6 @@ namespace gpuVertexFinder {
       nn[i] = -1;  // ndof
     }
 
-
-//#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
-//                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
 
 
 

--- a/src/openmp/plugin-PixelVertexFinding/gpuFitVertices.h
+++ b/src/openmp/plugin-PixelVertexFinding/gpuFitVertices.h
@@ -41,7 +41,6 @@ namespace gpuVertexFinder {
     assert(nvFinal <= nvIntermediate);
     nvFinal = nvIntermediate;
     auto foundClusters = nvFinal;
-    //printf("foundClusters = %d MAXVTX = %d\n",foundClusters,MAXVTX);
 
 #pragma omp target enter data map(alloc:zv[:MAXVTX], wv[:MAXVTX], chi2[:MAXVTX], nn[:MAXTRACKS]) \
                        map(to:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
@@ -122,8 +121,6 @@ namespace gpuVertexFinder {
       //atomicAdd(&chi2[iv[i]], c2);
       //atomicAdd(&nn[iv[i]], 1);
     }
-//#pragma omp target exit data map(from:zv[:MAXVTX], wv[:MAXVTX] , chi2[:MAXVTX], nn[:MAXTRACKS]) \
-//                       map(delete:iv[:MAXTRACKS], ezt2[:MAXTRACKS], zt[:MAXTRACKS])
 
 #pragma omp target teams distribute parallel for
     for (uint32_t i = 0; i < foundClusters; i++)


### PR DESCRIPTION
Port code in the PixelVertexFinding plugin to use OpenMP offload.

What remains to be done:
* Many of the loops are in individual `target` regions, which makes them separate kernels.  This is likely to lead to large launch overheads in aggregate.  The loop in `gpuSplitVertices` is different - the outer loops is `target teams distribute`, and the inner loops are `parallel for`.   The other kernels may need to be modified to do something similar in order to combine multiple loops in a single kernel invocation.
* Each kernel has the data movement pulled out of individual loops into a `target enter/exit data` region.  These regions should be be expanded to encompass the all the kernels.
* Sorting in `gpuSortByPt2` has not been ported.

The `atomicInc` function, which performs a clipped or bounded increment doesn't have a directly compatible version in OpenMP.   The workaround (which I didn't use here), is to perform a bounds check after the increment to guard whatever action is using the variable, and fix up the final value of the variable at the end of the loop.