### PR TITLE
Warm up before measuring the throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,25 @@ The program contains the changes from following external PRs on top of `cuda`
 
 #### `hip` and `hiptest`
 
+`hip` and `hiptest` are ports of the `cuda` and `cudatest` programs to HIP,
+built for the AMD ROCm backend.
+
 The path to ROCm can be set with `ROCM_BASE` variable.
+
+The use of caching allocator can be disabled at compile time setting the
+`HIP_DISABLE_CACHING_ALLOCATOR` preprocessor symbol:
+```
+make hip ... USER_CXXFLAGS="-DHIP_DISABLE_CACHING_ALLOCATOR"
+```
+
+If the caching allocator is disabled and HIP version is 5.2.0 or greater is detected,
+device allocations and deallocations will use the stream-ordered HIP functions
+`hipMallocAsync` and `hipFreeAsync`. Their use can be disabled explicitly at
+compile time setting also the `HIP_DISABLE_ASYNC_ALLOCATOR` preprocessor symbol:
+
+```
+make hip ... USER_CXXFLAGS="-DHIP_DISABLE_CACHING_ALLOCATOR -DHIP_DISABLE_ASYNC_ALLOCATOR"
+```
 
 
 #### `kokkos` and `kokkostest`

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ make cudauvm ... USER_CXXFLAGS="-DCUDAUVM_DISABLE_ADVISE"
 |----------------------------------------|-------------------------------------------------------|
 | `-DCUDAUVM_DISABLE_ADVISE`             | Disable `cudaMemAdvise(cudaMemAdviseSetReadMostly)`   |
 | `-DCUDAUVM_DISABLE_PREFETCH`           | Disable `cudaMemPrefetchAsync`                        |
-| `-DCUDAUVM_DISABLE_CACHING_ALLOCATOR`  | Disable caching allocator                             |
+| `-DCUDAUVM_DISABLE_CACHING_ALLOCATOR`  | Disable caching allocator, use `cudaMallocAsync`      |
+| `-DCUDAUVM_DISABLE_ASYNC_ALLOCATOR`    | Disable `cudaMallocAsync`, use `cudaMalloc`           |
 | `-DCUDAUVM_MANAGED_TEMPORARY`          | Use managed memory also for temporary data structures |
 | `-DCUDAUVM_DISABLE_MANAGED_BEAMSPOT`   | Disable managed memory in `BeamSpotToCUDA`            |
 | `-DCUDAUVM_DISABLE_MANAGED_CLUSTERING` | Disable managed memory in `SiPixelRawToClusterCUDA`   |

