### PR TITLE
Update the SYCL device selector and improve the synchronisations 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ ifdef SYCL_USE_INTEL_ONEAPI
   ONEAPI_BASE := /opt/intel/oneapi
 
   ifeq ($(wildcard $(ONEAPI_BASE)),)
-    $(error Cannot find an Intel oneAPI installation at $(ONEAPI_BASE))
+    $(warning Cannot find an Intel oneAPI installation at $(ONEAPI_BASE))
   endif
 
   # Intel oneTBB

--- a/src/sycl/bin/main.cc
+++ b/src/sycl/bin/main.cc
@@ -20,17 +20,17 @@ namespace {
   void print_help(std::string const& name) {
     std::cout
         << name
-        << ": [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--device DV] [--data PATH] [--transfer] "
-           "[--validation] "
-           "[--histogram] [--empty]\n\n"
+        << ": [--device BACKEND:DEVICE] [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] "
+           "                     [--transfer] [--validation] [--histogram] [--empty]\n\n"
         << "Options\n"
+        << " --device            Specifies the device which should run the code (default all, options: <backend>:<devices>\n"
+           "                       see https://intel.github.io/llvm-docs/EnvironmentVariables.html#oneapi-device-selector\n"
+           "                       for the accepted syntax)\n"
         << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
         << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --device            Specifies the device which should run the code (default all, options: cpu, gpu, cuda, "
-           "hip, backend:device:tile (e.g.opencl:gpu:0)..)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "(default -1 for disabled; conflicts with --maxEvents)\n"
+        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed\n"
+           "                       (default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
@@ -56,6 +56,10 @@ int main(int argc, char** argv) try {
     if (*i == "-h" or *i == "--help") {
       print_help(args.front());
       return EXIT_SUCCESS;
+    } else if (*i == "--device") {
+      ++i;
+      std::string device = *i;
+      setenv("ONEAPI_DEVICE_SELECTOR", device.c_str(), true);
     } else if (*i == "--numberOfThreads") {
       ++i;
       numberOfThreads = std::stoi(*i);
@@ -68,10 +72,6 @@ int main(int argc, char** argv) try {
     } else if (*i == "--runForMinutes") {
       ++i;
       runForMinutes = std::stoi(*i);
-    } else if (*i == "--device") {
-      ++i;
-      std::string device = *i;
-      setenv("SYCL_DEVICE_FILTER", device.c_str(), true);
     } else if (*i == "--data") {
       ++i;
       datadir = *i;

--- a/src/sycl/test/AtomicPairCounter_t.cc
+++ b/src/sycl/test/AtomicPairCounter_t.cc
@@ -44,7 +44,7 @@ void verify(AtomicPairCounter const *dc, uint32_t const *ind, uint32_t const *co
 #include <iostream>
 int main(int argc, char **argv) {
   std::string devices(argv[1]);
-  setenv("SYCL_DEVICE_FILTER", devices.c_str(), true);
+  setenv("ONEAPI_DEVICE_SELECTOR", devices.c_str(), true);
 
   cms::sycltools::enumerateDevices(true);
   sycl::device device = cms::sycltools::chooseDevice(0);
@@ -82,5 +82,6 @@ int main(int argc, char **argv) {
 
   std::cout << dc.get().n << ' ' << dc.get().m << std::endl;
 
+  queue.wait_and_throw();
   return 0;
 }

--- a/src/sycl/test/HistoContainer_t.cc
+++ b/src/sycl/test/HistoContainer_t.cc
@@ -19,7 +19,7 @@ void go(sycl::queue queue) {
   T v[N];
   auto v_d = cms::sycltools::make_device_unique<T[]>(N, queue);
 
-  queue.memcpy(v_d.get(), v, N * sizeof(T)).wait();
+  queue.memcpy(v_d.get(), v, N * sizeof(T));
 
   constexpr uint32_t nParts = 10;
   constexpr uint32_t partSize = N / nParts;
@@ -55,7 +55,7 @@ void go(sycl::queue queue) {
       offsets[10] = 3297 + offsets[9];
     }
 
-    queue.memcpy(off_d.get(), offsets, 4 * (nParts + 1)).wait();
+    queue.memcpy(off_d.get(), offsets, 4 * (nParts + 1));
 
     for (long long j = 0; j < N; j++)
       v[j] = rgen(eng);
@@ -65,7 +65,7 @@ void go(sycl::queue queue) {
         v[j] = sizeof(T) == 1 ? 22 : 3456;
     }
 
-    queue.memcpy(v_d.get(), v, N * sizeof(T)).wait();
+    queue.memcpy(v_d.get(), v, N * sizeof(T));
     cms::sycltools::fillManyFromVector(h_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, queue);
     queue.memcpy(&h, h_d.get(), sizeof(Hist)).wait();
     //assert(0 == h.off[0]);
@@ -139,12 +139,14 @@ void go(sycl::queue queue) {
         //assert(!l);
       }
     }
+
+    queue.wait_and_throw();
   }
 }
 
 int main(int argc, char** argv) {
   std::string devices(argv[1]);
-  setenv("SYCL_DEVICE_FILTER", devices.c_str(), true);
+  setenv("ONEAPI_DEVICE_SELECTOR", devices.c_str(), true);
 
   cms::sycltools::enumerateDevices(true);
   sycl::device device = cms::sycltools::chooseDevice(0);

--- a/src/sycl/test/OneHistoContainer_t.cc
+++ b/src/sycl/test/OneHistoContainer_t.cc
@@ -145,7 +145,7 @@ void go(sycl::queue queue) {
 
 int main(int argc, char** argv) {
   std::string devices(argv[1]);
-  setenv("SYCL_DEVICE_FILTER", devices.c_str(), true);
+  setenv("ONEAPI_DEVICE_SELECTOR", devices.c_str(), true);
 
   cms::sycltools::enumerateDevices(true);
   sycl::device device = cms::sycltools::chooseDevice(0);

--- a/src/sycl/test/OneToManyAssoc_t.cc
+++ b/src/sycl/test/OneToManyAssoc_t.cc
@@ -141,7 +141,7 @@ int main(int argc, char** argv) {
   std::cout << "filled with " << n << " elements " << double(ave) / n << ' ' << imax << ' ' << nz << std::endl;
 
   std::string devices(argv[1]);
-  setenv("SYCL_DEVICE_FILTER", devices.c_str(), true);
+  setenv("ONEAPI_DEVICE_SELECTOR", devices.c_str(), true);
 
   cms::sycltools::enumerateDevices(true);
   sycl::device device = cms::sycltools::chooseDevice(0);

--- a/src/sycl/test/VertexFinder_t.cc
+++ b/src/sycl/test/VertexFinder_t.cc
@@ -110,7 +110,7 @@ void print(gpuVertexFinder::ZVertices const* pdata, gpuVertexFinder::WorkSpace c
 
 int main(int argc, char** argv) {
   std::string devices(argv[1]);
-  setenv("SYCL_DEVICE_FILTER", devices.c_str(), true);
+  setenv("ONEAPI_DEVICE_SELECTOR", devices.c_str(), true);
 
   cms::sycltools::enumerateDevices(true);
   sycl::device device = cms::sycltools::chooseDevice(0);
@@ -332,6 +332,8 @@ int main(int argc, char** argv) {
       queue.memcpy(ptv2, LOC_ONGPU(ptv2), nv * sizeof(float));
       queue.memcpy(nn, LOC_ONGPU(ndof), nv * sizeof(int32_t));
       queue.memcpy(ind, LOC_ONGPU(sortInd), nv * sizeof(uint16_t));
+      queue.wait_and_throw();
+
       for (auto j = 0U; j < nv; ++j)
         if (nn[j] > 0)
           chi2[j] /= float(nn[j]);

--- a/src/sycltest/bin/main.cc
+++ b/src/sycltest/bin/main.cc
@@ -20,14 +20,17 @@ namespace {
   void print_help(std::string const& name) {
     std::cout
         << name
-        << ": [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] [--transfer] [--validation] "
-           "[--empty]\n\n"
+        << ": [--device BACKEND:DEVICE] [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH]"
+           "                     [--transfer] [--validation] [--empty]\n\n"
         << "Options\n"
+        << " --device            Specifies the device which should run the code (default all, options: <backend>:<devices>\n"
+           "                       see https://intel.github.io/llvm-docs/EnvironmentVariables.html#oneapi-device-selector\n"
+           "                       for the accepted syntax)\n"
         << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
         << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
         << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "(default -1 for disabled; conflicts with --maxEvents)\n"
+           "                       (default -1 for disabled; conflicts with --maxEvents)\n"
         << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
         << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
         << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
@@ -51,6 +54,10 @@ int main(int argc, char** argv) try {
     if (*i == "-h" or *i == "--help") {
       print_help(args.front());
       return EXIT_SUCCESS;
+    } else if (*i == "--device") {
+      ++i;
+      std::string device = *i;
+      setenv("ONEAPI_DEVICE_SELECTOR", device.c_str(), true);
     } else if (*i == "--numberOfThreads") {
       ++i;
       numberOfThreads = std::stoi(*i);


### PR DESCRIPTION
Use `ONEAPI_DEVICE_SELECTOR` instead of the legacy `SYCL_DEVICE_FILTER`.
Improve the synchronisation and error handling of the SYCL queues.
Downgrade the error about missing oneAPI to a warning.