### PR TITLE
Updates for the SYCL CPU target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ ifneq ($(wildcard $(SYCL_BASE)),)
 
   # add the SYCL paths to the PATH and LD_LIBRARY_PATH
   export PATH := $(SYCL_PATH):$(PATH)
-  export LD_LIBRARY_PATH := $(SYCL_LDPATH):$(LD_LIBRARY_PATH)
+  export LD_LIBRARY_PATH := $(SYCL_LDPATH):$(TBB_LIBDIR):$(LD_LIBRARY_PATH)
 
   # enable double precision floating point emulation for Intel GPUs
   # see https://github.com/intel/compute-runtime/blob/master/opencl/doc/FAQ.md#feature-double-precision-emulation-fp64

--- a/src/sycl/CondFormats/PixelCPEFast.cc
+++ b/src/sycl/CondFormats/PixelCPEFast.cc
@@ -53,7 +53,8 @@ const pixelCPEforGPU::ParamsOnGPU *PixelCPEFast::getGPUProductAsync(sycl::queue 
     stream.memcpy((void *)data.h_paramsOnGPU.m_detParams.get(),
                   this->m_detParamsGPU.data(),
                   this->m_detParamsGPU.size() * sizeof(pixelCPEforGPU::DetParams));
-#ifdef CPU_DEBUG
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+    // FIXME needed only on CPU ?
     stream.wait();
 #endif
   });

--- a/src/sycl/CondFormats/SiPixelFedCablingMapGPUWrapper.cc
+++ b/src/sycl/CondFormats/SiPixelFedCablingMapGPUWrapper.cc
@@ -29,7 +29,8 @@ const SiPixelFedCablingMapGPU* SiPixelFedCablingMapGPUWrapper::getGPUProductAsyn
     data.cablingMapDevice = cms::sycltools::make_device_unique_uninitialized<SiPixelFedCablingMapGPU>(stream);
     // transfer
     stream.memcpy(data.cablingMapDevice.get(), this->cablingMapHost_, sizeof(SiPixelFedCablingMapGPU));
-#ifdef CPU_DEBUG
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+    // FIXME needed only on CPU ?
     stream.wait();
 #endif
   });
@@ -42,7 +43,8 @@ const unsigned char* SiPixelFedCablingMapGPUWrapper::getModToUnpAllAsync(sycl::q
         cms::sycltools::make_device_unique<unsigned char[]>(pixelgpudetails::MAX_SIZE_BYTE_BOOL, stream);
     stream.memcpy(
         data.modToUnpDefault.get(), this->modToUnpDefault.data(), this->modToUnpDefault.size() * sizeof(unsigned char));
-#ifdef CPU_DEBUG
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+    // FIXME needed only on CPU ?
     stream.wait();
 #endif
   });

--- a/src/sycl/CondFormats/SiPixelGainCalibrationForHLTGPU.cc
+++ b/src/sycl/CondFormats/SiPixelGainCalibrationForHLTGPU.cc
@@ -21,13 +21,15 @@ const SiPixelGainForHLTonGPU* SiPixelGainCalibrationForHLTGPU::getGPUProductAsyn
     // those in CUDA were three memcpy: here they didn't work
     // this is another way to achieve the same result
     stream.memcpy(data.gainDataOnGPU.get(), this->gainData_.data(), this->gainData_.size());
-#ifdef CPU_DEBUG
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+    // FIXME needed only on CPU ?
     stream.wait();
 #endif
     this->gainForHLTonHost_->v_pedestals = data.gainDataOnGPU.get();
 
     stream.memcpy(data.gainForHLTonGPU.get(), this->gainForHLTonHost_, sizeof(SiPixelGainForHLTonGPU));
-#ifdef CPU_DEBUG
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+    // FIXME needed only on CPU ?
     stream.wait();
 #endif
   });

--- a/src/sycl/SYCLDataFormats/SiPixelDigisSYCL.cc
+++ b/src/sycl/SYCLDataFormats/SiPixelDigisSYCL.cc
@@ -22,7 +22,8 @@ SiPixelDigisSYCL::SiPixelDigisSYCL(size_t maxFedWords, sycl::queue stream) {
 
   view_d = cms::sycltools::make_device_unique<DeviceConstView>(stream);
   stream.memcpy(view_d.get(), view.get(), sizeof(DeviceConstView));
-#ifdef CPU_DEBUG
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+  // FIXME needed only on CPU ?
   stream.wait();
 #endif
 }