--- a/src/alpaka/bin/EventProcessor.h
+++ b/src/alpaka/bin/EventProcessor.h
@@ -27,7 +27,8 @@ namespace edm {
 
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             Alternatives alternatives,
@@ -39,17 +40,23 @@ namespace edm {
     int processedEvents() const { return source_.processedEvents(); }
     std::vector<std::pair<Backend, int>> const& backends() const { return streamsPerBackend_; }
 
+    void warmUp();
     void runToCompletion();
 
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
     std::vector<std::pair<Backend, int>> streamsPerBackend_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/alpaka/bin/Source.cc
+++ b/src/alpaka/bin/Source.cc
@@ -87,6 +87,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/alpaka/bin/Source.h
+++ b/src/alpaka/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/alpakatest/bin/EventProcessor.h
+++ b/src/alpakatest/bin/EventProcessor.h
@@ -27,7 +27,8 @@ namespace edm {
 
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             Alternatives alternatives,
@@ -39,17 +40,23 @@ namespace edm {
     int processedEvents() const { return source_.processedEvents(); }
     std::vector<std::pair<Backend, int>> const& backends() const { return streamsPerBackend_; }
 
+    void warmUp();
     void runToCompletion();
 
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
     std::vector<std::pair<Backend, int>> streamsPerBackend_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/alpakatest/bin/Source.cc
+++ b/src/alpakatest/bin/Source.cc
@@ -87,6 +87,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/alpakatest/bin/Source.h
+++ b/src/alpakatest/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/alpakatest/bin/main.cc
+++ b/src/alpakatest/bin/main.cc
@@ -38,7 +38,7 @@ namespace {
 #ifdef ALPAKA_ACC_GPU_HIP_PRESENT
         << "[--hip] "
 #endif
-        << "[--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] "
+        << "[--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--warmupEvents WE] [--data PATH] "
            "[--transfer]\n\n"
         << "Options\n"
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT
@@ -55,6 +55,7 @@ namespace {
 #endif
         << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
         << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
+        << " --warmupEvents      Number of events to process before starting the benchmark (default 0)\n"
         << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
         << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
            "(default -1 for disabled; conflicts with --maxEvents)\n"
@@ -121,6 +122,7 @@ int main(int argc, char** argv) {
   std::unordered_map<Backend, float> backends;
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -158,6 +160,8 @@ int main(int argc, char** argv) {
       getArgument(args, i, numberOfThreads);
     } else if (*i == "--numberOfStreams") {
       getArgument(args, i, numberOfStreams);
+    } else if (*i == "--warmupEvents") {
+      getArgument(args, i, warmupEvents);
     } else if (*i == "--maxEvents") {
       getArgument(args, i, maxEvents);
     } else if (*i == "--runForMinutes") {
@@ -233,13 +237,22 @@ int main(int argc, char** argv) {
       alternatives.emplace_back(backend, weight, std::move(edmodules));
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(alternatives), std::move(esmodules), datadir, false);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(alternatives),
+                                std::move(esmodules),
+                                datadir,
+                                false);
 
   if (runForMinutes < 0) {
     std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
     std::cout << "Processing for about " << runForMinutes << " minutes,";
+  }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
   }
   {
     std::cout << " with " << numberOfStreams << " concurrent events (";
@@ -257,6 +270,23 @@ int main(int argc, char** argv) {
   // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();

--- a/src/cuda/bin/EventProcessor.cc
+++ b/src/cuda/bin/EventProcessor.cc
@@ -5,28 +5,48 @@
 #include "EventProcessor.h"
 
 namespace edm {
-  EventProcessor::EventProcessor(int maxEvents,
+  EventProcessor::EventProcessor(int warmupEvents,
+                                 int maxEvents,
                                  int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation),
+        warmupEvents_(warmupEvents),
+        maxEvents_(source_.maxEvents()),
+        runForMinutes_(runForMinutes) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
       esp->produce(eventSetup_);
     }
 
-    //schedules_.reserve(numberOfStreams);
+    schedules_.reserve(numberOfStreams);
     for (int i = 0; i < numberOfStreams; ++i) {
       schedules_.emplace_back(registry_, pluginManager_, &source_, &eventSetup_, i, path);
     }
   }
 
+  void EventProcessor::warmUp() {
+    if (warmupEvents_ <= 0)
+      return;
+
+    // Configure the source for the warmup step
+    source_.reconfigure(warmupEvents_, -1);
+    process();
+  }
+
   void EventProcessor::runToCompletion() {
+    // Configure the source for the actual reconstrction
+    source_.reconfigure(maxEvents_, runForMinutes_);
+    process();
+  }
+
+  void EventProcessor::process() {
     source_.startProcessing();
+
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/cuda/bin/EventProcessor.h
+++ b/src/cuda/bin/EventProcessor.h
@@ -14,7 +14,8 @@
 namespace edm {
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
@@ -25,16 +26,21 @@ namespace edm {
     int maxEvents() const { return source_.maxEvents(); }
     int processedEvents() const { return source_.processedEvents(); }
 
+    void warmUp();
     void runToCompletion();
-
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/cuda/bin/Source.cc
+++ b/src/cuda/bin/Source.cc
@@ -83,6 +83,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/cuda/bin/Source.h
+++ b/src/cuda/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/cuda/bin/main.cc
+++ b/src/cuda/bin/main.cc
@@ -20,21 +20,23 @@
 namespace {
   void print_help(std::string const& name) {
     std::cout
-        << name
-        << ": [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] [--transfer] [--validation] "
-           "[--histogram] [--empty]\n\n"
-        << "Options\n"
-        << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
-        << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
-        << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "(default -1 for disabled; conflicts with --maxEvents)\n"
-        << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
-        << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
-        << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
-        << " --histogram         Produce histograms at the end (implies --transfer)\n"
-        << " --empty             Ignore all producers (for testing only)\n"
-        << std::endl;
+        << "Usage: " << name
+        << " [--numberOfThreads NT] [--numberOfStreams NS] [--warmupEvents WE] [--maxEvents ME] [--runForMinutes RM]"
+        << " [--data PATH] [--transfer] [--validation] [--histogram] [--empty]\n";
+    std::cout << R"(
+Options:
+  --numberOfThreads             Number of threads to use (default 1, use 0 to use all CPU cores).
+  --numberOfStreams             Number of concurrent events (default 0 = numberOfThreads).
+  --warmupEvents                Number of events to process before starting the benchmark (default 0).
+  --maxEvents                   Number of events to process (default -1 for all events in the input file).
+  --runForMinutes               Continue processing the set of 1000 events until this many minutes have passed
+                                (default -1 for disabled; conflicts with --maxEvents).
+  --data                        Path to the 'data' directory (default 'data' in the directory of the executable).
+  --transfer                    Transfer results from GPU to CPU (default is to leave them on GPU).
+  --validation                  Run (rudimentary) validation at the end (implies --transfer).
+  --histogram                   Produce histograms at the end (implies --transfer).
+  --empty                       Ignore all producers (for testing only).
+)";
   }
 }  // namespace
 
@@ -43,6 +45,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> args(argv, argv + argc);
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -60,6 +63,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
+    } else if (*i == "--warmupEvents") {
+      ++i;
+      warmupEvents = std::stoi(*i);
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -145,20 +151,45 @@ int main(int argc, char** argv) {
       edmodules.emplace_back("HistoValidator");
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(edmodules),
+                                std::move(esmodules),
+                                datadir,
+                                validation);
 
   if (runForMinutes < 0) {
-    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
-              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
-    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
-              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing for about " << runForMinutes << " minutes,";
   }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
+  }
+  std::cout << " with " << numberOfStreams << " concurrent events and " << numberOfThreads << " threads." << std::endl;
 
-  // Initialize he TBB thread pool
+  // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();

--- a/src/cuda/test/TrackingRecHit2DCUDA_t.cu
+++ b/src/cuda/test/TrackingRecHit2DCUDA_t.cu
@@ -6,22 +6,24 @@ namespace testTrackingRecHit2D {
 
   __global__ void fill(TrackingRecHit2DSOAView* phits) {
     assert(phits);
-    auto& hits = *phits;
-    assert(hits.nHits() == 200);
+    assert(phits->nHits() == 200);
 
     int i = threadIdx.x;
     if (i > 200)
       return;
+
+    // FIXME do something ?
   }
 
   __global__ void verify(TrackingRecHit2DSOAView const* phits) {
     assert(phits);
-    auto const& hits = *phits;
-    assert(hits.nHits() == 200);
+    assert(phits->nHits() == 200);
 
     int i = threadIdx.x;
     if (i > 200)
       return;
+
+    // FIXME do something ?
   }
 
   void runKernels(TrackingRecHit2DSOAView* hits) {
@@ -31,12 +33,6 @@ namespace testTrackingRecHit2D {
   }
 
 }  // namespace testTrackingRecHit2D
-
-namespace testTrackingRecHit2D {
-
-  void runKernels(TrackingRecHit2DSOAView* hits);
-
-}
 
 int main() {
   cudaStream_t stream;

--- a/src/cudacompat/CUDACore/deviceAllocatorStatus.h
+++ b/src/cudacompat/CUDACore/deviceAllocatorStatus.h
@@ -1,6 +1,7 @@
 #ifndef HeterogeneousCore_CUDAUtilities_deviceAllocatorStatus_h
 #define HeterogeneousCore_CUDAUtilities_deviceAllocatorStatus_h
 
+#include <cstddef>
 #include <map>
 
 namespace cms {

--- a/src/cudacompat/DataFormats/SiPixelDigisSoA.h
+++ b/src/cudacompat/DataFormats/SiPixelDigisSoA.h
@@ -1,6 +1,7 @@
 #ifndef DataFormats_SiPixelDigi_interface_SiPixelDigisSoA_h
 #define DataFormats_SiPixelDigi_interface_SiPixelDigisSoA_h
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 

--- a/src/cudacompat/bin/EventProcessor.cc
+++ b/src/cudacompat/bin/EventProcessor.cc
@@ -5,28 +5,48 @@
 #include "EventProcessor.h"
 
 namespace edm {
-  EventProcessor::EventProcessor(int maxEvents,
+  EventProcessor::EventProcessor(int warmupEvents,
+                                 int maxEvents,
                                  int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation),
+        warmupEvents_(warmupEvents),
+        maxEvents_(source_.maxEvents()),
+        runForMinutes_(runForMinutes) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
       esp->produce(eventSetup_);
     }
 
-    //schedules_.reserve(numberOfStreams);
+    schedules_.reserve(numberOfStreams);
     for (int i = 0; i < numberOfStreams; ++i) {
       schedules_.emplace_back(registry_, pluginManager_, &source_, &eventSetup_, i, path);
     }
   }
 
+  void EventProcessor::warmUp() {
+    if (warmupEvents_ <= 0)
+      return;
+
+    // Configure the source for the warmup step
+    source_.reconfigure(warmupEvents_, -1);
+    process();
+  }
+
   void EventProcessor::runToCompletion() {
+    // Configure the source for the actual reconstrction
+    source_.reconfigure(maxEvents_, runForMinutes_);
+    process();
+  }
+
+  void EventProcessor::process() {
     source_.startProcessing();
+
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/cudacompat/bin/EventProcessor.h
+++ b/src/cudacompat/bin/EventProcessor.h
@@ -14,7 +14,8 @@
 namespace edm {
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
@@ -25,16 +26,21 @@ namespace edm {
     int maxEvents() const { return source_.maxEvents(); }
     int processedEvents() const { return source_.processedEvents(); }
 
+    void warmUp();
     void runToCompletion();
-
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/cudacompat/bin/Source.cc
+++ b/src/cudacompat/bin/Source.cc
@@ -83,6 +83,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/cudacompat/bin/Source.h
+++ b/src/cudacompat/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/cudacompat/bin/main.cc
+++ b/src/cudacompat/bin/main.cc
@@ -19,20 +19,22 @@
 namespace {
   void print_help(std::string const& name) {
     std::cout
-        << name
-        << ": [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] [--validation] "
-           "[--histogram] [--empty]\n\n"
-        << "Options\n"
-        << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
-        << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
-        << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "(default -1 for disabled; conflicts with --maxEvents)\n"
-        << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
-        << " --validation        Run (rudimentary) validation at the end\n"
-        << " --histogram         Produce histograms at the end\n"
-        << " --empty             Ignore all producers (for testing only)\n"
-        << std::endl;
+        << "Usage: " << name
+        << " [--numberOfThreads NT] [--numberOfStreams NS] [--warmupEvents WE] [--maxEvents ME] [--runForMinutes RM]"
+        << " [--data PATH] [--validation] [--histogram] [--empty]\n";
+    std::cout << R"(
+Options:
+  --numberOfThreads             Number of threads to use (default 1, use 0 to use all CPU cores).
+  --numberOfStreams             Number of concurrent events (default 0 = numberOfThreads).
+  --warmupEvents                Number of events to process before starting the benchmark (default 0).
+  --maxEvents                   Number of events to process (default -1 for all events in the input file).
+  --runForMinutes               Continue processing the set of 1000 events until this many minutes have passed
+                                (default -1 for disabled; conflicts with --maxEvents).
+  --data                        Path to the 'data' directory (default 'data' in the directory of the executable).
+  --validation                  Run (rudimentary) validation at the end.
+  --histogram                   Produce histograms at the end.
+  --empty                       Ignore all producers (for testing only).
+)";
   }
 }  // namespace
 
@@ -41,6 +43,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> args(argv, argv + argc);
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -57,6 +60,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
+    } else if (*i == "--warmupEvents") {
+      ++i;
+      warmupEvents = std::stoi(*i);
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -122,20 +128,45 @@ int main(int argc, char** argv) {
       edmodules.emplace_back("HistoValidator");
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(edmodules),
+                                std::move(esmodules),
+                                datadir,
+                                validation);
 
   if (runForMinutes < 0) {
-    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
-              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
-    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
-              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing for about " << runForMinutes << " minutes,";
   }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
+  }
+  std::cout << " with " << numberOfStreams << " concurrent events and " << numberOfThreads << " threads." << std::endl;
 
-  // Initialize he TBB thread pool
+  // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();

--- a/src/cudadev/bin/EventProcessor.cc
+++ b/src/cudadev/bin/EventProcessor.cc
@@ -5,28 +5,48 @@
 #include "EventProcessor.h"
 
 namespace edm {
-  EventProcessor::EventProcessor(int maxEvents,
+  EventProcessor::EventProcessor(int warmupEvents,
+                                 int maxEvents,
                                  int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation),
+        warmupEvents_(warmupEvents),
+        maxEvents_(source_.maxEvents()),
+        runForMinutes_(runForMinutes) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
       esp->produce(eventSetup_);
     }
 
-    //schedules_.reserve(numberOfStreams);
+    schedules_.reserve(numberOfStreams);
     for (int i = 0; i < numberOfStreams; ++i) {
       schedules_.emplace_back(registry_, pluginManager_, &source_, &eventSetup_, i, path);
     }
   }
 
+  void EventProcessor::warmUp() {
+    if (warmupEvents_ <= 0)
+      return;
+
+    // Configure the source for the warmup step
+    source_.reconfigure(warmupEvents_, -1);
+    process();
+  }
+
   void EventProcessor::runToCompletion() {
+    // Configure the source for the actual reconstrction
+    source_.reconfigure(maxEvents_, runForMinutes_);
+    process();
+  }
+
+  void EventProcessor::process() {
     source_.startProcessing();
+
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/cudadev/bin/EventProcessor.h
+++ b/src/cudadev/bin/EventProcessor.h
@@ -14,7 +14,8 @@
 namespace edm {
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
@@ -25,16 +26,21 @@ namespace edm {
     int maxEvents() const { return source_.maxEvents(); }
     int processedEvents() const { return source_.processedEvents(); }
 
+    void warmUp();
     void runToCompletion();
-
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/cudadev/bin/Source.cc
+++ b/src/cudadev/bin/Source.cc
@@ -83,6 +83,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/cudadev/bin/Source.h
+++ b/src/cudadev/bin/Source.h
@@ -17,12 +17,10 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents,
-                    int runForMinutes,
-                    ProductRegistry& reg,
-                    std::filesystem::path const& datadir,
-                    bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -35,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/cudadev/bin/main.cc
+++ b/src/cudadev/bin/main.cc
@@ -20,21 +20,23 @@
 namespace {
   void print_help(std::string const& name) {
     std::cout
-        << name
-        << ": [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] [--transfer] [--validation] "
-           "[--histogram] [--empty]\n\n"
-        << "Options\n"
-        << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
-        << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
-        << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "(default -1 for disabled; conflicts with --maxEvents)\n"
-        << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
-        << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
-        << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
-        << " --histogram         Produce histograms at the end (implies --transfer)\n"
-        << " --empty             Ignore all producers (for testing only)\n"
-        << std::endl;
+        << "Usage: " << name
+        << " [--numberOfThreads NT] [--numberOfStreams NS] [--warmupEvents WE] [--maxEvents ME] [--runForMinutes RM]"
+        << " [--data PATH] [--transfer] [--validation] [--histogram] [--empty]\n";
+    std::cout << R"(
+Options:
+  --numberOfThreads             Number of threads to use (default 1, use 0 to use all CPU cores).
+  --numberOfStreams             Number of concurrent events (default 0 = numberOfThreads).
+  --warmupEvents                Number of events to process before starting the benchmark (default 0).
+  --maxEvents                   Number of events to process (default -1 for all events in the input file).
+  --runForMinutes               Continue processing the set of 1000 events until this many minutes have passed
+                                (default -1 for disabled; conflicts with --maxEvents).
+  --data                        Path to the 'data' directory (default 'data' in the directory of the executable).
+  --transfer                    Transfer results from GPU to CPU (default is to leave them on GPU).
+  --validation                  Run (rudimentary) validation at the end (implies --transfer).
+  --histogram                   Produce histograms at the end (implies --transfer).
+  --empty                       Ignore all producers (for testing only).
+)";
   }
 }  // namespace
 
@@ -43,6 +45,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> args(argv, argv + argc);
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -60,6 +63,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
+    } else if (*i == "--warmupEvents") {
+      ++i;
+      warmupEvents = std::stoi(*i);
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -145,20 +151,45 @@ int main(int argc, char** argv) {
       edmodules.emplace_back("HistoValidator");
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(edmodules),
+                                std::move(esmodules),
+                                datadir,
+                                validation);
 
   if (runForMinutes < 0) {
-    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
-              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
-    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
-              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing for about " << runForMinutes << " minutes,";
   }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
+  }
+  std::cout << " with " << numberOfStreams << " concurrent events and " << numberOfThreads << " threads." << std::endl;
 
-  // Initialize he TBB thread pool
+  // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();

--- a/src/cudadev/test/TrackingRecHit2DCUDA_t.cu
+++ b/src/cudadev/test/TrackingRecHit2DCUDA_t.cu
@@ -6,22 +6,24 @@ namespace testTrackingRecHit2D {
 
   __global__ void fill(TrackingRecHit2DSOAView* phits) {
     assert(phits);
-    auto& hits = *phits;
-    assert(hits.nHits() == 200);
+    assert(phits->nHits() == 200);
 
     int i = threadIdx.x;
     if (i > 200)
       return;
+
+    // FIXME do something ?
   }
 
   __global__ void verify(TrackingRecHit2DSOAView const* phits) {
     assert(phits);
-    auto const& hits = *phits;
-    assert(hits.nHits() == 200);
+    assert(phits->nHits() == 200);
 
     int i = threadIdx.x;
     if (i > 200)
       return;
+
+    // FIXME do something ?
   }
 
   void runKernels(TrackingRecHit2DSOAView* hits) {
@@ -31,12 +33,6 @@ namespace testTrackingRecHit2D {
   }
 
 }  // namespace testTrackingRecHit2D
-
-namespace testTrackingRecHit2D {
-
-  void runKernels(TrackingRecHit2DSOAView* hits);
-
-}
 
 int main() {
   cudaStream_t stream;

--- a/src/cudatest/CUDACore/deviceAllocatorStatus.h
+++ b/src/cudatest/CUDACore/deviceAllocatorStatus.h
@@ -1,6 +1,7 @@
 #ifndef HeterogeneousCore_CUDAUtilities_deviceAllocatorStatus_h
 #define HeterogeneousCore_CUDAUtilities_deviceAllocatorStatus_h
 
+#include <cstddef>
 #include <map>
 
 namespace cms {

--- a/src/cudatest/bin/EventProcessor.cc
+++ b/src/cudatest/bin/EventProcessor.cc
@@ -6,12 +6,13 @@
 
 namespace edm {
   EventProcessor::EventProcessor(int maxEvents,
+                                 int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
@@ -25,6 +26,7 @@ namespace edm {
   }
 
   void EventProcessor::runToCompletion() {
+    source_.startProcessing();
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/cudatest/bin/EventProcessor.cc
+++ b/src/cudatest/bin/EventProcessor.cc
@@ -5,28 +5,48 @@
 #include "EventProcessor.h"
 
 namespace edm {
-  EventProcessor::EventProcessor(int maxEvents,
+  EventProcessor::EventProcessor(int warmupEvents,
+                                 int maxEvents,
                                  int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation),
+        warmupEvents_(warmupEvents),
+        maxEvents_(source_.maxEvents()),
+        runForMinutes_(runForMinutes) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
       esp->produce(eventSetup_);
     }
 
-    //schedules_.reserve(numberOfStreams);
+    schedules_.reserve(numberOfStreams);
     for (int i = 0; i < numberOfStreams; ++i) {
       schedules_.emplace_back(registry_, pluginManager_, &source_, &eventSetup_, i, path);
     }
   }
 
+  void EventProcessor::warmUp() {
+    if (warmupEvents_ <= 0)
+      return;
+
+    // Configure the source for the warmup step
+    source_.reconfigure(warmupEvents_, -1);
+    process();
+  }
+
   void EventProcessor::runToCompletion() {
+    // Configure the source for the actual reconstrction
+    source_.reconfigure(maxEvents_, runForMinutes_);
+    process();
+  }
+
+  void EventProcessor::process() {
     source_.startProcessing();
+
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/cudatest/bin/EventProcessor.h
+++ b/src/cudatest/bin/EventProcessor.h
@@ -15,6 +15,7 @@ namespace edm {
   class EventProcessor {
   public:
     explicit EventProcessor(int maxEvents,
+                            int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
                             std::vector<std::string> const& esproducers,
@@ -22,6 +23,7 @@ namespace edm {
                             bool validation);
 
     int maxEvents() const { return source_.maxEvents(); }
+    int processedEvents() const { return source_.processedEvents(); }
 
     void runToCompletion();
 

--- a/src/cudatest/bin/EventProcessor.h
+++ b/src/cudatest/bin/EventProcessor.h
@@ -14,7 +14,8 @@
 namespace edm {
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
@@ -25,16 +26,21 @@ namespace edm {
     int maxEvents() const { return source_.maxEvents(); }
     int processedEvents() const { return source_.processedEvents(); }
 
+    void warmUp();
     void runToCompletion();
-
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/cudatest/bin/Source.cc
+++ b/src/cudatest/bin/Source.cc
@@ -83,6 +83,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/cudatest/bin/Source.cc
+++ b/src/cudatest/bin/Source.cc
@@ -23,8 +23,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  Source::Source(int maxEvents, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
-      : maxEvents_(maxEvents), numEvents_(0), rawToken_(reg.produces<FEDRawDataCollection>()), validation_(validation) {
+  Source::Source(
+      int maxEvents, int runForMinutes, ProductRegistry &reg, std::filesystem::path const &datadir, bool validation)
+      : maxEvents_(maxEvents),
+        runForMinutes_(runForMinutes),
+        rawToken_(reg.produces<FEDRawDataCollection>()),
+        validation_(validation) {
     std::ifstream in_raw(datadir / "raw.bin", std::ios::binary);
     std::ifstream in_digiclusters;
     std::ifstream in_tracks;
@@ -74,16 +78,46 @@ namespace edm {
       assert(raw_.size() == vertices_.size());
     }
 
-    if (maxEvents_ < 0) {
+    if (runForMinutes_ < 0 and maxEvents_ < 0) {
       maxEvents_ = raw_.size();
     }
   }
 
+  void Source::startProcessing() {
+    if (runForMinutes_ >= 0) {
+      startTime_ = std::chrono::steady_clock::now();
+    }
+  }
+
   std::unique_ptr<Event> Source::produce(int streamId, ProductRegistry const &reg) {
+    if (shouldStop_) {
+      return nullptr;
+    }
+
     const int old = numEvents_.fetch_add(1);
     const int iev = old + 1;
-    if (old >= maxEvents_) {
-      return nullptr;
+    if (runForMinutes_ < 0) {
+      if (old >= maxEvents_) {
+        shouldStop_ = true;
+        --numEvents_;
+        return nullptr;
+      }
+    } else {
+      if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+        std::scoped_lock lock(timeMutex_);
+        // if some other thread beat us, no need to do anything
+        if (numEvents_ - numEventsTimeLastCheck_ > static_cast<int>(raw_.size())) {
+          auto processingTime = std::chrono::steady_clock::now() - startTime_;
+          if (std::chrono::duration_cast<std::chrono::minutes>(processingTime).count() >= runForMinutes_) {
+            shouldStop_ = true;
+          }
+          numEventsTimeLastCheck_ = (numEvents_ / raw_.size()) * raw_.size();
+        }
+        if (shouldStop_) {
+          --numEvents_;
+          return nullptr;
+        }
+      }
     }
     auto ev = std::make_unique<Event>(streamId, iev, reg);
     const int index = old % raw_.size();

--- a/src/cudatest/bin/Source.h
+++ b/src/cudatest/bin/Source.h
@@ -2,9 +2,11 @@
 #define Source_h
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
-#include <string>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "Framework/Event.h"
 #include "DataFormats/FEDRawDataCollection.h"
@@ -15,16 +17,28 @@
 namespace edm {
   class Source {
   public:
-    explicit Source(int maxEvents, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+    explicit Source(
+        int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
+
+    void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
+    int processedEvents() const { return numEvents_; }
 
     // thread safe
     std::unique_ptr<Event> produce(int streamId, ProductRegistry const& reg);
 
   private:
     int maxEvents_;
-    std::atomic<int> numEvents_;
+
+    // these are all for the mode where the processing length is limited by time
+    int const runForMinutes_;
+    std::chrono::steady_clock::time_point startTime_;
+    std::mutex timeMutex_;
+    std::atomic<int> numEventsTimeLastCheck_ = 0;
+    std::atomic<bool> shouldStop_ = false;
+
+    std::atomic<int> numEvents_ = 0;
     EDPutTokenT<FEDRawDataCollection> const rawToken_;
     EDPutTokenT<DigiClusterCount> digiClusterToken_;
     EDPutTokenT<TrackCount> trackToken_;

--- a/src/cudatest/bin/Source.h
+++ b/src/cudatest/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/cudatest/bin/main.cc
+++ b/src/cudatest/bin/main.cc
@@ -20,20 +20,22 @@
 namespace {
   void print_help(std::string const& name) {
     std::cout
-        << name
-        << ": [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] [--transfer] [--validation] "
-           "[--empty]\n\n"
-        << "Options\n"
-        << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
-        << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
-        << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "(default -1 for disabled; conflicts with --maxEvents)\n"
-        << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
-        << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
-        << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
-        << " --empty             Ignore all producers (for testing only)\n"
-        << std::endl;
+        << "Usage: " << name
+        << " [--numberOfThreads NT] [--numberOfStreams NS] [--warmupEvents WE] [--maxEvents ME] [--runForMinutes RM]"
+        << " [--data PATH] [--transfer] [--validation] [--empty]\n";
+    std::cout << R"(
+Options:
+  --numberOfThreads             Number of threads to use (default 1, use 0 to use all CPU cores).
+  --numberOfStreams             Number of concurrent events (default 0 = numberOfThreads).
+  --warmupEvents                Number of events to process before starting the benchmark (default 0).
+  --maxEvents                   Number of events to process (default -1 for all events in the input file).
+  --runForMinutes               Continue processing the set of 1000 events until this many minutes have passed
+                                (default -1 for disabled; conflicts with --maxEvents).
+  --data                        Path to the 'data' directory (default 'data' in the directory of the executable).
+  --transfer                    Transfer results from GPU to CPU (default is to leave them on GPU).
+  --validation                  Run (rudimentary) validation at the end (implies --transfer).
+  --empty                       Ignore all producers (for testing only).
+)";
   }
 }  // namespace
 
@@ -42,6 +44,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> args(argv, argv + argc);
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -58,6 +61,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
+    } else if (*i == "--warmupEvents") {
+      ++i;
+      warmupEvents = std::stoi(*i);
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -125,20 +131,45 @@ int main(int argc, char** argv) {
       // add modules for transfer
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(edmodules),
+                                std::move(esmodules),
+                                datadir,
+                                validation);
 
   if (runForMinutes < 0) {
-    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
-              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
-    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
-              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing for about " << runForMinutes << " minutes,";
   }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
+  }
+  std::cout << " with " << numberOfStreams << " concurrent events and " << numberOfThreads << " threads." << std::endl;
 
-  // Initialize he TBB thread pool
+  // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();

--- a/src/cudauvm/CUDACore/CachingDeviceAllocator.h
+++ b/src/cudauvm/CUDACore/CachingDeviceAllocator.h
@@ -40,8 +40,8 @@
 
 #include <cmath>
 #include <map>
-#include <set>
 #include <mutex>
+#include <set>
 
 #include "CUDACore/cudaCheck.h"
 #include "CUDACore/deviceAllocatorStatus.h"
@@ -335,7 +335,7 @@ namespace notcub {
         cudaStream_t active_stream = nullptr)  ///< [in] The stream to be associated with this allocation
     {
       // CMS: use RAII instead of (un)locking explicitly
-      std::unique_lock<std::mutex> mutex_locker(mutex, std::defer_lock);
+      std::unique_lock mutex_locker(mutex, std::defer_lock);
       *d_ptr = nullptr;
       int entrypoint_device = INVALID_DEVICE_ORDINAL;
       cudaError_t error = cudaSuccess;
@@ -557,7 +557,7 @@ namespace notcub {
       int entrypoint_device = INVALID_DEVICE_ORDINAL;
       cudaError_t error = cudaSuccess;
       // CMS: use RAII instead of (un)locking explicitly
-      std::unique_lock<std::mutex> mutex_locker(mutex, std::defer_lock);
+      std::unique_lock mutex_locker(mutex, std::defer_lock);
 
       if (device == INVALID_DEVICE_ORDINAL) {
         // CMS: throw exception on error
@@ -668,7 +668,7 @@ namespace notcub {
       int entrypoint_device = INVALID_DEVICE_ORDINAL;
       int current_device = INVALID_DEVICE_ORDINAL;
       // CMS: use RAII instead of (un)locking explicitly
-      std::unique_lock<std::mutex> mutex_locker(mutex);
+      std::unique_lock mutex_locker(mutex);
 
       while (!cached_blocks.empty()) {
         // Get first block

--- a/src/cudauvm/CUDACore/CachingHostAllocator.h
+++ b/src/cudauvm/CUDACore/CachingHostAllocator.h
@@ -40,8 +40,8 @@
 
 #include <cmath>
 #include <map>
-#include <set>
 #include <mutex>
+#include <set>
 
 #include "CUDACore/cudaCheck.h"
 
@@ -314,7 +314,7 @@ namespace notcub {
         size_t bytes,                          ///< [in] Minimum number of bytes for the allocation
         cudaStream_t active_stream = nullptr)  ///< [in] The stream to be associated with this allocation
     {
-      std::unique_lock<std::mutex> mutex_locker(mutex, std::defer_lock);
+      std::unique_lock mutex_locker(mutex, std::defer_lock);
       *d_ptr = nullptr;
       int device = INVALID_DEVICE_ORDINAL;
       cudaError_t error = cudaSuccess;
@@ -499,7 +499,7 @@ namespace notcub {
       cudaError_t error = cudaSuccess;
 
       // Lock
-      std::unique_lock<std::mutex> mutex_locker(mutex);
+      std::unique_lock mutex_locker(mutex);
 
       // Find corresponding block descriptor
       bool recached = false;
@@ -581,7 +581,7 @@ namespace notcub {
       int entrypoint_device = INVALID_DEVICE_ORDINAL;
       int current_device = INVALID_DEVICE_ORDINAL;
 
-      std::unique_lock<std::mutex> mutex_locker(mutex);
+      std::unique_lock mutex_locker(mutex);
 
       while (!cached_blocks.empty()) {
         // Get first block

--- a/src/cudauvm/CUDACore/ScopedContext.h
+++ b/src/cudauvm/CUDACore/ScopedContext.h
@@ -227,11 +227,10 @@ namespace cms {
     namespace impl {
       template <typename F>
       void ScopedContextHolderHelper::pushNextTask(F&& f, ContextState const* state) {
-        replaceWaitingTaskHolder(edm::WaitingTaskWithArenaHolder{
-            edm::make_waiting_task_with_holder(std::move(waitingTaskHolder_),
-                                               [state, func = std::forward<F>(f)](edm::WaitingTaskWithArenaHolder h) {
-                                                 func(ScopedContextTask{state, std::move(h)});
-                                               })});
+        replaceWaitingTaskHolder(edm::WaitingTaskWithArenaHolder{edm::make_waiting_task_with_holder(
+            std::move(waitingTaskHolder_), [state, func = std::forward<F>(f)](edm::WaitingTaskWithArenaHolder h) {
+              func(ScopedContextTask{state, std::move(h)});
+            })});
       }
     }  // namespace impl
   }    // namespace cuda

--- a/src/cudauvm/CUDACore/allocate_device.cc
+++ b/src/cudauvm/CUDACore/allocate_device.cc
@@ -1,4 +1,7 @@
+#include <cassert>
 #include <limits>
+
+#include <cuda_runtime.h>
 
 #include "CUDACore/ScopedSetDevice.h"
 #include "CUDACore/allocate_device.h"
@@ -14,12 +17,17 @@ namespace {
 namespace cms::cuda {
   void *allocate_device(int dev, size_t nbytes, cudaStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
+#if CUDA_VERSION >= 11020
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(dev);
+      cudaCheck(cudaMallocAsync(&ptr, nbytes, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(dev);
       cudaCheck(cudaMalloc(&ptr, nbytes));
@@ -27,9 +35,14 @@ namespace cms::cuda {
     return ptr;
   }
 
-  void free_device(int device, void *ptr) {
-    if constexpr (allocator::useCaching) {
+  void free_device(int device, void *ptr, cudaStream_t stream) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceFree(device, ptr));
+#if CUDA_VERSION >= 11020
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(device);
+      cudaCheck(cudaFreeAsync(ptr, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(device);
       cudaCheck(cudaFree(ptr));

--- a/src/cudauvm/CUDACore/allocate_device.h
+++ b/src/cudauvm/CUDACore/allocate_device.h
@@ -6,10 +6,10 @@
 namespace cms {
   namespace cuda {
     // Allocate device memory
-    void *allocate_device(int dev, size_t nbytes, cudaStream_t stream);
+    void *allocate_device(int device, size_t nbytes, cudaStream_t stream);
 
     // Free device memory (to be called from unique_ptr)
-    void free_device(int device, void *ptr);
+    void free_device(int device, void *ptr, cudaStream_t stream);
   }  // namespace cuda
 }  // namespace cms
 

--- a/src/cudauvm/CUDACore/allocate_host.cc
+++ b/src/cudauvm/CUDACore/allocate_host.cc
@@ -13,7 +13,7 @@ namespace {
 namespace cms::cuda {
   void *allocate_host(size_t nbytes, cudaStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
@@ -26,7 +26,7 @@ namespace cms::cuda {
   }
 
   void free_host(void *ptr) {
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingHostAllocator().HostFree(ptr));
     } else {
       cudaCheck(cudaFreeHost(ptr));

--- a/src/cudauvm/CUDACore/allocate_managed.cc
+++ b/src/cudauvm/CUDACore/allocate_managed.cc
@@ -13,7 +13,7 @@ namespace {
 namespace cms::cuda {
   void *allocate_managed(size_t nbytes, cudaStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
@@ -26,7 +26,7 @@ namespace cms::cuda {
   }
 
   void free_managed(void *ptr) {
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingManagedAllocator().ManagedFree(ptr));
     } else {
       cudaCheck(cudaFree(ptr));

--- a/src/cudauvm/CUDACore/deviceAllocatorStatus.h
+++ b/src/cudauvm/CUDACore/deviceAllocatorStatus.h
@@ -1,6 +1,7 @@
 #ifndef HeterogeneousCore_CUDAUtilities_deviceAllocatorStatus_h
 #define HeterogeneousCore_CUDAUtilities_deviceAllocatorStatus_h
 
+#include <cstddef>
 #include <map>
 
 namespace cms {

--- a/src/cudauvm/CUDACore/device_unique_ptr.h
+++ b/src/cudauvm/CUDACore/device_unique_ptr.h
@@ -1,8 +1,10 @@
 #ifndef HeterogeneousCore_CUDAUtilities_interface_device_unique_ptr_h
 #define HeterogeneousCore_CUDAUtilities_interface_device_unique_ptr_h
 
-#include <memory>
 #include <functional>
+#include <memory>
+
+#include <cuda_runtime.h>
 
 #include "CUDACore/allocate_device.h"
 #include "CUDACore/currentDevice.h"
@@ -15,16 +17,17 @@ namespace cms {
         class DeviceDeleter {
         public:
           DeviceDeleter() = default;  // for edm::Wrapper
-          DeviceDeleter(int device) : device_{device} {}
+          DeviceDeleter(int device, cudaStream_t stream) : device_{device}, stream_{stream} {}
 
           void operator()(void *ptr) {
             if (device_ >= 0) {
-              free_device(device_, ptr);
+              free_device(device_, ptr, stream_);
             }
           }
 
         private:
           int device_ = -1;
+          cudaStream_t stream_ = cudaStreamDefault;
         };
       }  // namespace impl
 
@@ -54,7 +57,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, sizeof(T), stream);
       return typename device::impl::make_device_unique_selector<T>::non_array{reinterpret_cast<T *>(mem),
-                                                                              device::impl::DeviceDeleter{dev}};
+                                                                              device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T>
@@ -66,7 +69,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, n * sizeof(element_type), stream);
       return typename device::impl::make_device_unique_selector<T>::unbounded_array{
-          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev}};
+          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T, typename... Args>
@@ -79,7 +82,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, sizeof(T), stream);
       return typename device::impl::make_device_unique_selector<T>::non_array{reinterpret_cast<T *>(mem),
-                                                                              device::impl::DeviceDeleter{dev}};
+                                                                              device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T>
@@ -89,7 +92,7 @@ namespace cms {
       int dev = currentDevice();
       void *mem = allocate_device(dev, n * sizeof(element_type), stream);
       return typename device::impl::make_device_unique_selector<T>::unbounded_array{
-          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev}};
+          reinterpret_cast<element_type *>(mem), device::impl::DeviceDeleter{dev, stream}};
     }
 
     template <typename T, typename... Args>

--- a/src/cudauvm/CUDACore/getCachingDeviceAllocator.h
+++ b/src/cudauvm/CUDACore/getCachingDeviceAllocator.h
@@ -4,16 +4,21 @@
 #include <iomanip>
 #include <iostream>
 
+#include <cuda_runtime.h>
+
 #include "CUDACore/cudaCheck.h"
 #include "CUDACore/deviceCount.h"
 #include "CachingDeviceAllocator.h"
 
 namespace cms::cuda::allocator {
   // Use caching or not
-#ifdef CUDAUVM_DISABLE_CACHING_ALLOCATOR
-  constexpr bool useCaching = false;
+  enum class Policy { Synchronous = 0, Asynchronous = 1, Caching = 2 };
+#ifndef CUDAUVM_DISABLE_CACHING_ALLOCATOR
+  constexpr Policy policy = Policy::Caching;
+#elif CUDA_VERSION >= 11020 && !defined CUDAUVM_DISABLE_ASYNC_ALLOCATOR
+  constexpr Policy policy = Policy::Asynchronous;
 #else
-  constexpr bool useCaching = true;
+  constexpr Policy policy = Policy::Synchronous;
 #endif
   // Growth factor (bin_growth in cub::CachingDeviceAllocator
   constexpr unsigned int binGrowth = 2;

--- a/src/cudauvm/DataFormats/SiPixelDigisSoA.h
+++ b/src/cudauvm/DataFormats/SiPixelDigisSoA.h
@@ -1,6 +1,7 @@
 #ifndef DataFormats_SiPixelDigi_interface_SiPixelDigisSoA_h
 #define DataFormats_SiPixelDigi_interface_SiPixelDigisSoA_h
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 

--- a/src/cudauvm/bin/EventProcessor.cc
+++ b/src/cudauvm/bin/EventProcessor.cc
@@ -5,28 +5,48 @@
 #include "EventProcessor.h"
 
 namespace edm {
-  EventProcessor::EventProcessor(int maxEvents,
+  EventProcessor::EventProcessor(int warmupEvents,
+                                 int maxEvents,
                                  int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation),
+        warmupEvents_(warmupEvents),
+        maxEvents_(source_.maxEvents()),
+        runForMinutes_(runForMinutes) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
       esp->produce(eventSetup_);
     }
 
-    //schedules_.reserve(numberOfStreams);
+    schedules_.reserve(numberOfStreams);
     for (int i = 0; i < numberOfStreams; ++i) {
       schedules_.emplace_back(registry_, pluginManager_, &source_, &eventSetup_, i, path);
     }
   }
 
+  void EventProcessor::warmUp() {
+    if (warmupEvents_ <= 0)
+      return;
+
+    // Configure the source for the warmup step
+    source_.reconfigure(warmupEvents_, -1);
+    process();
+  }
+
   void EventProcessor::runToCompletion() {
+    // Configure the source for the actual reconstrction
+    source_.reconfigure(maxEvents_, runForMinutes_);
+    process();
+  }
+
+  void EventProcessor::process() {
     source_.startProcessing();
+
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/cudauvm/bin/EventProcessor.h
+++ b/src/cudauvm/bin/EventProcessor.h
@@ -14,7 +14,8 @@
 namespace edm {
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
@@ -25,16 +26,21 @@ namespace edm {
     int maxEvents() const { return source_.maxEvents(); }
     int processedEvents() const { return source_.processedEvents(); }
 
+    void warmUp();
     void runToCompletion();
-
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/cudauvm/bin/Source.cc
+++ b/src/cudauvm/bin/Source.cc
@@ -83,6 +83,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/cudauvm/bin/Source.h
+++ b/src/cudauvm/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/cudauvm/bin/main.cc
+++ b/src/cudauvm/bin/main.cc
@@ -19,21 +19,23 @@
 namespace {
   void print_help(std::string const& name) {
     std::cout
-        << name
-        << ": [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] [--transfer] [--validation] "
-           "[--histogram] [--empty]\n\n"
-        << "Options\n"
-        << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
-        << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
-        << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "(default -1 for disabled; conflicts with --maxEvents)\n"
-        << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
-        << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
-        << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
-        << " --histogram         Produce histograms at the end (implies --transfer)\n"
-        << " --empty             Ignore all producers (for testing only)\n"
-        << std::endl;
+        << "Usage: " << name
+        << " [--numberOfThreads NT] [--numberOfStreams NS] [--warmupEvents WE] [--maxEvents ME] [--runForMinutes RM]"
+        << " [--data PATH] [--transfer] [--validation] [--histogram] [--empty]\n";
+    std::cout << R"(
+Options:
+  --numberOfThreads             Number of threads to use (default 1, use 0 to use all CPU cores).
+  --numberOfStreams             Number of concurrent events (default 0 = numberOfThreads).
+  --warmupEvents                Number of events to process before starting the benchmark (default 0).
+  --maxEvents                   Number of events to process (default -1 for all events in the input file).
+  --runForMinutes               Continue processing the set of 1000 events until this many minutes have passed
+                                (default -1 for disabled; conflicts with --maxEvents).
+  --data                        Path to the 'data' directory (default 'data' in the directory of the executable).
+  --transfer                    Transfer results from GPU to CPU (default is to leave them on GPU).
+  --validation                  Run (rudimentary) validation at the end (implies --transfer).
+  --histogram                   Produce histograms at the end (implies --transfer).
+  --empty                       Ignore all producers (for testing only).
+)";
   }
 }  // namespace
 
@@ -42,6 +44,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> args(argv, argv + argc);
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -59,6 +62,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
+    } else if (*i == "--warmupEvents") {
+      ++i;
+      warmupEvents = std::stoi(*i);
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -144,20 +150,45 @@ int main(int argc, char** argv) {
       edmodules.emplace_back("HistoValidator");
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(edmodules),
+                                std::move(esmodules),
+                                datadir,
+                                validation);
 
   if (runForMinutes < 0) {
-    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
-              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
-    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
-              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing for about " << runForMinutes << " minutes,";
   }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
+  }
+  std::cout << " with " << numberOfStreams << " concurrent events and " << numberOfThreads << " threads." << std::endl;
 
-  // Initialize he TBB thread pool
+  // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();

--- a/src/cudauvm/test/TrackingRecHit2DCUDA_t.cu
+++ b/src/cudauvm/test/TrackingRecHit2DCUDA_t.cu
@@ -6,22 +6,24 @@ namespace testTrackingRecHit2D {
 
   __global__ void fill(TrackingRecHit2DSOAView* phits) {
     assert(phits);
-    auto& hits = *phits;
-    assert(hits.nHits() == 200);
+    assert(phits->nHits() == 200);
 
     int i = threadIdx.x;
     if (i > 200)
       return;
+
+    // FIXME do something ?
   }
 
   __global__ void verify(TrackingRecHit2DSOAView const* phits) {
     assert(phits);
-    auto const& hits = *phits;
-    assert(hits.nHits() == 200);
+    assert(phits->nHits() == 200);
 
     int i = threadIdx.x;
     if (i > 200)
       return;
+
+    // FIXME do something ?
   }
 
   void runKernels(TrackingRecHit2DSOAView* hits) {
@@ -31,12 +33,6 @@ namespace testTrackingRecHit2D {
   }
 
 }  // namespace testTrackingRecHit2D
-
-namespace testTrackingRecHit2D {
-
-  void runKernels(TrackingRecHit2DSOAView* hits);
-
-}
 
 int main() {
   cudaStream_t stream;

--- a/src/fwtest/bin/EventProcessor.cc
+++ b/src/fwtest/bin/EventProcessor.cc
@@ -5,28 +5,48 @@
 #include "EventProcessor.h"
 
 namespace edm {
-  EventProcessor::EventProcessor(int maxEvents,
+  EventProcessor::EventProcessor(int warmupEvents,
+                                 int maxEvents,
                                  int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation),
+        warmupEvents_(warmupEvents),
+        maxEvents_(source_.maxEvents()),
+        runForMinutes_(runForMinutes) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
       esp->produce(eventSetup_);
     }
 
-    //schedules_.reserve(numberOfStreams);
+    schedules_.reserve(numberOfStreams);
     for (int i = 0; i < numberOfStreams; ++i) {
       schedules_.emplace_back(registry_, pluginManager_, &source_, &eventSetup_, i, path);
     }
   }
 
+  void EventProcessor::warmUp() {
+    if (warmupEvents_ <= 0)
+      return;
+
+    // Configure the source for the warmup step
+    source_.reconfigure(warmupEvents_, -1);
+    process();
+  }
+
   void EventProcessor::runToCompletion() {
+    // Configure the source for the actual reconstrction
+    source_.reconfigure(maxEvents_, runForMinutes_);
+    process();
+  }
+
+  void EventProcessor::process() {
     source_.startProcessing();
+
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/fwtest/bin/EventProcessor.h
+++ b/src/fwtest/bin/EventProcessor.h
@@ -14,7 +14,8 @@
 namespace edm {
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
@@ -25,16 +26,21 @@ namespace edm {
     int maxEvents() const { return source_.maxEvents(); }
     int processedEvents() const { return source_.processedEvents(); }
 
+    void warmUp();
     void runToCompletion();
-
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/fwtest/bin/Source.cc
+++ b/src/fwtest/bin/Source.cc
@@ -83,6 +83,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/fwtest/bin/Source.h
+++ b/src/fwtest/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/fwtest/bin/main.cc
+++ b/src/fwtest/bin/main.cc
@@ -16,20 +16,22 @@
 namespace {
   void print_help(std::string const& name) {
     std::cout
-        << name
-        << ": [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] [--transfer] [--validation] "
-           "[--empty]\n\n"
-        << "Options\n"
-        << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
-        << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
-        << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "(default -1 for disabled; conflicts with --maxEvents)\n"
-        << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
-        << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
-        << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
-        << " --empty             Ignore all producers (for testing only)\n"
-        << std::endl;
+        << "Usage: " << name
+        << " [--numberOfThreads NT] [--numberOfStreams NS] [--warmupEvents WE] [--maxEvents ME] [--runForMinutes RM]"
+        << " [--data PATH] [--transfer] [--validation] [--empty]\n";
+    std::cout << R"(
+Options:
+  --numberOfThreads             Number of threads to use (default 1, use 0 to use all CPU cores).
+  --numberOfStreams             Number of concurrent events (default 0 = numberOfThreads).
+  --warmupEvents                Number of events to process before starting the benchmark (default 0).
+  --maxEvents                   Number of events to process (default -1 for all events in the input file).
+  --runForMinutes               Continue processing the set of 1000 events until this many minutes have passed
+                                (default -1 for disabled; conflicts with --maxEvents).
+  --data                        Path to the 'data' directory (default 'data' in the directory of the executable).
+  --transfer                    Transfer results from GPU to CPU (default is to leave them on GPU)\n"
+  --validation                  Run (rudimentary) validation at the end (implies --transfer)\n"
+  --empty                       Ignore all producers (for testing only).
+)";
   }
 }  // namespace
 
@@ -38,6 +40,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> args(argv, argv + argc);
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -54,6 +57,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
+    } else if (*i == "--warmupEvents") {
+      ++i;
+      warmupEvents = std::stoi(*i);
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -104,20 +110,45 @@ int main(int argc, char** argv) {
       // add modules for transfer
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(edmodules),
+                                std::move(esmodules),
+                                datadir,
+                                validation);
 
   if (runForMinutes < 0) {
-    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
-              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
-    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
-              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing for about " << runForMinutes << " minutes,";
   }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
+  }
+  std::cout << " with " << numberOfStreams << " concurrent events and " << numberOfThreads << " threads." << std::endl;
 
-  // Initialize he TBB thread pool
+  // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();

--- a/src/hip/CUDACore/allocate_device.cc
+++ b/src/hip/CUDACore/allocate_device.cc
@@ -1,4 +1,7 @@
+#include <cassert>
 #include <limits>
+
+#include <hip/hip_runtime.h>
 
 #include "CUDACore/ScopedSetDevice.h"
 #include "CUDACore/allocate_device.h"
@@ -14,12 +17,17 @@ namespace {
 namespace cms::hip {
   void *allocate_device(int dev, size_t nbytes, hipStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
+#if HIP_VERSION >= 50200000
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(dev);
+      cudaCheck(hipMallocAsync(&ptr, nbytes, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(dev);
       cudaCheck(hipMalloc(&ptr, nbytes));
@@ -27,9 +35,14 @@ namespace cms::hip {
     return ptr;
   }
 
-  void free_device(int device, void *ptr) {
-    if constexpr (allocator::useCaching) {
+  void free_device(int device, void *ptr, hipStream_t stream) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceFree(device, ptr));
+#if HIP_VERSION >= 50200000
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(device);
+      cudaCheck(hipFreeAsync(ptr, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(device);
       cudaCheck(hipFree(ptr));

--- a/src/hip/CUDACore/allocate_device.h
+++ b/src/hip/CUDACore/allocate_device.h
@@ -6,10 +6,10 @@
 namespace cms {
   namespace hip {
     // Allocate device memory
-    void *allocate_device(int dev, size_t nbytes, hipStream_t stream);
+    void *allocate_device(int device, size_t nbytes, hipStream_t stream);
 
     // Free device memory (to be called from unique_ptr)
-    void free_device(int device, void *ptr);
+    void free_device(int device, void *ptr, hipStream_t stream);
   }  // namespace hip
 }  // namespace cms
 

--- a/src/hip/CUDACore/allocate_host.cc
+++ b/src/hip/CUDACore/allocate_host.cc
@@ -13,7 +13,7 @@ namespace {
 namespace cms::hip {
   void *allocate_host(size_t nbytes, hipStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
@@ -26,7 +26,7 @@ namespace cms::hip {
   }
 
   void free_host(void *ptr) {
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingHostAllocator().HostFree(ptr));
     } else {
       cudaCheck(hipHostFree(ptr));

--- a/src/hip/CUDACore/getCachingDeviceAllocator.h
+++ b/src/hip/CUDACore/getCachingDeviceAllocator.h
@@ -4,13 +4,22 @@
 #include <iomanip>
 #include <iostream>
 
+#include <hip/hip_runtime.h>
+
 #include "CUDACore/cudaCheck.h"
 #include "CUDACore/deviceCount.h"
 #include "CachingDeviceAllocator.h"
 
 namespace cms::hip::allocator {
   // Use caching or not
-  constexpr bool useCaching = true;
+  enum class Policy { Synchronous = 0, Asynchronous = 1, Caching = 2 };
+#ifndef HIP_DISABLE_CACHING_ALLOCATOR
+  constexpr Policy policy = Policy::Caching;
+#elif HIP_VERSION >= 50200000 && !defined HIP_DISABLE_ASYNC_ALLOCATOR
+  constexpr Policy policy = Policy::Asynchronous;
+#else
+  constexpr Policy policy = Policy::Synchronous;
+#endif
   // Growth factor (bin_growth in hipcub::CachingDeviceAllocator
   constexpr unsigned int binGrowth = 2;
   // Smallest bin, corresponds to binGrowth^minBin bytes (min_bin in hipcub::CacingDeviceAllocator

--- a/src/hip/bin/EventProcessor.cc
+++ b/src/hip/bin/EventProcessor.cc
@@ -5,28 +5,48 @@
 #include "EventProcessor.h"
 
 namespace edm {
-  EventProcessor::EventProcessor(int maxEvents,
+  EventProcessor::EventProcessor(int warmupEvents,
+                                 int maxEvents,
                                  int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation),
+        warmupEvents_(warmupEvents),
+        maxEvents_(source_.maxEvents()),
+        runForMinutes_(runForMinutes) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
       esp->produce(eventSetup_);
     }
 
-    //schedules_.reserve(numberOfStreams);
+    schedules_.reserve(numberOfStreams);
     for (int i = 0; i < numberOfStreams; ++i) {
       schedules_.emplace_back(registry_, pluginManager_, &source_, &eventSetup_, i, path);
     }
   }
 
+  void EventProcessor::warmUp() {
+    if (warmupEvents_ <= 0)
+      return;
+
+    // Configure the source for the warmup step
+    source_.reconfigure(warmupEvents_, -1);
+    process();
+  }
+
   void EventProcessor::runToCompletion() {
+    // Configure the source for the actual reconstrction
+    source_.reconfigure(maxEvents_, runForMinutes_);
+    process();
+  }
+
+  void EventProcessor::process() {
     source_.startProcessing();
+
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/hip/bin/EventProcessor.h
+++ b/src/hip/bin/EventProcessor.h
@@ -14,7 +14,8 @@
 namespace edm {
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
@@ -25,16 +26,21 @@ namespace edm {
     int maxEvents() const { return source_.maxEvents(); }
     int processedEvents() const { return source_.processedEvents(); }
 
+    void warmUp();
     void runToCompletion();
-
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/hip/bin/Source.cc
+++ b/src/hip/bin/Source.cc
@@ -83,6 +83,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/hip/bin/Source.h
+++ b/src/hip/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/hip/bin/main.cc
+++ b/src/hip/bin/main.cc
@@ -13,27 +13,30 @@
 
 #include <hip/hip_runtime.h>
 
+#include "CUDACore/getCachingDeviceAllocator.h"
 #include "EventProcessor.h"
 #include "PosixClockGettime.h"
 
 namespace {
   void print_help(std::string const& name) {
     std::cout
-        << name
-        << ": [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] [--transfer] [--validation] "
-           "[--histogram] [--empty]\n\n"
-        << "Options\n"
-        << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
-        << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
-        << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "(default -1 for disabled; conflicts with --maxEvents)\n"
-        << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
-        << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
-        << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
-        << " --histogram         Produce histograms at the end (implies --transfer)\n"
-        << " --empty             Ignore all producers (for testing only)\n"
-        << std::endl;
+        << "Usage: " << name
+        << " [--numberOfThreads NT] [--numberOfStreams NS] [--warmupEvents WE] [--maxEvents ME] [--runForMinutes RM]"
+        << " [--data PATH] [--transfer] [--validation] [--histogram] [--empty]\n";
+    std::cout << R"(
+Options:
+  --numberOfThreads             Number of threads to use (default 1, use 0 to use all CPU cores).
+  --numberOfStreams             Number of concurrent events (default 0 = numberOfThreads).
+  --warmupEvents                Number of events to process before starting the benchmark (default 0).
+  --maxEvents                   Number of events to process (default -1 for all events in the input file).
+  --runForMinutes               Continue processing the set of 1000 events until this many minutes have passed
+                                (default -1 for disabled; conflicts with --maxEvents).
+  --data                        Path to the 'data' directory (default 'data' in the directory of the executable).
+  --transfer                    Transfer results from GPU to CPU (default is to leave them on GPU).
+  --validation                  Run (rudimentary) validation at the end (implies --transfer).
+  --histogram                   Produce histograms at the end (implies --transfer).
+  --empty                       Ignore all producers (for testing only).
+)";
   }
 }  // namespace
 
@@ -42,6 +45,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> args(argv, argv + argc);
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -59,6 +63,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
+    } else if (*i == "--warmupEvents") {
+      ++i;
+      warmupEvents = std::stoi(*i);
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -134,20 +141,45 @@ int main(int argc, char** argv) {
       edmodules.emplace_back("HistoValidator");
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(edmodules),
+                                std::move(esmodules),
+                                datadir,
+                                validation);
 
   if (runForMinutes < 0) {
-    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
-              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
-    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
-              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing for about " << runForMinutes << " minutes,";
   }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
+  }
+  std::cout << " with " << numberOfStreams << " concurrent events and " << numberOfThreads << " threads." << std::endl;
 
-  // Initialize he TBB thread pool
+  // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();

--- a/src/hip/bin/main.cc
+++ b/src/hip/bin/main.cc
@@ -111,10 +111,20 @@ int main(int argc, char** argv) {
   int numberOfDevices;
   auto status = hipGetDeviceCount(&numberOfDevices);
   if (hipSuccess != status) {
-    std::cout << "Failed to initialize the CUDA runtime";
+    std::cout << "Failed to initialize the HIP runtime";
     return EXIT_FAILURE;
   }
   std::cout << "Found " << numberOfDevices << " devices" << std::endl;
+
+#if HIP_VERSION >= 50200000
+  // Initialize the HIP memory pool
+  uint64_t threshold = cms::hip::allocator::minCachedBytes();
+  for (int device = 0; device < numberOfDevices; ++device) {
+    hipMemPool_t pool;
+    hipDeviceGetDefaultMemPool(&pool, device);
+    hipMemPoolSetAttribute(pool, hipMemPoolAttrReleaseThreshold, &threshold);
+  }
+#endif
 
   // Initialize EventProcessor
   std::vector<std::string> edmodules;

--- a/src/hip/plugin-PixelTriplets/CAHitNtupletGeneratorKernelsImpl.h
+++ b/src/hip/plugin-PixelTriplets/CAHitNtupletGeneratorKernelsImpl.h
@@ -463,7 +463,7 @@ __global__ void kernel_fillHitDetIndices(HitContainer const *__restrict__ tuples
   }
   // fill hit indices
   auto const &hh = *hhp;
-  auto nhits = hh.nHits();
+  auto const nhits [[maybe_unused]] = hh.nHits();
   for (int idx = first, ntot = tuples->size(); idx < ntot; idx += gridDim.x * blockDim.x) {
     assert(tuples->bins[idx] < nhits);
     hitDetIndices->bins[idx] = hh.detectorIndex(tuples->bins[idx]);

--- a/src/hip/plugin-PixelTriplets/CAHitNtupletGeneratorOnGPU.cc
+++ b/src/hip/plugin-PixelTriplets/CAHitNtupletGeneratorOnGPU.cc
@@ -97,7 +97,7 @@ CAHitNtupletGeneratorOnGPU::~CAHitNtupletGeneratorOnGPU() {
       // crash on multi-gpu processes
       CAHitNtupletGeneratorKernelsGPU::printCounters(m_counters);
     }
-    hipFree(m_counters);
+    (void)hipFree(m_counters);
   } else {
     if (m_params.doStats_) {
       CAHitNtupletGeneratorKernelsCPU::printCounters(m_counters);

--- a/src/hip/plugin-PixelTriplets/gpuPixelDoublets.h
+++ b/src/hip/plugin-PixelTriplets/gpuPixelDoublets.h
@@ -78,11 +78,9 @@ namespace gpuPixelDoublets {
     if (0 == first) {
       cellNeighbors->construct(CAConstants::maxNumOfActiveDoublets(), cellNeighborsContainer);
       cellTracks->construct(CAConstants::maxNumOfActiveDoublets(), cellTracksContainer);
-      auto i = cellNeighbors->extend();
-      assert(0 == i);
+      assert(0 == cellNeighbors->extend());
       (*cellNeighbors)[0].reset();
-      i = cellTracks->extend();
-      assert(0 == i);
+      assert(0 == cellTracks->extend());
       (*cellTracks)[0].reset();
     }
   }

--- a/src/hiptest/CUDACore/allocate_device.cc
+++ b/src/hiptest/CUDACore/allocate_device.cc
@@ -1,4 +1,7 @@
+#include <cassert>
 #include <limits>
+
+#include <hip/hip_runtime.h>
 
 #include "CUDACore/ScopedSetDevice.h"
 #include "CUDACore/allocate_device.h"
@@ -14,12 +17,17 @@ namespace {
 namespace cms::hip {
   void *allocate_device(int dev, size_t nbytes, hipStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
+#if HIP_VERSION >= 50200000
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(dev);
+      cudaCheck(hipMallocAsync(&ptr, nbytes, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(dev);
       cudaCheck(hipMalloc(&ptr, nbytes));
@@ -27,9 +35,14 @@ namespace cms::hip {
     return ptr;
   }
 
-  void free_device(int device, void *ptr) {
-    if constexpr (allocator::useCaching) {
+  void free_device(int device, void *ptr, hipStream_t stream) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingDeviceAllocator().DeviceFree(device, ptr));
+#if HIP_VERSION >= 50200000
+    } else if constexpr (allocator::policy == allocator::Policy::Asynchronous) {
+      ScopedSetDevice setDeviceForThisScope(device);
+      cudaCheck(hipFreeAsync(ptr, stream));
+#endif
     } else {
       ScopedSetDevice setDeviceForThisScope(device);
       cudaCheck(hipFree(ptr));

--- a/src/hiptest/CUDACore/allocate_device.h
+++ b/src/hiptest/CUDACore/allocate_device.h
@@ -6,10 +6,10 @@
 namespace cms {
   namespace hip {
     // Allocate device memory
-    void *allocate_device(int dev, size_t nbytes, hipStream_t stream);
+    void *allocate_device(int device, size_t nbytes, hipStream_t stream);
 
     // Free device memory (to be called from unique_ptr)
-    void free_device(int device, void *ptr);
+    void free_device(int device, void *ptr, hipStream_t stream);
   }  // namespace hip
 }  // namespace cms
 

--- a/src/hiptest/CUDACore/allocate_host.cc
+++ b/src/hiptest/CUDACore/allocate_host.cc
@@ -13,7 +13,7 @@ namespace {
 namespace cms::hip {
   void *allocate_host(size_t nbytes, hipStream_t stream) {
     void *ptr = nullptr;
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       if (nbytes > maxAllocationSize) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
@@ -26,7 +26,7 @@ namespace cms::hip {
   }
 
   void free_host(void *ptr) {
-    if constexpr (allocator::useCaching) {
+    if constexpr (allocator::policy == allocator::Policy::Caching) {
       cudaCheck(allocator::getCachingHostAllocator().HostFree(ptr));
     } else {
       cudaCheck(hipHostFree(ptr));

--- a/src/hiptest/CUDACore/getCachingDeviceAllocator.h
+++ b/src/hiptest/CUDACore/getCachingDeviceAllocator.h
@@ -4,13 +4,22 @@
 #include <iomanip>
 #include <iostream>
 
+#include <hip/hip_runtime.h>
+
 #include "CUDACore/cudaCheck.h"
 #include "CUDACore/deviceCount.h"
 #include "CachingDeviceAllocator.h"
 
 namespace cms::hip::allocator {
   // Use caching or not
-  constexpr bool useCaching = true;
+  enum class Policy { Synchronous = 0, Asynchronous = 1, Caching = 2 };
+#ifndef HIPTEST_DISABLE_CACHING_ALLOCATOR
+  constexpr Policy policy = Policy::Caching;
+#elif HIP_VERSION >= 50200000 && !defined HIPTEST_DISABLE_ASYNC_ALLOCATOR
+  constexpr Policy policy = Policy::Asynchronous;
+#else
+  constexpr Policy policy = Policy::Synchronous;
+#endif
   // Growth factor (bin_growth in hipcub::CachingDeviceAllocator
   constexpr unsigned int binGrowth = 2;
   // Smallest bin, corresponds to binGrowth^minBin bytes (min_bin in hipcub::CacingDeviceAllocator

--- a/src/hiptest/bin/EventProcessor.cc
+++ b/src/hiptest/bin/EventProcessor.cc
@@ -5,28 +5,48 @@
 #include "EventProcessor.h"
 
 namespace edm {
-  EventProcessor::EventProcessor(int maxEvents,
+  EventProcessor::EventProcessor(int warmupEvents,
+                                 int maxEvents,
                                  int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation),
+        warmupEvents_(warmupEvents),
+        maxEvents_(source_.maxEvents()),
+        runForMinutes_(runForMinutes) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
       esp->produce(eventSetup_);
     }
 
-    //schedules_.reserve(numberOfStreams);
+    schedules_.reserve(numberOfStreams);
     for (int i = 0; i < numberOfStreams; ++i) {
       schedules_.emplace_back(registry_, pluginManager_, &source_, &eventSetup_, i, path);
     }
   }
 
+  void EventProcessor::warmUp() {
+    if (warmupEvents_ <= 0)
+      return;
+
+    // Configure the source for the warmup step
+    source_.reconfigure(warmupEvents_, -1);
+    process();
+  }
+
   void EventProcessor::runToCompletion() {
+    // Configure the source for the actual reconstrction
+    source_.reconfigure(maxEvents_, runForMinutes_);
+    process();
+  }
+
+  void EventProcessor::process() {
     source_.startProcessing();
+
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/hiptest/bin/EventProcessor.h
+++ b/src/hiptest/bin/EventProcessor.h
@@ -14,7 +14,8 @@
 namespace edm {
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
@@ -25,16 +26,21 @@ namespace edm {
     int maxEvents() const { return source_.maxEvents(); }
     int processedEvents() const { return source_.processedEvents(); }
 
+    void warmUp();
     void runToCompletion();
-
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/hiptest/bin/Source.cc
+++ b/src/hiptest/bin/Source.cc
@@ -83,6 +83,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/hiptest/bin/Source.h
+++ b/src/hiptest/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/hiptest/bin/main.cc
+++ b/src/hiptest/bin/main.cc
@@ -18,20 +18,22 @@
 namespace {
   void print_help(std::string const& name) {
     std::cout
-        << name
-        << ": [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] [--transfer] [--validation] "
-           "[--empty]\n\n"
-        << "Options\n"
-        << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
-        << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
-        << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "(default -1 for disabled; conflicts with --maxEvents)\n"
-        << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
-        << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
-        << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
-        << " --empty             Ignore all producers (for testing only)\n"
-        << std::endl;
+        << "Usage: " << name
+        << " [--numberOfThreads NT] [--numberOfStreams NS] [--warmupEvents WE] [--maxEvents ME] [--runForMinutes RM]"
+        << " [--data PATH] [--transfer] [--validation] [--empty]\n";
+    std::cout << R"(
+Options:
+  --numberOfThreads             Number of threads to use (default 1, use 0 to use all CPU cores).
+  --numberOfStreams             Number of concurrent events (default 0 = numberOfThreads).
+  --warmupEvents                Number of events to process before starting the benchmark (default 0).
+  --maxEvents                   Number of events to process (default -1 for all events in the input file).
+  --runForMinutes               Continue processing the set of 1000 events until this many minutes have passed
+                                (default -1 for disabled; conflicts with --maxEvents).
+  --data                        Path to the 'data' directory (default 'data' in the directory of the executable).
+  --transfer                    Transfer results from GPU to CPU (default is to leave them on GPU).
+  --validation                  Run (rudimentary) validation at the end (implies --transfer).
+  --empty                       Ignore all producers (for testing only).
+)";
   }
 }  // namespace
 
@@ -40,6 +42,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> args(argv, argv + argc);
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -56,6 +59,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
+    } else if (*i == "--warmupEvents") {
+      ++i;
+      warmupEvents = std::stoi(*i);
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -113,20 +119,45 @@ int main(int argc, char** argv) {
       // add modules for transfer
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(edmodules),
+                                std::move(esmodules),
+                                datadir,
+                                validation);
 
   if (runForMinutes < 0) {
-    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
-              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
-    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
-              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing for about " << runForMinutes << " minutes,";
   }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
+  }
+  std::cout << " with " << numberOfStreams << " concurrent events and " << numberOfThreads << " threads." << std::endl;
 
-  // Initialize he TBB thread pool
+  // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();

--- a/src/hiptest/bin/main.cc
+++ b/src/hiptest/bin/main.cc
@@ -12,6 +12,7 @@
 
 #include <hip/hip_runtime.h>
 
+#include "CUDACore/getCachingDeviceAllocator.h"
 #include "EventProcessor.h"
 #include "PosixClockGettime.h"
 
@@ -104,10 +105,20 @@ int main(int argc, char** argv) {
   int numberOfDevices;
   auto status = hipGetDeviceCount(&numberOfDevices);
   if (hipSuccess != status) {
-    std::cout << "Failed to initialize the CUDA runtime";
+    std::cout << "Failed to initialize the HIP runtime";
     return EXIT_FAILURE;
   }
   std::cout << "Found " << numberOfDevices << " devices" << std::endl;
+
+#if HIP_VERSION >= 50200000
+  // Initialize the HIP memory pool
+  uint64_t threshold = cms::hip::allocator::minCachedBytes();
+  for (int device = 0; device < numberOfDevices; ++device) {
+    hipMemPool_t pool;
+    hipDeviceGetDefaultMemPool(&pool, device);
+    hipMemPoolSetAttribute(pool, hipMemPoolAttrReleaseThreshold, &threshold);
+  }
+#endif
 
   // Initialize EventProcessor
   std::vector<std::string> edmodules;

--- a/src/serial/bin/EventProcessor.cc
+++ b/src/serial/bin/EventProcessor.cc
@@ -5,28 +5,48 @@
 #include "EventProcessor.h"
 
 namespace edm {
-  EventProcessor::EventProcessor(int maxEvents,
+  EventProcessor::EventProcessor(int warmupEvents,
+                                 int maxEvents,
                                  int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation),
+        warmupEvents_(warmupEvents),
+        maxEvents_(source_.maxEvents()),
+        runForMinutes_(runForMinutes) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
       esp->produce(eventSetup_);
     }
 
-    //schedules_.reserve(numberOfStreams);
+    schedules_.reserve(numberOfStreams);
     for (int i = 0; i < numberOfStreams; ++i) {
       schedules_.emplace_back(registry_, pluginManager_, &source_, &eventSetup_, i, path);
     }
   }
 
+  void EventProcessor::warmUp() {
+    if (warmupEvents_ <= 0)
+      return;
+
+    // Configure the source for the warmup step
+    source_.reconfigure(warmupEvents_, -1);
+    process();
+  }
+
   void EventProcessor::runToCompletion() {
+    // Configure the source for the actual reconstrction
+    source_.reconfigure(maxEvents_, runForMinutes_);
+    process();
+  }
+
+  void EventProcessor::process() {
     source_.startProcessing();
+
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/serial/bin/EventProcessor.h
+++ b/src/serial/bin/EventProcessor.h
@@ -14,7 +14,8 @@
 namespace edm {
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
@@ -25,16 +26,21 @@ namespace edm {
     int maxEvents() const { return source_.maxEvents(); }
     int processedEvents() const { return source_.processedEvents(); }
 
+    void warmUp();
     void runToCompletion();
-
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/serial/bin/Source.cc
+++ b/src/serial/bin/Source.cc
@@ -83,6 +83,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/serial/bin/Source.h
+++ b/src/serial/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/serial/bin/main.cc
+++ b/src/serial/bin/main.cc
@@ -17,20 +17,22 @@
 namespace {
   void print_help(std::string const& name) {
     std::cout
-        << name
-        << ": [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] [--validation] "
-           "[--histogram] [--empty]\n\n"
-        << "Options\n"
-        << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
-        << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
-        << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "(default -1 for disabled; conflicts with --maxEvents)\n"
-        << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
-        << " --validation        Run (rudimentary) validation at the end\n"
-        << " --histogram         Produce histograms at the end\n"
-        << " --empty             Ignore all producers (for testing only)\n"
-        << std::endl;
+        << "Usage: " << name
+        << " [--numberOfThreads NT] [--numberOfStreams NS] [--warmupEvents WE] [--maxEvents ME] [--runForMinutes RM]"
+        << " [--data PATH] [--validation] [--histogram] [--empty]\n";
+    std::cout << R"(
+Options:
+  --numberOfThreads             Number of threads to use (default 1, use 0 to use all CPU cores).
+  --numberOfStreams             Number of concurrent events (default 0 = numberOfThreads).
+  --warmupEvents                Number of events to process before starting the benchmark (default 0).
+  --maxEvents                   Number of events to process (default -1 for all events in the input file).
+  --runForMinutes               Continue processing the set of 1000 events until this many minutes have passed
+                                (default -1 for disabled; conflicts with --maxEvents).
+  --data                        Path to the 'data' directory (default 'data' in the directory of the executable).
+  --validation                  Run (rudimentary) validation at the end.
+  --histogram                   Produce histograms at the end.
+  --empty                       Ignore all producers (for testing only).
+)";
   }
 }  // namespace
 
@@ -39,6 +41,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> args(argv, argv + argc);
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -55,6 +58,9 @@ int main(int argc, char** argv) {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
+    } else if (*i == "--warmupEvents") {
+      ++i;
+      warmupEvents = std::stoi(*i);
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -111,20 +117,45 @@ int main(int argc, char** argv) {
       edmodules.emplace_back("HistoValidator");
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(edmodules),
+                                std::move(esmodules),
+                                datadir,
+                                validation);
 
   if (runForMinutes < 0) {
-    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
-              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
-    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
-              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing for about " << runForMinutes << " minutes,";
   }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
+  }
+  std::cout << " with " << numberOfStreams << " concurrent events and " << numberOfThreads << " threads." << std::endl;
 
-  // Initialize he TBB thread pool
+  // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();

--- a/src/sycl/bin/EventProcessor.cc
+++ b/src/sycl/bin/EventProcessor.cc
@@ -5,28 +5,48 @@
 #include "EventProcessor.h"
 
 namespace edm {
-  EventProcessor::EventProcessor(int maxEvents,
+  EventProcessor::EventProcessor(int warmupEvents,
+                                 int maxEvents,
                                  int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation),
+        warmupEvents_(warmupEvents),
+        maxEvents_(source_.maxEvents()),
+        runForMinutes_(runForMinutes) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
       esp->produce(eventSetup_);
     }
 
-    //schedules_.reserve(numberOfStreams);
+    schedules_.reserve(numberOfStreams);
     for (int i = 0; i < numberOfStreams; ++i) {
       schedules_.emplace_back(registry_, pluginManager_, &source_, &eventSetup_, i, path);
     }
   }
 
+  void EventProcessor::warmUp() {
+    if (warmupEvents_ <= 0)
+      return;
+
+    // Configure the source for the warmup step
+    source_.reconfigure(warmupEvents_, -1);
+    process();
+  }
+
   void EventProcessor::runToCompletion() {
+    // Configure the source for the actual reconstrction
+    source_.reconfigure(maxEvents_, runForMinutes_);
+    process();
+  }
+
+  void EventProcessor::process() {
     source_.startProcessing();
+
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/sycl/bin/EventProcessor.h
+++ b/src/sycl/bin/EventProcessor.h
@@ -14,7 +14,8 @@
 namespace edm {
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
@@ -25,16 +26,21 @@ namespace edm {
     int maxEvents() const { return source_.maxEvents(); }
     int processedEvents() const { return source_.processedEvents(); }
 
+    void warmUp();
     void runToCompletion();
-
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/sycl/bin/Source.cc
+++ b/src/sycl/bin/Source.cc
@@ -83,6 +83,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/sycl/bin/Source.h
+++ b/src/sycl/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/sycl/bin/main.cc
+++ b/src/sycl/bin/main.cc
@@ -19,24 +19,26 @@
 namespace {
   void print_help(std::string const& name) {
     std::cout
-        << name
-        << ": [--device BACKEND:DEVICE] [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH] "
-           "                     [--transfer] [--validation] [--histogram] [--empty]\n\n"
-        << "Options\n"
-        << " --device            Specifies the device which should run the code (default all, options: <backend>:<devices>\n"
-           "                       see https://intel.github.io/llvm-docs/EnvironmentVariables.html#oneapi-device-selector\n"
-           "                       for the accepted syntax)\n"
-        << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
-        << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
-        << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed\n"
-           "                       (default -1 for disabled; conflicts with --maxEvents)\n"
-        << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
-        << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
-        << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
-        << " --histogram         Produce histograms at the end (implies --transfer)\n"
-        << " --empty             Ignore all producers (for testing only)\n"
-        << std::endl;
+        << "Usage: " << name
+        << " [--device BACKEND:DEVICE] [--numberOfThreads NT] [--numberOfStreams NS] [--warmupEvents WE]"
+        << " [--maxEvents ME] [--runForMinutes RM] [--data PATH] [--transfer] [--validation] [--histogram] [--empty]\n";
+    std::cout << R"(
+Options:
+  --device BACKEND:DEVICE       Specifies which device(s) to use (default all).
+                                See https://intel.github.io/llvm-docs/EnvironmentVariables.html#oneapi-device-selector
+                                for the accepted syntax.
+  --numberOfThreads             Number of threads to use (default 1, use 0 to use all CPU cores).
+  --numberOfStreams             Number of concurrent events (default 0 = numberOfThreads).
+  --warmupEvents                Number of events to process before starting the benchmark (default 0).
+  --maxEvents                   Number of events to process (default -1 for all events in the input file).
+  --runForMinutes               Continue processing the set of 1000 events until this many minutes have passed
+                                (default -1 for disabled; conflicts with --maxEvents).
+  --data                        Path to the 'data' directory (default 'data' in the directory of the executable).
+  --transfer                    Transfer results from GPU to CPU (default is to leave them on GPU).
+  --validation                  Run (rudimentary) validation at the end (implies --transfer).
+  --histogram                   Produce histograms at the end (implies --transfer).
+  --empty                       Ignore all producers (for testing only).
+)";
   }
 }  // namespace
 
@@ -45,6 +47,7 @@ int main(int argc, char** argv) try {
   std::vector<std::string> args(argv, argv + argc);
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -66,6 +69,9 @@ int main(int argc, char** argv) try {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
+    } else if (*i == "--warmupEvents") {
+      ++i;
+      warmupEvents = std::stoi(*i);
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -137,20 +143,45 @@ int main(int argc, char** argv) try {
       edmodules.emplace_back("HistoValidator");
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(edmodules),
+                                std::move(esmodules),
+                                datadir,
+                                validation);
 
   if (runForMinutes < 0) {
-    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
-              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
-    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
-              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing for about " << runForMinutes << " minutes,";
   }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
+  }
+  std::cout << " with " << numberOfStreams << " concurrent events and " << numberOfThreads << " threads." << std::endl;
 
-  // Initialize he TBB thread pool
+  // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();

--- a/src/sycltest/bin/EventProcessor.cc
+++ b/src/sycltest/bin/EventProcessor.cc
@@ -5,28 +5,48 @@
 #include "EventProcessor.h"
 
 namespace edm {
-  EventProcessor::EventProcessor(int maxEvents,
+  EventProcessor::EventProcessor(int warmupEvents,
+                                 int maxEvents,
                                  int runForMinutes,
                                  int numberOfStreams,
                                  std::vector<std::string> const& path,
                                  std::vector<std::string> const& esproducers,
                                  std::filesystem::path const& datadir,
                                  bool validation)
-      : source_(maxEvents, runForMinutes, registry_, datadir, validation) {
+      : source_(maxEvents, runForMinutes, registry_, datadir, validation),
+        warmupEvents_(warmupEvents),
+        maxEvents_(source_.maxEvents()),
+        runForMinutes_(runForMinutes) {
     for (auto const& name : esproducers) {
       pluginManager_.load(name);
       auto esp = ESPluginFactory::create(name, datadir);
       esp->produce(eventSetup_);
     }
 
-    //schedules_.reserve(numberOfStreams);
+    schedules_.reserve(numberOfStreams);
     for (int i = 0; i < numberOfStreams; ++i) {
       schedules_.emplace_back(registry_, pluginManager_, &source_, &eventSetup_, i, path);
     }
   }
 
+  void EventProcessor::warmUp() {
+    if (warmupEvents_ <= 0)
+      return;
+
+    // Configure the source for the warmup step
+    source_.reconfigure(warmupEvents_, -1);
+    process();
+  }
+
   void EventProcessor::runToCompletion() {
+    // Configure the source for the actual reconstrction
+    source_.reconfigure(maxEvents_, runForMinutes_);
+    process();
+  }
+
+  void EventProcessor::process() {
     source_.startProcessing();
+
     // The task that waits for all other work
     FinalWaitingTask globalWaitTask;
     tbb::task_group group;

--- a/src/sycltest/bin/EventProcessor.h
+++ b/src/sycltest/bin/EventProcessor.h
@@ -14,7 +14,8 @@
 namespace edm {
   class EventProcessor {
   public:
-    explicit EventProcessor(int maxEvents,
+    explicit EventProcessor(int warmupEvents,
+                            int maxEvents,
                             int runForMinutes,
                             int numberOfStreams,
                             std::vector<std::string> const& path,
@@ -25,16 +26,21 @@ namespace edm {
     int maxEvents() const { return source_.maxEvents(); }
     int processedEvents() const { return source_.processedEvents(); }
 
+    void warmUp();
     void runToCompletion();
-
     void endJob();
 
   private:
+    void process();
+
     edmplugin::PluginManager pluginManager_;
     ProductRegistry registry_;
     Source source_;
     EventSetup eventSetup_;
     std::vector<StreamSchedule> schedules_;
+    int warmupEvents_;
+    int maxEvents_;
+    int runForMinutes_;
   };
 }  // namespace edm
 

--- a/src/sycltest/bin/Source.cc
+++ b/src/sycltest/bin/Source.cc
@@ -83,6 +83,15 @@ namespace edm {
     }
   }
 
+  void Source::reconfigure(int maxEvents, int runForMinutes) {
+    std::scoped_lock lock(timeMutex_);
+    maxEvents_ = maxEvents;
+    runForMinutes_ = runForMinutes;
+    numEventsTimeLastCheck_ = 0;
+    shouldStop_ = false;
+    numEvents_ = 0;
+  }
+
   void Source::startProcessing() {
     if (runForMinutes_ >= 0) {
       startTime_ = std::chrono::steady_clock::now();

--- a/src/sycltest/bin/Source.h
+++ b/src/sycltest/bin/Source.h
@@ -20,6 +20,7 @@ namespace edm {
     explicit Source(
         int maxEvents, int runForMinutes, ProductRegistry& reg, std::filesystem::path const& datadir, bool validation);
 
+    void reconfigure(int maxEvents, int runForMinutes);
     void startProcessing();
 
     int maxEvents() const { return maxEvents_; }
@@ -32,7 +33,7 @@ namespace edm {
     int maxEvents_;
 
     // these are all for the mode where the processing length is limited by time
-    int const runForMinutes_;
+    int runForMinutes_;
     std::chrono::steady_clock::time_point startTime_;
     std::mutex timeMutex_;
     std::atomic<int> numEventsTimeLastCheck_ = 0;

--- a/src/sycltest/bin/main.cc
+++ b/src/sycltest/bin/main.cc
@@ -18,24 +18,25 @@
 
 namespace {
   void print_help(std::string const& name) {
-    std::cout
-        << name
-        << ": [--device BACKEND:DEVICE] [--numberOfThreads NT] [--numberOfStreams NS] [--maxEvents ME] [--data PATH]"
-           "                     [--transfer] [--validation] [--empty]\n\n"
-        << "Options\n"
-        << " --device            Specifies the device which should run the code (default all, options: <backend>:<devices>\n"
-           "                       see https://intel.github.io/llvm-docs/EnvironmentVariables.html#oneapi-device-selector\n"
-           "                       for the accepted syntax)\n"
-        << " --numberOfThreads   Number of threads to use (default 1, use 0 to use all CPU cores)\n"
-        << " --numberOfStreams   Number of concurrent events (default 0 = numberOfThreads)\n"
-        << " --maxEvents         Number of events to process (default -1 for all events in the input file)\n"
-        << " --runForMinutes     Continue processing the set of 1000 events until this many minutes have passed "
-           "                       (default -1 for disabled; conflicts with --maxEvents)\n"
-        << " --data              Path to the 'data' directory (default 'data' in the directory of the executable)\n"
-        << " --transfer          Transfer results from GPU to CPU (default is to leave them on GPU)\n"
-        << " --validation        Run (rudimentary) validation at the end (implies --transfer)\n"
-        << " --empty             Ignore all producers (for testing only)\n"
-        << std::endl;
+    std::cout << "Usage: " << name
+              << " [--device BACKEND:DEVICE] [--numberOfThreads NT] [--numberOfStreams NS] [--warmupEvents WE]"
+              << " [--maxEvents ME] [--runForMinutes RM] [--data PATH] [--transfer] [--validation] [--empty]\n";
+    std::cout << R"(
+Options:
+  --device BACKEND:DEVICE       Specifies which device(s) to use (default all).
+                                See https://intel.github.io/llvm-docs/EnvironmentVariables.html#oneapi-device-selector
+                                for the accepted syntax.
+  --numberOfThreads             Number of threads to use (default 1, use 0 to use all CPU cores).
+  --numberOfStreams             Number of concurrent events (default 0 = numberOfThreads).
+  --warmupEvents                Number of events to process before starting the benchmark (default 0).
+  --maxEvents                   Number of events to process (default -1 for all events in the input file).
+  --runForMinutes               Continue processing the set of 1000 events until this many minutes have passed
+                                (default -1 for disabled; conflicts with --maxEvents).
+  --data                        Path to the 'data' directory (default 'data' in the directory of the executable).
+  --transfer                    Transfer results from GPU to CPU (default is to leave them on GPU).
+  --validation                  Run (rudimentary) validation at the end (implies --transfer).
+  --empty                       Ignore all producers (for testing only).
+)";
   }
 }  // namespace
 
@@ -44,6 +45,7 @@ int main(int argc, char** argv) try {
   std::vector<std::string> args(argv, argv + argc);
   int numberOfThreads = 1;
   int numberOfStreams = 0;
+  int warmupEvents = 0;
   int maxEvents = -1;
   int runForMinutes = -1;
   std::filesystem::path datadir;
@@ -64,6 +66,9 @@ int main(int argc, char** argv) try {
     } else if (*i == "--numberOfStreams") {
       ++i;
       numberOfStreams = std::stoi(*i);
+    } else if (*i == "--warmupEvents") {
+      ++i;
+      warmupEvents = std::stoi(*i);
     } else if (*i == "--maxEvents") {
       ++i;
       maxEvents = std::stoi(*i);
@@ -117,20 +122,45 @@ int main(int argc, char** argv) try {
       // add modules for transfer
     }
   }
-  edm::EventProcessor processor(
-      maxEvents, runForMinutes, numberOfStreams, std::move(edmodules), std::move(esmodules), datadir, validation);
+  edm::EventProcessor processor(warmupEvents,
+                                maxEvents,
+                                runForMinutes,
+                                numberOfStreams,
+                                std::move(edmodules),
+                                std::move(esmodules),
+                                datadir,
+                                validation);
 
   if (runForMinutes < 0) {
-    std::cout << "Processing " << processor.maxEvents() << " events, of which " << numberOfStreams
-              << " concurrently, with " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing " << processor.maxEvents() << " events,";
   } else {
-    std::cout << "Processing for about " << runForMinutes << " minutes with " << numberOfStreams
-              << " concurrent events and " << numberOfThreads << " threads." << std::endl;
+    std::cout << "Processing for about " << runForMinutes << " minutes,";
   }
+  if (warmupEvents > 0) {
+    std::cout << " after " << warmupEvents << " events of warm up,";
+  }
+  std::cout << " with " << numberOfStreams << " concurrent events and " << numberOfThreads << " threads." << std::endl;
 
-  // Initialize he TBB thread pool
+  // Initialize the TBB thread pool
   tbb::global_control tbb_max_threads{tbb::global_control::max_allowed_parallelism,
                                       static_cast<std::size_t>(numberOfThreads)};
+
+  // Warm up
+  try {
+    tbb::task_arena arena(numberOfThreads);
+    arena.execute([&] { processor.warmUp(); });
+  } catch (std::runtime_error& e) {
+    std::cout << "\n----------\nCaught std::runtime_error" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cout << "\n----------\nCaught std::exception" << std::endl;
+    std::cout << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cout << "\n----------\nCaught exception of unknown type" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Run work
   auto cpu_start = PosixClockGettime<CLOCK_PROCESS_CPUTIME_ID>::now();


### PR DESCRIPTION
This is implemented for most back-ends:
  - `alpaka`
  - `alpakatest`
  - `cuda`
  - `cudacompat`
  - `cudadev`
  - `cudatest`
  - `cudauvm`
  - `fwtest`
  - `hip`
  - `hiptest`
  - `serial`
  - `sycl`
  - `sycltest`

The missing ones are those that I don't have any experience with:
  - `kokkos`
  - `kokkostest`
  - `openmp`
  - `stdpar`
