### PR TITLE
Make alpaka platforms full objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -748,7 +748,7 @@ external_alpaka: $(ALPAKA_BASE)
 
 $(ALPAKA_BASE):
 	git clone https://github.com/alpaka-group/alpaka.git -b develop $@
-	cd $@ && git checkout b518e8c943a816eba06c3e12c0a7e1b58c8faedc
+	cd $@ && git checkout bb74c9129e8761cb74b9733b034eec62f7c0f600
 
 # Kokkos
 external_kokkos: $(KOKKOS_LIB)

--- a/src/alpaka/AlpakaCore/CachingAllocator.h
+++ b/src/alpaka/AlpakaCore/CachingAllocator.h
@@ -323,7 +323,7 @@ namespace cms::alpakatools {
       } else if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
         // allocate pinned host memory accessible by the queue's platform
         return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<Queue>>, std::byte, size_t>(
-            device_, *platform, bytes);
+            device_, *platform<alpaka::Platform<alpaka::Dev<Queue>>>, bytes);
       } else {
         // unsupported combination
         static_assert(std::is_same_v<Device, alpaka::Dev<Queue>> or std::is_same_v<Device, alpaka::DevCpu>,

--- a/src/alpaka/AlpakaCore/CachingAllocator.h
+++ b/src/alpaka/AlpakaCore/CachingAllocator.h
@@ -322,7 +322,8 @@ namespace cms::alpakatools {
         return alpaka::allocBuf<std::byte, size_t>(device_, bytes);
       } else if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
         // allocate pinned host memory accessible by the queue's platform
-        return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<Queue>>, std::byte, size_t>(device_, bytes);
+        return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<Queue>>, std::byte, size_t>(
+            device_, *platform, bytes);
       } else {
         // unsupported combination
         static_assert(std::is_same_v<Device, alpaka::Dev<Queue>> or std::is_same_v<Device, alpaka::DevCpu>,

--- a/src/alpaka/AlpakaCore/ESProduct.h
+++ b/src/alpaka/AlpakaCore/ESProduct.h
@@ -22,7 +22,7 @@ namespace cms::alpakatools {
     using Queue = TQueue;
     using Event = alpaka::Event<Queue>;
     using Device = alpaka::Dev<Queue>;
-    using Platform = alpaka::Pltf<Device>;
+    using Platform = alpaka::Platform<Device>;
 
     ESProduct() : gpuDataPerDevice_(cms::alpakatools::devices<Platform>.size()) {
       for (size_t i = 0; i < gpuDataPerDevice_.size(); ++i) {

--- a/src/alpaka/AlpakaCore/EventCache.h
+++ b/src/alpaka/AlpakaCore/EventCache.h
@@ -20,7 +20,7 @@ namespace cms::alpakatools {
 
     // EventCache should be constructed by the first call to
     // getEventCache() only if we have CUDA devices present
-    EventCache() : cache_(alpaka::getDevCount(*platform)) {}
+    EventCache() : cache_(alpaka::getDevCount(*platform<Platform>)) {}
 
     // Gets a (cached) CUDA event for the current device. The event
     // will be returned to the cache by the shared_ptr destructor. The
@@ -65,7 +65,7 @@ namespace cms::alpakatools {
       // EventCache lives through multiple tests (and go through
       // multiple shutdowns of the framework).
       cache_.clear();
-      cache_.resize(alpaka::getDevCount(*platform));
+      cache_.resize(alpaka::getDevCount(*platform<Platform>));
     }
 
     std::vector<edm::ReusableObjectHolder<Event>> cache_;

--- a/src/alpaka/AlpakaCore/EventCache.h
+++ b/src/alpaka/AlpakaCore/EventCache.h
@@ -7,8 +7,7 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include "AlpakaCore/alpakaConfig.h"
-#include "AlpakaCore/getDeviceIndex.h"
+#include "AlpakaCore/alpakaDevices.h"
 #include "Framework/ReusableObjectHolder.h"
 
 namespace cms::alpakatools {
@@ -17,11 +16,11 @@ namespace cms::alpakatools {
   class EventCache {
   public:
     using Device = alpaka::Dev<Event>;
-    using Platform = alpaka::Pltf<Device>;
+    using Platform = alpaka::Platform<Device>;
 
     // EventCache should be constructed by the first call to
     // getEventCache() only if we have CUDA devices present
-    EventCache() : cache_(alpaka::getDevCount<Platform>()) {}
+    EventCache() : cache_(alpaka::getDevCount(*platform)) {}
 
     // Gets a (cached) CUDA event for the current device. The event
     // will be returned to the cache by the shared_ptr destructor. The
@@ -66,7 +65,7 @@ namespace cms::alpakatools {
       // EventCache lives through multiple tests (and go through
       // multiple shutdowns of the framework).
       cache_.clear();
-      cache_.resize(alpaka::getDevCount<Platform>());
+      cache_.resize(alpaka::getDevCount(*platform));
     }
 
     std::vector<edm::ReusableObjectHolder<Event>> cache_;

--- a/src/alpaka/AlpakaCore/ScopedContext.h
+++ b/src/alpaka/AlpakaCore/ScopedContext.h
@@ -30,7 +30,7 @@ namespace cms::alpakatools {
     public:
       using Queue = TQueue;
       using Device = alpaka::Dev<Queue>;
-      using Platform = alpaka::Pltf<Device>;
+      using Platform = alpaka::Platform<Device>;
 
       Device device() const { return alpaka::getDev(*stream_); }
 

--- a/src/alpaka/AlpakaCore/StreamCache.h
+++ b/src/alpaka/AlpakaCore/StreamCache.h
@@ -4,8 +4,7 @@
 #include <memory>
 #include <vector>
 
-#include "AlpakaCore/alpakaConfig.h"
-#include "AlpakaCore/getDeviceIndex.h"
+#include "AlpakaCore/alpakaDevices.h"
 #include "Framework/ReusableObjectHolder.h"
 
 namespace cms::alpakatools {
@@ -13,12 +12,12 @@ namespace cms::alpakatools {
   template <typename Queue>
   class StreamCache {
     using Device = alpaka::Dev<Queue>;
-    using Platform = alpaka::Pltf<Device>;
+    using Platform = alpaka::Platform<Device>;
 
   public:
     // StreamCache should be constructed by the first call to
     // getStreamCache() only if we have CUDA devices present
-    StreamCache() : cache_(alpaka::getDevCount<Platform>()) {}
+    StreamCache() : cache_(alpaka::getDevCount(*cms::alpakatools::platform)) {}
 
     // Gets a (cached) CUDA stream for the current device. The stream
     // will be returned to the cache by the shared_ptr destructor.
@@ -36,7 +35,7 @@ namespace cms::alpakatools {
       // StreamCache lives through multiple tests (and go through
       // multiple shutdowns of the framework).
       cache_.clear();
-      cache_.resize(alpaka::getDevCount<Platform>());
+      cache_.resize(alpaka::getDevCount(*cms::alpakatools::platform));
     }
 
     std::vector<edm::ReusableObjectHolder<Queue>> cache_;

--- a/src/alpaka/AlpakaCore/StreamCache.h
+++ b/src/alpaka/AlpakaCore/StreamCache.h
@@ -17,7 +17,7 @@ namespace cms::alpakatools {
   public:
     // StreamCache should be constructed by the first call to
     // getStreamCache() only if we have CUDA devices present
-    StreamCache() : cache_(alpaka::getDevCount(*cms::alpakatools::platform)) {}
+    StreamCache() : cache_(alpaka::getDevCount(*cms::alpakatools::platform<Platform>)) {}
 
     // Gets a (cached) CUDA stream for the current device. The stream
     // will be returned to the cache by the shared_ptr destructor.
@@ -35,7 +35,7 @@ namespace cms::alpakatools {
       // StreamCache lives through multiple tests (and go through
       // multiple shutdowns of the framework).
       cache_.clear();
-      cache_.resize(alpaka::getDevCount(*cms::alpakatools::platform));
+      cache_.resize(alpaka::getDevCount(*cms::alpakatools::platform<Platform>));
     }
 
     std::vector<edm::ReusableObjectHolder<Queue>> cache_;

--- a/src/alpaka/AlpakaCore/alpaka/initialise.cc
+++ b/src/alpaka/AlpakaCore/alpaka/initialise.cc
@@ -2,7 +2,6 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include "AlpakaCore/alpakaConfig.h"
 #include "AlpakaCore/alpakaDevices.h"
 #include "AlpakaCore/initialise.h"
 #include "Framework/demangle.h"

--- a/src/alpaka/AlpakaCore/alpaka/initialise.cc
+++ b/src/alpaka/AlpakaCore/alpaka/initialise.cc
@@ -2,6 +2,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "AlpakaCore/alpakaConfig.h"
 #include "AlpakaCore/alpakaDevices.h"
 #include "AlpakaCore/initialise.h"
 #include "Framework/demangle.h"
@@ -9,23 +10,31 @@
 namespace cms::alpakatools {
 
   template <typename TPlatform>
-  void initialise() {
+  void initialise(bool verbose) {
     constexpr const char* suffix[] = {"devices.", "device:", "devices:"};
 
-    if (devices<TPlatform>.empty()) {
-      devices<TPlatform> = enumerate<TPlatform>();
+    if (not platform<TPlatform>.has_value()) {
+      // global objects in the cms::alpakatools namespace
+      platform<TPlatform> = TPlatform{};
+      devices<TPlatform> = alpaka::getDevs(*platform<TPlatform>);
+
       auto size = devices<TPlatform>.size();
-      //std::cout << edm::demangle<TPlatform> << " platform succesfully initialised." << std::endl;
       std::cout << "Found " << size << " " << suffix[size < 2 ? size : 2] << std::endl;
       for (auto const& device : devices<TPlatform>) {
         std::cout << "  - " << alpaka::getName(device) << std::endl;
       }
+      if (verbose) {
+        std::cout << edm::demangle<TPlatform> << " platform succesfully initialised." << std::endl;
+      }
     } else {
-      //std::cout << edm::demangle<TPlatform> << " platform already initialised." << std::endl;
+      if (verbose) {
+        std::cout << edm::demangle<TPlatform> << " platform already initialised." << std::endl;
+      }
     }
+    std::cout << std::endl;
   }
 
   // explicit template instantiation definition
-  template void initialise<ALPAKA_ACCELERATOR_NAMESPACE::Platform>();
+  template void initialise<ALPAKA_ACCELERATOR_NAMESPACE::Platform>(bool);
 
 }  // namespace cms::alpakatools

--- a/src/alpaka/AlpakaCore/alpakaConfig.h
+++ b/src/alpaka/AlpakaCore/alpakaConfig.h
@@ -30,7 +30,7 @@ namespace alpaka_common {
 
   // host types
   using DevHost = alpaka::DevCpu;
-  using PltfHost = alpaka::PltfCpu;
+  using PlatformHost = alpaka::PlatformCpu;
 
 }  // namespace alpaka_common
 
@@ -46,7 +46,7 @@ namespace alpaka_common {
 namespace alpaka_cuda_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCudaRt;
+  using Platform = alpaka::PlatformCudaRt;
   using Device = alpaka::DevCudaRt;
   using Queue = alpaka::QueueCudaRtNonBlocking;
   using Event = alpaka::EventCudaRt;
@@ -69,7 +69,7 @@ namespace alpaka_cuda_async {
 namespace alpaka_rocm_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfHipRt;
+  using Platform = alpaka::PlatformHipRt;
   using Device = alpaka::DevHipRt;
   using Queue = alpaka::QueueHipRtNonBlocking;
   using Event = alpaka::EventHipRt;
@@ -92,7 +92,7 @@ namespace alpaka_rocm_async {
 namespace alpaka_serial_sync {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCpu;
+  using Platform = alpaka::PlatformCpu;
   using Device = alpaka::DevCpu;
   using Queue = alpaka::QueueCpuBlocking;
   using Event = alpaka::EventCpu;
@@ -115,7 +115,7 @@ namespace alpaka_serial_sync {
 namespace alpaka_tbb_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCpu;
+  using Platform = alpaka::PlatformCpu;
   using Device = alpaka::DevCpu;
   using Queue = alpaka::QueueCpuNonBlocking;
   using Event = alpaka::EventCpu;
@@ -138,7 +138,7 @@ namespace alpaka_tbb_async {
 namespace alpaka_omp2_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCpu;
+  using Platform = alpaka::PlatformCpu;
   using Device = alpaka::DevCpu;
   using Queue = alpaka::QueueCpuBlocking;
   using Event = alpaka::EventCpu;

--- a/src/alpaka/AlpakaCore/alpakaDevices.h
+++ b/src/alpaka/AlpakaCore/alpakaDevices.h
@@ -11,31 +11,17 @@
 
 namespace cms::alpakatools {
 
-  // alpaka host device
+  // alpaka host platform and device
   inline const alpaka_common::PlatformHost platformHost{};
   inline const alpaka_common::DevHost host = alpaka::getDevByIdx(platformHost, 0u);
 
-  // alpaka accelerator devices
+  // alpaka accelerator platform and devices
+  // these objects are filled by a call to cms::alpakatools::initialise<TPlatform>()
+  template <typename TPlatform>
+  inline std::optional<TPlatform> platform;
+
   template <typename TPlatform>
   inline std::vector<alpaka::Dev<TPlatform>> devices;
-
-  template <typename TPlatform>
-  std::vector<alpaka::Dev<TPlatform>> enumerate() {
-    assert(getDeviceIndex(host) == 0u);
-
-    using Device = alpaka::Dev<TPlatform>;
-    using Platform = TPlatform;
-    platform = Platform{};
-
-    std::vector<Device> devices;
-    uint32_t n = alpaka::getDevCount(*platform);
-    devices.reserve(n);
-    for (uint32_t i = 0; i < n; ++i) {
-      devices.push_back(alpaka::getDevByIdx(*platform, i));
-      assert(getDeviceIndex(devices.back()) == static_cast<int>(i));
-    }
-    return devices;
-  }
 
 }  // namespace cms::alpakatools
 

--- a/src/alpaka/AlpakaCore/alpakaDevices.h
+++ b/src/alpaka/AlpakaCore/alpakaDevices.h
@@ -12,7 +12,8 @@
 namespace cms::alpakatools {
 
   // alpaka host device
-  inline const alpaka_common::DevHost host = alpaka::getDevByIdx<alpaka_common::PltfHost>(0u);
+  inline const alpaka_common::PlatformHost platformHost{};
+  inline const alpaka_common::DevHost host = alpaka::getDevByIdx(platformHost, 0u);
 
   // alpaka accelerator devices
   template <typename TPlatform>
@@ -24,12 +25,13 @@ namespace cms::alpakatools {
 
     using Device = alpaka::Dev<TPlatform>;
     using Platform = TPlatform;
+    platform = Platform{};
 
     std::vector<Device> devices;
-    uint32_t n = alpaka::getDevCount<Platform>();
+    uint32_t n = alpaka::getDevCount(*platform);
     devices.reserve(n);
     for (uint32_t i = 0; i < n; ++i) {
-      devices.push_back(alpaka::getDevByIdx<Platform>(i));
+      devices.push_back(alpaka::getDevByIdx(*platform, i));
       assert(getDeviceIndex(devices.back()) == static_cast<int>(i));
     }
     return devices;

--- a/src/alpaka/AlpakaCore/alpakaFwd.h
+++ b/src/alpaka/AlpakaCore/alpakaFwd.h
@@ -31,11 +31,11 @@ namespace alpaka {
   struct ApiHipRt;
 
   // Platforms
-  class PltfCpu;
+  class PlatformCpu;
   template <typename TApi>
-  class PltfUniformCudaHipRt;
-  using PltfCudaRt = PltfUniformCudaHipRt<ApiCudaRt>;
-  using PltfHipRt = PltfUniformCudaHipRt<ApiHipRt>;
+  class PlatformUniformCudaHipRt;
+  using PlatformCudaRt = PlatformUniformCudaHipRt<ApiCudaRt>;
+  using PlatformHipRt = PlatformUniformCudaHipRt<ApiHipRt>;
 
   // Devices
   class DevCpu;

--- a/src/alpaka/AlpakaCore/alpakaMemory.h
+++ b/src/alpaka/AlpakaCore/alpakaMemory.h
@@ -101,19 +101,20 @@ namespace cms::alpakatools {
 
   template <typename T, typename TPlatform>
   std::enable_if_t<not std::is_array_v<T>, host_buffer<T>> make_host_buffer() {
-    return alpaka::allocMappedBuf<TPlatform, T, Idx>(host, *platform, Scalar{});
+    return alpaka::allocMappedBuf<TPlatform, T, Idx>(host, *platform<TPlatform>, Scalar{});
   }
 
   template <typename T, typename TPlatform>
   std::enable_if_t<cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
   make_host_buffer(Extent extent) {
-    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform, Vec1D{extent});
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform<TPlatform>, Vec1D{extent});
   }
 
   template <typename T, typename TPlatform>
   std::enable_if_t<cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
   make_host_buffer() {
-    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform, Vec1D{std::extent_v<T>});
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(
+        host, *platform<TPlatform>, Vec1D{std::extent_v<T>});
   }
 
   // potentially cached, pinned, scalar and 1-dimensional host buffers, associated to a work queue
@@ -124,7 +125,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<T, Idx>(host, queue, Scalar{});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, T, Idx>(host, *platform, Scalar{});
+      using Platform = alpaka::Platform<alpaka::Dev<TQueue>>;
+      return alpaka::allocMappedBuf<Platform, T, Idx>(host, *platform<Platform>, Scalar{});
     }
   }
 
@@ -134,8 +136,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{extent});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
-          host, *platform, Vec1D{extent});
+      using Platform = alpaka::Platform<alpaka::Dev<TQueue>>;
+      return alpaka::allocMappedBuf<Platform, std::remove_extent_t<T>, Idx>(host, *platform<Platform>, Vec1D{extent});
     }
   }
 
@@ -145,8 +147,9 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{std::extent_v<T>});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
-          host, *platform, Vec1D{std::extent_v<T>});
+      using Platform = alpaka::Platform<alpaka::Dev<TQueue>>;
+      return alpaka::allocMappedBuf<Platform, std::remove_extent_t<T>, Idx>(
+          host, *platform<Platform>, Vec1D{std::extent_v<T>});
     }
   }
 

--- a/src/alpaka/AlpakaCore/alpakaMemory.h
+++ b/src/alpaka/AlpakaCore/alpakaMemory.h
@@ -101,19 +101,19 @@ namespace cms::alpakatools {
 
   template <typename T, typename TPlatform>
   std::enable_if_t<not std::is_array_v<T>, host_buffer<T>> make_host_buffer() {
-    return alpaka::allocMappedBuf<TPlatform, T, Idx>(host, Scalar{});
+    return alpaka::allocMappedBuf<TPlatform, T, Idx>(host, *platform, Scalar{});
   }
 
   template <typename T, typename TPlatform>
   std::enable_if_t<cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
   make_host_buffer(Extent extent) {
-    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, Vec1D{extent});
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform, Vec1D{extent});
   }
 
   template <typename T, typename TPlatform>
   std::enable_if_t<cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
   make_host_buffer() {
-    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, Vec1D{std::extent_v<T>});
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform, Vec1D{std::extent_v<T>});
   }
 
   // potentially cached, pinned, scalar and 1-dimensional host buffers, associated to a work queue
@@ -124,7 +124,7 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<T, Idx>(host, queue, Scalar{});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, T, Idx>(host, Scalar{});
+      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, T, Idx>(host, *platform, Scalar{});
     }
   }
 
@@ -134,7 +134,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{extent});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(host, Vec1D{extent});
+      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
+          host, *platform, Vec1D{extent});
     }
   }
 
@@ -144,7 +145,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{std::extent_v<T>});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(host, Vec1D{std::extent_v<T>});
+      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
+          host, *platform, Vec1D{std::extent_v<T>});
     }
   }
 

--- a/src/alpaka/AlpakaCore/getDeviceCachingAllocator.h
+++ b/src/alpaka/AlpakaCore/getDeviceCachingAllocator.h
@@ -17,7 +17,7 @@ namespace cms::alpakatools {
     template <typename TDevice, typename TQueue>
     auto allocate_device_allocators() {
       using Allocator = CachingAllocator<TDevice, TQueue>;
-      auto const& devices = cms::alpakatools::devices<alpaka::Pltf<TDevice>>;
+      auto const& devices = cms::alpakatools::devices<alpaka::Platform<TDevice>>;
       auto const size = devices.size();
 
       // allocate the storage for the objects
@@ -54,7 +54,7 @@ namespace cms::alpakatools {
     static auto allocators = detail::allocate_device_allocators<TDevice, TQueue>();
 
     size_t const index = getDeviceIndex(device);
-    assert(index < cms::alpakatools::devices<alpaka::Pltf<TDevice>>.size());
+    assert(index < cms::alpakatools::devices<alpaka::Platform<TDevice>>.size());
 
     // the public interface is thread safe
     return allocators[index];

--- a/src/alpaka/AlpakaCore/getDeviceIndex.h
+++ b/src/alpaka/AlpakaCore/getDeviceIndex.h
@@ -5,6 +5,8 @@
 
 namespace cms::alpakatools {
 
+  inline std::optional<ALPAKA_ACCELERATOR_NAMESPACE::Platform> platform;
+
   // generic interface, for DevOacc and DevOmp5
   template <typename Device>
   inline int getDeviceIndex(Device const& device) {

--- a/src/alpaka/AlpakaCore/getDeviceIndex.h
+++ b/src/alpaka/AlpakaCore/getDeviceIndex.h
@@ -5,8 +5,6 @@
 
 namespace cms::alpakatools {
 
-  inline std::optional<ALPAKA_ACCELERATOR_NAMESPACE::Platform> platform;
-
   // generic interface, for DevOacc and DevOmp5
   template <typename Device>
   inline int getDeviceIndex(Device const& device) {

--- a/src/alpaka/AlpakaCore/initialise.h
+++ b/src/alpaka/AlpakaCore/initialise.h
@@ -5,21 +5,22 @@
 
 namespace cms::alpakatools {
 
+  // note: this function is not thread-safe
   template <typename TPlatform>
-  void initialise();
+  void initialise(bool verbose = false);
 
   // explicit template instantiation declaration
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT
-  extern template void initialise<alpaka_serial_sync::Platform>();
+  extern template void initialise<alpaka_serial_sync::Platform>(bool);
 #endif
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_PRESENT
-  extern template void initialise<alpaka_tbb_async::Platform>();
+  extern template void initialise<alpaka_tbb_async::Platform>(bool);
 #endif
 #ifdef ALPAKA_ACC_GPU_CUDA_PRESENT
-  extern template void initialise<alpaka_cuda_async::Platform>();
+  extern template void initialise<alpaka_cuda_async::Platform>(bool);
 #endif
 #ifdef ALPAKA_ACC_GPU_HIP_PRESENT
-  extern template void initialise<alpaka_rocm_async::Platform>();
+  extern template void initialise<alpaka_rocm_async::Platform>(bool);
 #endif
 
 }  // namespace cms::alpakatools

--- a/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
+++ b/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
@@ -2,7 +2,7 @@
 #include <iostream>
 
 #include "AlpakaCore/AtomicPairCounter.h"
-#include "AlpakaCore/alpakaConfig.h"
+#include "AlpakaCore/alpakaDevices.h"
 #include "AlpakaCore/alpakaMemory.h"
 #include "AlpakaCore/alpakaWorkDiv.h"
 #include "AlpakaCore/initialise.h"
@@ -57,8 +57,8 @@ struct verify {
 
 int main() {
   cms::alpakatools::initialise<Platform>();
-  const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
-  const Device device(alpaka::getDevByIdx<Platform>(0u));
+  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
   Queue queue(device);
 
   auto c_d = make_device_buffer<AtomicPairCounter>(queue);

--- a/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
+++ b/src/alpaka/test/alpaka/AtomicPairCounter_t.cc
@@ -56,9 +56,9 @@ struct verify {
 };
 
 int main() {
-  cms::alpakatools::initialise<Platform>();
-  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
-  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
+  initialise<Platform>();
+  const DevHost host(alpaka::getDevByIdx(platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*platform<Platform>, 0u));
   Queue queue(device);
 
   auto c_d = make_device_buffer<AtomicPairCounter>(queue);

--- a/src/alpaka/test/alpaka/HistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/HistoContainer_t.cc
@@ -157,9 +157,9 @@ void go(const DevHost& host, const Device& device, Queue& queue) {
 }
 
 int main() {
-  cms::alpakatools::initialise<Platform>();
-  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
-  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
+  initialise<Platform>();
+  const DevHost host(alpaka::getDevByIdx(platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*platform<Platform>, 0u));
   Queue queue(device);
 
   go<int16_t>(host, device, queue);

--- a/src/alpaka/test/alpaka/HistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/HistoContainer_t.cc
@@ -6,7 +6,7 @@
 #include <random>
 
 #include "AlpakaCore/HistoContainer.h"
-#include "AlpakaCore/alpakaConfig.h"
+#include "AlpakaCore/alpakaDevices.h"
 #include "AlpakaCore/alpakaMemory.h"
 #include "AlpakaCore/alpakaWorkDiv.h"
 #include "AlpakaCore/initialise.h"
@@ -158,8 +158,8 @@ void go(const DevHost& host, const Device& device, Queue& queue) {
 
 int main() {
   cms::alpakatools::initialise<Platform>();
-  const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
-  const Device device(alpaka::getDevByIdx<Platform>(0u));
+  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
   Queue queue(device);
 
   go<int16_t>(host, device, queue);

--- a/src/alpaka/test/alpaka/OneHistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/OneHistoContainer_t.cc
@@ -154,9 +154,9 @@ void go(const DevHost& host, const Device& device, Queue& queue) {
 }
 
 int main() {
-  cms::alpakatools::initialise<Platform>();
-  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
-  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
+  initialise<Platform>();
+  const DevHost host(alpaka::getDevByIdx(platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*platform<Platform>, 0u));
   Queue queue(device);
 
   go<int16_t>(host, device, queue);

--- a/src/alpaka/test/alpaka/OneHistoContainer_t.cc
+++ b/src/alpaka/test/alpaka/OneHistoContainer_t.cc
@@ -5,6 +5,7 @@
 #include <random>
 
 #include "AlpakaCore/HistoContainer.h"
+#include "AlpakaCore/alpakaDevices.h"
 #include "AlpakaCore/alpakaMemory.h"
 #include "AlpakaCore/initialise.h"
 
@@ -154,8 +155,8 @@ void go(const DevHost& host, const Device& device, Queue& queue) {
 
 int main() {
   cms::alpakatools::initialise<Platform>();
-  const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
-  const Device device(alpaka::getDevByIdx<Platform>(0u));
+  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
   Queue queue(device);
 
   go<int16_t>(host, device, queue);

--- a/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
+++ b/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
@@ -6,6 +6,7 @@
 #include <memory>
 #include <random>
 
+#include "AlpakaCore/alpakaDevices.h"
 #include "AlpakaCore/HistoContainer.h"
 #include "AlpakaCore/alpakaMemory.h"
 #include "AlpakaCore/alpakaWorkDiv.h"
@@ -134,8 +135,8 @@ struct verifyBulk {
 
 int main() {
   cms::alpakatools::initialise<Platform>();
-  const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
-  const Device device(alpaka::getDevByIdx<Platform>(0u));
+  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
   Queue queue(device);
 
   std::cout << "OneToManyAssoc " << sizeof(Assoc) << ' ' << Assoc::nbins() << ' ' << Assoc::capacity() << std::endl;

--- a/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
+++ b/src/alpaka/test/alpaka/OneToManyAssoc_t.cc
@@ -134,9 +134,9 @@ struct verifyBulk {
 };
 
 int main() {
-  cms::alpakatools::initialise<Platform>();
-  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
-  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
+  initialise<Platform>();
+  const DevHost host(alpaka::getDevByIdx(platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*platform<Platform>, 0u));
   Queue queue(device);
 
   std::cout << "OneToManyAssoc " << sizeof(Assoc) << ' ' << Assoc::nbins() << ' ' << Assoc::capacity() << std::endl;

--- a/src/alpaka/test/alpaka/clustering_t.cc
+++ b/src/alpaka/test/alpaka/clustering_t.cc
@@ -9,7 +9,7 @@
 #include <set>
 #include <vector>
 
-#include "AlpakaCore/alpakaConfig.h"
+#include "AlpakaCore/alpakaDevices.h"
 #include "AlpakaCore/alpakaMemory.h"
 #include "AlpakaCore/alpakaWorkDiv.h"
 #include "AlpakaCore/initialise.h"
@@ -24,8 +24,8 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 int main(void) {
   cms::alpakatools::initialise<Platform>();
 
-  const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
-  const Device device(alpaka::getDevByIdx<Platform>(0u));
+  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
   Queue queue(device);
 
   constexpr unsigned int numElements = 256 * 2000;

--- a/src/alpaka/test/alpaka/clustering_t.cc
+++ b/src/alpaka/test/alpaka/clustering_t.cc
@@ -22,10 +22,9 @@ using namespace cms::alpakatools;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 int main(void) {
-  cms::alpakatools::initialise<Platform>();
-
-  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
-  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
+  initialise<Platform>();
+  const DevHost host(alpaka::getDevByIdx(platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*platform<Platform>, 0u));
   Queue queue(device);
 
   constexpr unsigned int numElements = 256 * 2000;

--- a/src/alpaka/test/alpaka/prefixScan_t.cc
+++ b/src/alpaka/test/alpaka/prefixScan_t.cc
@@ -110,10 +110,9 @@ struct verify {
 };
 
 int main() {
-  cms::alpakatools::initialise<Platform>();
-
-  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
-  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
+  initialise<Platform>();
+  const DevHost host(alpaka::getDevByIdx(platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*platform<Platform>, 0u));
   Queue queue(device);
 
   // WARP PREFIXSCAN (OBVIOUSLY GPU-ONLY)

--- a/src/alpaka/test/alpaka/prefixScan_t.cc
+++ b/src/alpaka/test/alpaka/prefixScan_t.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include "AlpakaCore/alpakaConfig.h"
+#include "AlpakaCore/alpakaDevices.h"
 #include "AlpakaCore/alpakaMemory.h"
 #include "AlpakaCore/alpakaWorkDiv.h"
 #include "AlpakaCore/initialise.h"
@@ -112,8 +112,8 @@ struct verify {
 int main() {
   cms::alpakatools::initialise<Platform>();
 
-  const DevHost host(alpaka::getDevByIdx<PltfHost>(0u));
-  const Device device(alpaka::getDevByIdx<Platform>(0u));
+  const DevHost host(alpaka::getDevByIdx(cms::alpakatools::platformHost, 0u));
+  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
   Queue queue(device);
 
   // WARP PREFIXSCAN (OBVIOUSLY GPU-ONLY)

--- a/src/alpakatest/AlpakaCore/CachingAllocator.h
+++ b/src/alpakatest/AlpakaCore/CachingAllocator.h
@@ -323,7 +323,7 @@ namespace cms::alpakatools {
       } else if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
         // allocate pinned host memory accessible by the queue's platform
         return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<Queue>>, std::byte, size_t>(
-            device_, *platform, bytes);
+            device_, *platform<alpaka::Platform<alpaka::Dev<Queue>>>, bytes);
       } else {
         // unsupported combination
         static_assert(std::is_same_v<Device, alpaka::Dev<Queue>> or std::is_same_v<Device, alpaka::DevCpu>,

--- a/src/alpakatest/AlpakaCore/CachingAllocator.h
+++ b/src/alpakatest/AlpakaCore/CachingAllocator.h
@@ -322,7 +322,8 @@ namespace cms::alpakatools {
         return alpaka::allocBuf<std::byte, size_t>(device_, bytes);
       } else if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
         // allocate pinned host memory accessible by the queue's platform
-        return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<Queue>>, std::byte, size_t>(device_, bytes);
+        return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<Queue>>, std::byte, size_t>(
+            device_, *platform, bytes);
       } else {
         // unsupported combination
         static_assert(std::is_same_v<Device, alpaka::Dev<Queue>> or std::is_same_v<Device, alpaka::DevCpu>,

--- a/src/alpakatest/AlpakaCore/EventCache.h
+++ b/src/alpakatest/AlpakaCore/EventCache.h
@@ -20,7 +20,7 @@ namespace cms::alpakatools {
 
     // EventCache should be constructed by the first call to
     // getEventCache() only if we have CUDA devices present
-    EventCache() : cache_(alpaka::getDevCount(*platform)) {}
+    EventCache() : cache_(alpaka::getDevCount(*platform<Platform>)) {}
 
     // Gets a (cached) CUDA event for the current device. The event
     // will be returned to the cache by the shared_ptr destructor. The
@@ -65,7 +65,7 @@ namespace cms::alpakatools {
       // EventCache lives through multiple tests (and go through
       // multiple shutdowns of the framework).
       cache_.clear();
-      cache_.resize(alpaka::getDevCount(*platform));
+      cache_.resize(alpaka::getDevCount(*platform<Platform>));
     }
 
     std::vector<edm::ReusableObjectHolder<Event>> cache_;

--- a/src/alpakatest/AlpakaCore/EventCache.h
+++ b/src/alpakatest/AlpakaCore/EventCache.h
@@ -7,8 +7,7 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include "AlpakaCore/alpakaConfig.h"
-#include "AlpakaCore/getDeviceIndex.h"
+#include "AlpakaCore/alpakaDevices.h"
 #include "Framework/ReusableObjectHolder.h"
 
 namespace cms::alpakatools {
@@ -17,11 +16,11 @@ namespace cms::alpakatools {
   class EventCache {
   public:
     using Device = alpaka::Dev<Event>;
-    using Platform = alpaka::Pltf<Device>;
+    using Platform = alpaka::Platform<Device>;
 
     // EventCache should be constructed by the first call to
     // getEventCache() only if we have CUDA devices present
-    EventCache() : cache_(alpaka::getDevCount<Platform>()) {}
+    EventCache() : cache_(alpaka::getDevCount(*platform)) {}
 
     // Gets a (cached) CUDA event for the current device. The event
     // will be returned to the cache by the shared_ptr destructor. The
@@ -66,7 +65,7 @@ namespace cms::alpakatools {
       // EventCache lives through multiple tests (and go through
       // multiple shutdowns of the framework).
       cache_.clear();
-      cache_.resize(alpaka::getDevCount<Platform>());
+      cache_.resize(alpaka::getDevCount(*platform));
     }
 
     std::vector<edm::ReusableObjectHolder<Event>> cache_;

--- a/src/alpakatest/AlpakaCore/ScopedContext.h
+++ b/src/alpakatest/AlpakaCore/ScopedContext.h
@@ -30,7 +30,7 @@ namespace cms::alpakatools {
     public:
       using Queue = TQueue;
       using Device = alpaka::Dev<Queue>;
-      using Platform = alpaka::Pltf<Device>;
+      using Platform = alpaka::Platform<Device>;
 
       Device device() const { return alpaka::getDev(*stream_); }
 

--- a/src/alpakatest/AlpakaCore/StreamCache.h
+++ b/src/alpakatest/AlpakaCore/StreamCache.h
@@ -4,8 +4,7 @@
 #include <memory>
 #include <vector>
 
-#include "AlpakaCore/alpakaConfig.h"
-#include "AlpakaCore/getDeviceIndex.h"
+#include "AlpakaCore/alpakaDevices.h"
 #include "Framework/ReusableObjectHolder.h"
 
 namespace cms::alpakatools {
@@ -13,12 +12,12 @@ namespace cms::alpakatools {
   template <typename Queue>
   class StreamCache {
     using Device = alpaka::Dev<Queue>;
-    using Platform = alpaka::Pltf<Device>;
+    using Platform = alpaka::Platform<Device>;
 
   public:
     // StreamCache should be constructed by the first call to
     // getStreamCache() only if we have CUDA devices present
-    StreamCache() : cache_(alpaka::getDevCount<Platform>()) {}
+    StreamCache() : cache_(alpaka::getDevCount(*cms::alpakatools::platform)) {}
 
     // Gets a (cached) CUDA stream for the current device. The stream
     // will be returned to the cache by the shared_ptr destructor.
@@ -36,7 +35,7 @@ namespace cms::alpakatools {
       // StreamCache lives through multiple tests (and go through
       // multiple shutdowns of the framework).
       cache_.clear();
-      cache_.resize(alpaka::getDevCount<Platform>());
+      cache_.resize(alpaka::getDevCount(*cms::alpakatools::platform));
     }
 
     std::vector<edm::ReusableObjectHolder<Queue>> cache_;

--- a/src/alpakatest/AlpakaCore/StreamCache.h
+++ b/src/alpakatest/AlpakaCore/StreamCache.h
@@ -17,7 +17,7 @@ namespace cms::alpakatools {
   public:
     // StreamCache should be constructed by the first call to
     // getStreamCache() only if we have CUDA devices present
-    StreamCache() : cache_(alpaka::getDevCount(*cms::alpakatools::platform)) {}
+    StreamCache() : cache_(alpaka::getDevCount(*cms::alpakatools::platform<Platform>)) {}
 
     // Gets a (cached) CUDA stream for the current device. The stream
     // will be returned to the cache by the shared_ptr destructor.
@@ -35,7 +35,7 @@ namespace cms::alpakatools {
       // StreamCache lives through multiple tests (and go through
       // multiple shutdowns of the framework).
       cache_.clear();
-      cache_.resize(alpaka::getDevCount(*cms::alpakatools::platform));
+      cache_.resize(alpaka::getDevCount(*cms::alpakatools::platform<Platform>));
     }
 
     std::vector<edm::ReusableObjectHolder<Queue>> cache_;

--- a/src/alpakatest/AlpakaCore/alpaka/initialise.cc
+++ b/src/alpakatest/AlpakaCore/alpaka/initialise.cc
@@ -2,7 +2,6 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include "AlpakaCore/alpakaConfig.h"
 #include "AlpakaCore/alpakaDevices.h"
 #include "AlpakaCore/initialise.h"
 #include "Framework/demangle.h"

--- a/src/alpakatest/AlpakaCore/alpaka/initialise.cc
+++ b/src/alpakatest/AlpakaCore/alpaka/initialise.cc
@@ -2,6 +2,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "AlpakaCore/alpakaConfig.h"
 #include "AlpakaCore/alpakaDevices.h"
 #include "AlpakaCore/initialise.h"
 #include "Framework/demangle.h"
@@ -9,23 +10,31 @@
 namespace cms::alpakatools {
 
   template <typename TPlatform>
-  void initialise() {
+  void initialise(bool verbose) {
     constexpr const char* suffix[] = {"devices.", "device:", "devices:"};
 
-    if (devices<TPlatform>.empty()) {
-      devices<TPlatform> = enumerate<TPlatform>();
+    if (not platform<TPlatform>.has_value()) {
+      // global objects in the cms::alpakatools namespace
+      platform<TPlatform> = TPlatform{};
+      devices<TPlatform> = alpaka::getDevs(*platform<TPlatform>);
+
       auto size = devices<TPlatform>.size();
-      //std::cout << edm::demangle<TPlatform> << " platform succesfully initialised." << std::endl;
       std::cout << "Found " << size << " " << suffix[size < 2 ? size : 2] << std::endl;
       for (auto const& device : devices<TPlatform>) {
         std::cout << "  - " << alpaka::getName(device) << std::endl;
       }
+      if (verbose) {
+        std::cout << edm::demangle<TPlatform> << " platform succesfully initialised." << std::endl;
+      }
     } else {
-      //std::cout << edm::demangle<TPlatform> << " platform already initialised." << std::endl;
+      if (verbose) {
+        std::cout << edm::demangle<TPlatform> << " platform already initialised." << std::endl;
+      }
     }
+    std::cout << std::endl;
   }
 
   // explicit template instantiation definition
-  template void initialise<ALPAKA_ACCELERATOR_NAMESPACE::Platform>();
+  template void initialise<ALPAKA_ACCELERATOR_NAMESPACE::Platform>(bool);
 
 }  // namespace cms::alpakatools

--- a/src/alpakatest/AlpakaCore/alpakaConfig.h
+++ b/src/alpakatest/AlpakaCore/alpakaConfig.h
@@ -30,7 +30,7 @@ namespace alpaka_common {
 
   // host types
   using DevHost = alpaka::DevCpu;
-  using PltfHost = alpaka::PltfCpu;
+  using PlatformHost = alpaka::PlatformCpu;
 
 }  // namespace alpaka_common
 
@@ -46,7 +46,7 @@ namespace alpaka_common {
 namespace alpaka_cuda_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCudaRt;
+  using Platform = alpaka::PlatformCudaRt;
   using Device = alpaka::DevCudaRt;
   using Queue = alpaka::QueueCudaRtNonBlocking;
   using Event = alpaka::EventCudaRt;
@@ -69,7 +69,7 @@ namespace alpaka_cuda_async {
 namespace alpaka_rocm_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfHipRt;
+  using Platform = alpaka::PlatformHipRt;
   using Device = alpaka::DevHipRt;
   using Queue = alpaka::QueueHipRtNonBlocking;
   using Event = alpaka::EventHipRt;
@@ -92,7 +92,7 @@ namespace alpaka_rocm_async {
 namespace alpaka_serial_sync {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCpu;
+  using Platform = alpaka::PlatformCpu;
   using Device = alpaka::DevCpu;
   using Queue = alpaka::QueueCpuBlocking;
   using Event = alpaka::EventCpu;
@@ -115,7 +115,7 @@ namespace alpaka_serial_sync {
 namespace alpaka_tbb_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCpu;
+  using Platform = alpaka::PlatformCpu;
   using Device = alpaka::DevCpu;
   using Queue = alpaka::QueueCpuNonBlocking;
   using Event = alpaka::EventCpu;
@@ -138,7 +138,7 @@ namespace alpaka_tbb_async {
 namespace alpaka_omp2_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCpu;
+  using Platform = alpaka::PlatformCpu;
   using Device = alpaka::DevCpu;
   using Queue = alpaka::QueueCpuBlocking;
   using Event = alpaka::EventCpu;

--- a/src/alpakatest/AlpakaCore/alpakaDevices.h
+++ b/src/alpakatest/AlpakaCore/alpakaDevices.h
@@ -11,31 +11,17 @@
 
 namespace cms::alpakatools {
 
-  // alpaka host device
+  // alpaka host platform and device
   inline const alpaka_common::PlatformHost platformHost{};
   inline const alpaka_common::DevHost host = alpaka::getDevByIdx(platformHost, 0u);
 
-  // alpaka accelerator devices
+  // alpaka accelerator platform and devices
+  // these objects are filled by a call to cms::alpakatools::initialise<TPlatform>()
+  template <typename TPlatform>
+  inline std::optional<TPlatform> platform;
+
   template <typename TPlatform>
   inline std::vector<alpaka::Dev<TPlatform>> devices;
-
-  template <typename TPlatform>
-  std::vector<alpaka::Dev<TPlatform>> enumerate() {
-    assert(getDeviceIndex(host) == 0u);
-
-    using Device = alpaka::Dev<TPlatform>;
-    using Platform = TPlatform;
-    platform = Platform{};
-
-    std::vector<Device> devices;
-    uint32_t n = alpaka::getDevCount(*platform);
-    devices.reserve(n);
-    for (uint32_t i = 0; i < n; ++i) {
-      devices.push_back(alpaka::getDevByIdx(*platform, i));
-      assert(getDeviceIndex(devices.back()) == static_cast<int>(i));
-    }
-    return devices;
-  }
 
 }  // namespace cms::alpakatools
 

--- a/src/alpakatest/AlpakaCore/alpakaDevices.h
+++ b/src/alpakatest/AlpakaCore/alpakaDevices.h
@@ -12,7 +12,8 @@
 namespace cms::alpakatools {
 
   // alpaka host device
-  inline const alpaka_common::DevHost host = alpaka::getDevByIdx<alpaka_common::PltfHost>(0u);
+  inline const alpaka_common::PlatformHost platformHost{};
+  inline const alpaka_common::DevHost host = alpaka::getDevByIdx(platformHost, 0u);
 
   // alpaka accelerator devices
   template <typename TPlatform>
@@ -24,12 +25,13 @@ namespace cms::alpakatools {
 
     using Device = alpaka::Dev<TPlatform>;
     using Platform = TPlatform;
+    platform = Platform{};
 
     std::vector<Device> devices;
-    uint32_t n = alpaka::getDevCount<Platform>();
+    uint32_t n = alpaka::getDevCount(*platform);
     devices.reserve(n);
     for (uint32_t i = 0; i < n; ++i) {
-      devices.push_back(alpaka::getDevByIdx<Platform>(i));
+      devices.push_back(alpaka::getDevByIdx(*platform, i));
       assert(getDeviceIndex(devices.back()) == static_cast<int>(i));
     }
     return devices;

--- a/src/alpakatest/AlpakaCore/alpakaFwd.h
+++ b/src/alpakatest/AlpakaCore/alpakaFwd.h
@@ -31,11 +31,11 @@ namespace alpaka {
   struct ApiHipRt;
 
   // Platforms
-  class PltfCpu;
+  class PlatformCpu;
   template <typename TApi>
-  class PltfUniformCudaHipRt;
-  using PltfCudaRt = PltfUniformCudaHipRt<ApiCudaRt>;
-  using PltfHipRt = PltfUniformCudaHipRt<ApiHipRt>;
+  class PlatformUniformCudaHipRt;
+  using PlatformCudaRt = PlatformUniformCudaHipRt<ApiCudaRt>;
+  using PlatformHipRt = PlatformUniformCudaHipRt<ApiHipRt>;
 
   // Devices
   class DevCpu;

--- a/src/alpakatest/AlpakaCore/alpakaMemory.h
+++ b/src/alpakatest/AlpakaCore/alpakaMemory.h
@@ -101,19 +101,20 @@ namespace cms::alpakatools {
 
   template <typename T, typename TPlatform>
   std::enable_if_t<not std::is_array_v<T>, host_buffer<T>> make_host_buffer() {
-    return alpaka::allocMappedBuf<TPlatform, T, Idx>(host, *platform, Scalar{});
+    return alpaka::allocMappedBuf<TPlatform, T, Idx>(host, *platform<TPlatform>, Scalar{});
   }
 
   template <typename T, typename TPlatform>
   std::enable_if_t<cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
   make_host_buffer(Extent extent) {
-    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform, Vec1D{extent});
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform<TPlatform>, Vec1D{extent});
   }
 
   template <typename T, typename TPlatform>
   std::enable_if_t<cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
   make_host_buffer() {
-    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform, Vec1D{std::extent_v<T>});
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(
+        host, *platform<TPlatform>, Vec1D{std::extent_v<T>});
   }
 
   // potentially cached, pinned, scalar and 1-dimensional host buffers, associated to a work queue
@@ -124,7 +125,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<T, Idx>(host, queue, Scalar{});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, T, Idx>(host, *platform, Scalar{});
+      using Platform = alpaka::Platform<alpaka::Dev<TQueue>>;
+      return alpaka::allocMappedBuf<Platform, T, Idx>(host, *platform<Platform>, Scalar{});
     }
   }
 
@@ -134,8 +136,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{extent});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
-          host, *platform, Vec1D{extent});
+      using Platform = alpaka::Platform<alpaka::Dev<TQueue>>;
+      return alpaka::allocMappedBuf<Platform, std::remove_extent_t<T>, Idx>(host, *platform<Platform>, Vec1D{extent});
     }
   }
 
@@ -145,8 +147,9 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{std::extent_v<T>});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
-          host, *platform, Vec1D{std::extent_v<T>});
+      using Platform = alpaka::Platform<alpaka::Dev<TQueue>>;
+      return alpaka::allocMappedBuf<Platform, std::remove_extent_t<T>, Idx>(
+          host, *platform<Platform>, Vec1D{std::extent_v<T>});
     }
   }
 

--- a/src/alpakatest/AlpakaCore/alpakaMemory.h
+++ b/src/alpakatest/AlpakaCore/alpakaMemory.h
@@ -101,19 +101,19 @@ namespace cms::alpakatools {
 
   template <typename T, typename TPlatform>
   std::enable_if_t<not std::is_array_v<T>, host_buffer<T>> make_host_buffer() {
-    return alpaka::allocMappedBuf<TPlatform, T, Idx>(host, Scalar{});
+    return alpaka::allocMappedBuf<TPlatform, T, Idx>(host, *platform, Scalar{});
   }
 
   template <typename T, typename TPlatform>
   std::enable_if_t<cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
   make_host_buffer(Extent extent) {
-    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, Vec1D{extent});
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform, Vec1D{extent});
   }
 
   template <typename T, typename TPlatform>
   std::enable_if_t<cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
   make_host_buffer() {
-    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, Vec1D{std::extent_v<T>});
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform, Vec1D{std::extent_v<T>});
   }
 
   // potentially cached, pinned, scalar and 1-dimensional host buffers, associated to a work queue
@@ -124,7 +124,7 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<T, Idx>(host, queue, Scalar{});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, T, Idx>(host, Scalar{});
+      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, T, Idx>(host, *platform, Scalar{});
     }
   }
 
@@ -134,7 +134,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{extent});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(host, Vec1D{extent});
+      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
+          host, *platform, Vec1D{extent});
     }
   }
 
@@ -144,7 +145,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{std::extent_v<T>});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(host, Vec1D{std::extent_v<T>});
+      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
+          host, *platform, Vec1D{std::extent_v<T>});
     }
   }
 

--- a/src/alpakatest/AlpakaCore/getDeviceCachingAllocator.h
+++ b/src/alpakatest/AlpakaCore/getDeviceCachingAllocator.h
@@ -17,7 +17,7 @@ namespace cms::alpakatools {
     template <typename TDevice, typename TQueue>
     auto allocate_device_allocators() {
       using Allocator = CachingAllocator<TDevice, TQueue>;
-      auto const& devices = cms::alpakatools::devices<alpaka::Pltf<TDevice>>;
+      auto const& devices = cms::alpakatools::devices<alpaka::Platform<TDevice>>;
       auto const size = devices.size();
 
       // allocate the storage for the objects
@@ -54,7 +54,7 @@ namespace cms::alpakatools {
     static auto allocators = detail::allocate_device_allocators<TDevice, TQueue>();
 
     size_t const index = getDeviceIndex(device);
-    assert(index < cms::alpakatools::devices<alpaka::Pltf<TDevice>>.size());
+    assert(index < cms::alpakatools::devices<alpaka::Platform<TDevice>>.size());
 
     // the public interface is thread safe
     return allocators[index];

--- a/src/alpakatest/AlpakaCore/getDeviceIndex.h
+++ b/src/alpakatest/AlpakaCore/getDeviceIndex.h
@@ -5,6 +5,8 @@
 
 namespace cms::alpakatools {
 
+  inline std::optional<ALPAKA_ACCELERATOR_NAMESPACE::Platform> platform;
+
   // generic interface, for DevOacc and DevOmp5
   template <typename Device>
   inline int getDeviceIndex(Device const& device) {

--- a/src/alpakatest/AlpakaCore/getDeviceIndex.h
+++ b/src/alpakatest/AlpakaCore/getDeviceIndex.h
@@ -5,8 +5,6 @@
 
 namespace cms::alpakatools {
 
-  inline std::optional<ALPAKA_ACCELERATOR_NAMESPACE::Platform> platform;
-
   // generic interface, for DevOacc and DevOmp5
   template <typename Device>
   inline int getDeviceIndex(Device const& device) {

--- a/src/alpakatest/AlpakaCore/initialise.h
+++ b/src/alpakatest/AlpakaCore/initialise.h
@@ -5,21 +5,22 @@
 
 namespace cms::alpakatools {
 
+  // note: this function is not thread-safe
   template <typename TPlatform>
-  void initialise();
+  void initialise(bool verbose = false);
 
   // explicit template instantiation declaration
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT
-  extern template void initialise<alpaka_serial_sync::Platform>();
+  extern template void initialise<alpaka_serial_sync::Platform>(bool);
 #endif
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_PRESENT
-  extern template void initialise<alpaka_tbb_async::Platform>();
+  extern template void initialise<alpaka_tbb_async::Platform>(bool);
 #endif
 #ifdef ALPAKA_ACC_GPU_CUDA_PRESENT
-  extern template void initialise<alpaka_cuda_async::Platform>();
+  extern template void initialise<alpaka_cuda_async::Platform>(bool);
 #endif
 #ifdef ALPAKA_ACC_GPU_HIP_PRESENT
-  extern template void initialise<alpaka_rocm_async::Platform>();
+  extern template void initialise<alpaka_rocm_async::Platform>(bool);
 #endif
 
 }  // namespace cms::alpakatools

--- a/src/alpakatest/test/alpaka/world.cc
+++ b/src/alpakatest/test/alpaka/world.cc
@@ -2,6 +2,7 @@
 
 #include "AlpakaCore/alpakaConfig.h"
 #include "AlpakaCore/alpakaWorkDiv.h"
+#include "AlpakaCore/alpakaDevices.h"
 
 namespace {
   struct Print {
@@ -18,7 +19,7 @@ int main() {
   std::cout << "World" << std::endl;
 
   using namespace ALPAKA_ACCELERATOR_NAMESPACE;
-  const Device device(alpaka::getDevByIdx<Platform>(0u));
+  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
   Queue queue(device);
 
   // Prepare 1D workDiv

--- a/src/alpakatest/test/alpaka/world.cc
+++ b/src/alpakatest/test/alpaka/world.cc
@@ -15,19 +15,22 @@ namespace {
   };
 }  // namespace
 
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+using namespace cms::alpakatools;
+
 int main() {
   std::cout << "World" << std::endl;
 
-  using namespace ALPAKA_ACCELERATOR_NAMESPACE;
-  const Device device(alpaka::getDevByIdx(*cms::alpakatools::platform, 0u));
+  const Device device(alpaka::getDevByIdx(*platform<Platform>, 0u));
   Queue queue(device);
 
-  // Prepare 1D workDiv
-  const Vec1D& blocksPerGrid(Vec1D::all(1u));
-  const Vec1D& threadsPerBlockOrElementsPerThread(Vec1D(4u));
-  const WorkDiv1D& workDiv = cms::alpakatools::make_workdiv<Acc1D>(blocksPerGrid, threadsPerBlockOrElementsPerThread);
+  // prepare a 1D work division
+  const auto blocksPerGrid = Vec1D::all(1u);
+  const auto threadsPerBlockOrElementsPerThread = Vec1D(4u);
+  const auto workDiv = make_workdiv<Acc1D>(blocksPerGrid, threadsPerBlockOrElementsPerThread);
 
   alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, Print()));
   alpaka::wait(queue);
+
   return 0;
 }


### PR DESCRIPTION
Since [41e9956](https://github.com/alpaka-group/alpaka/commit/41e99568f1aa24a8b40b84f09b9db78dfdf98816) in Alpaka the `platform`s are actual objects and a couple of [commits](https://github.com/alpaka-group/alpaka/commit/8cf861bd6a3f8c511d21ae896a6fe13211944c4c) later they have been renamed from `Pltf` to `Platform`.
This PR propagates these changes to `alpaka` and `alpakatest`.

It also replaces `cms::alpakatools::enumerate()` with `alpaka::getDevs()` (thanks @fwyzard).