--- a/src/sycl/SYCLDataFormats/TrackingRecHit2DSYCL.h
+++ b/src/sycl/SYCLDataFormats/TrackingRecHit2DSYCL.h
@@ -83,7 +83,8 @@ inline TrackingRecHit2DSYCL::TrackingRecHit2DSYCL(uint32_t nHits,
   // if empy do not bother
   if (0 == nHits) {
     stream.memcpy(m_view.get(), view.get(), sizeof(TrackingRecHit2DSOAView));
-#ifdef CPU_DEBUG
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+    // FIXME needed only on CPU ?
     stream.wait();
 #endif
     return;
@@ -125,7 +126,8 @@ inline TrackingRecHit2DSYCL::TrackingRecHit2DSYCL(uint32_t nHits,
 
   // transfer view
   stream.memcpy(m_view.get(), view.get(), sizeof(TrackingRecHit2DSOAView));
-#ifdef CPU_DEBUG
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+  // FIXME needed only on CPU ?
   stream.wait();
 #endif
 }

--- a/src/sycl/plugin-PixelTriplets/BrokenLineFitOnGPU.cc
+++ b/src/sycl/plugin-PixelTriplets/BrokenLineFitOnGPU.cc
@@ -199,7 +199,8 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                                 });
       });
     }
-#ifdef CPU_DEBUG
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+    // FIXME needed only on CPU ?
     stream.wait();
 #endif
   }  // loop on concurrent fits

--- a/src/sycl/plugin-PixelTriplets/CAHitNtupletGeneratorOnGPU.cc
+++ b/src/sycl/plugin-PixelTriplets/CAHitNtupletGeneratorOnGPU.cc
@@ -96,14 +96,16 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuplesAsync(TrackingRecH
   } else {
     fitter.launchBrokenLineKernels(hits_d.view(), hits_d.nHits(), CAConstants::maxNumberOfQuadruplets(), stream);
   }
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+  // FIXME needed only on CPU ?
+  stream.wait();
+#endif
 
 #ifdef NTUPLE_DEBUG
   std::cout << "..end of n-tuplets fit.\n";
   std::cout << "------------------------\n";
 #endif
-#ifdef CPU_DEBUG
-  stream.wait();
-#endif
+
   kernels.classifyTuples(hits_d, soa, stream);
   stream.wait();
 

--- a/src/sycl/plugin-PixelVertexFinding/gpuVertexFinderImpl.h
+++ b/src/sycl/plugin-PixelVertexFinding/gpuVertexFinderImpl.h
@@ -433,7 +433,8 @@ namespace gpuVertexFinder {
 #ifdef GPU_DEBUG
     stream.wait();
 #endif
-#ifdef CPU_DEBUG
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+    // FIXME needed only on CPU ?
     stream.wait();
 #endif
 

--- a/src/sycl/plugin-SiPixelClusterizer/SiPixelRawToClusterGPUKernel.cc
+++ b/src/sycl/plugin-SiPixelClusterizer/SiPixelRawToClusterGPUKernel.cc
@@ -754,15 +754,15 @@ namespace pixelgpudetails {
       // last element holds the number of all clusters
       stream.memcpy(
           &(nModules_Clusters_h[1]), clusters_d.clusModuleStart() + gpuClustering::MaxNumModules, sizeof(int32_t));
-#ifdef CPU_DEBUG
-      stream.wait();
-#endif
 #ifdef GPU_DEBUG
       stream.wait();
       std::cout << "Number of modules (nModules_Clusters_h[0]): " << nModules_Clusters_h[0]
                 << " and number of clusters (nModules_Clusters_h[1]): " << nModules_Clusters_h[1] << std::endl;
 #endif
-
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+      // FIXME needed only on CPU ?
+      stream.wait();
+#endif
     }  // end clusterizer scope
   }
 }  // namespace pixelgpudetails

--- a/src/sycl/plugin-SiPixelRecHits/PixelRecHits.cc
+++ b/src/sycl/plugin-SiPixelRecHits/PixelRecHits.cc
@@ -96,7 +96,8 @@ namespace pixelgpudetails {
 #ifdef GPU_DEBUG
     stream.wait();
 #endif
-#ifdef CPU_DEBUG
+#ifdef __SYCL_TARGET_INTEL_X86_64__
+    // FIXME needed only on CPU ?
     stream.wait();
 #endif
 


### PR DESCRIPTION
Automatically enable the workarounds for the OpenCL CPU back-end based on the `__SYCL_TARGET_INTEL_X86_64__` macro, instead of by setting the `CPU_DEBUG` macro explicitly.

Add the path to the TBB library to the `LD_LIBRARY_PATH`: the AOT compiler for the CPU target requires the OpenCL CPU runtime. In turn, the OpenCL CPU runtime requires the TBB library.