### PR TITLE
[Compatibility] Fixes for CUDA 13.3, GCC 16.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,13 @@ HOST_CXXFLAGS := -O2 -fPIC -fdiagnostics-show-option -felide-constructors -fmess
 # Compiler flags supported by GCC but not by the LLVM-based compilers (clang, hipcc, icpx, etc.)
 LLVM_UNSUPPORTED_CXXFLAGS := --param vect-max-version-for-alias-checks=50 -Werror=format-contains-nul -Wno-non-template-friend -Werror=return-local-addr -Werror=unused-but-set-variable
 
+# In case nvcc uses a different compiler than CXX
+CUDA_NVCC_HOST_COMPILER := $(if $(NVCC_CCBIN),$(NVCC_CCBIN),$(CXX))
+
 export CXXFLAGS := -std=c++20 $(HOST_CXXFLAGS) $(USER_CXXFLAGS) -g
 export NVCXX_CXXFLAGS := -std=c++20 -O0 -cuda -gpu=managed -stdpar -fpic -gopt $(USER_CXXFLAGS)
 export LDFLAGS := -O2 -fPIC -pthread -Wl,-E -lstdc++fs -ldl
-export LDFLAGS_NVCC := -ccbin $(CXX) --linker-options '-E' --linker-options '-lstdc++fs'
+export LDFLAGS_NVCC := -ccbin $(CUDA_NVCC_HOST_COMPILER) --linker-options '-E' --linker-options '-lstdc++fs'
 export LDFLAGS_NVCXX := -cuda -Wl,-E -ldl -gpu=managed -stdpar
 export SO_LDFLAGS := -Wl,-z,defs
 export SO_LDFLAGS_NVCC := --linker-options '-z,defs'
@@ -87,7 +90,7 @@ CUDA_DEBUG_FLAGS := --generate-line-info --source-in-ptx
 endif
 define CUFLAGS_template
 $(2)NVCC_FLAGS := $$(foreach ARCH,$(1),-gencode arch=compute_$$(ARCH),code=[sm_$$(ARCH),compute_$$(ARCH)]) -Wno-deprecated-gpu-targets -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --expt-relaxed-constexpr --expt-extended-lambda $(CUDA_DEBUG_FLAGS) --display-error-number --threads $$(words $(1)) --cudart=shared
-$(2)NVCC_COMMON := -std=c++20 -O3 -g $$($(2)NVCC_FLAGS) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS) $(USER_CXXFLAGS)'
+$(2)NVCC_COMMON := -std=c++20 -O3 -g $$($(2)NVCC_FLAGS) -ccbin $(CUDA_NVCC_HOST_COMPILER) --compiler-options '$(HOST_CXXFLAGS) $(USER_CXXFLAGS)'
 $(2)CUDA_CUFLAGS := -dc $$($(2)NVCC_COMMON) $(USER_CUDAFLAGS)
 $(2)CUDA_DLINKFLAGS := -dlink $$($(2)NVCC_COMMON)
 endef
@@ -374,6 +377,10 @@ else ifeq ($(KOKKOS_CUDA_ARCH),80)
   KOKKOS_CMAKE_CUDA_ARCH := -DKokkos_ARCH_AMPERE80=On
 else ifeq ($(KOKKOS_CUDA_ARCH),86)
   KOKKOS_CMAKE_CUDA_ARCH := -DKokkos_ARCH_AMPERE86=On
+else ifeq ($(KOKKOS_CUDA_ARCH),90)
+  KOKKOS_CMAKE_CUDA_ARCH := -DKokkos_ARCH_HOPPER90=On
+else ifeq ($(KOKKOS_CUDA_ARCH),120)
+  KOKKOS_CMAKE_CUDA_ARCH := -DKokkos_ARCH_BLACKWELL120=On
 else
   $(error Unsupported KOKKOS_CUDA_ARCH $(KOKKOS_CUDA_ARCH). Likely it is sufficient just add another case in the Makefile)
 endif

--- a/src/cuda/plugin-SiPixelClusterizer/gpuClustering.h
+++ b/src/cuda/plugin-SiPixelClusterizer/gpuClustering.h
@@ -204,7 +204,7 @@ namespace gpuClustering {
     int nloops = 0;
     while (__syncthreads_or(more)) {
       if (1 == nloops % 2) {
-        for (auto j = threadIdx.x, k = 0U; j < hist.size(); j += blockDim.x, ++k) {
+        for (auto j = threadIdx.x; j < hist.size(); j += blockDim.x) {
           auto p = hist.begin() + j;
           auto i = *p + firstPixel;
           auto m = clusterId[i];

--- a/src/cudacompat/plugin-SiPixelClusterizer/gpuClustering.h
+++ b/src/cudacompat/plugin-SiPixelClusterizer/gpuClustering.h
@@ -205,7 +205,7 @@ namespace gpuClustering {
       int nloops = 0;
       while (__syncthreads_or(more)) {
         if (1 == nloops % 2) {
-          for (auto j = threadIdx.x, k = 0U; j < hist.size(); j += blockDim.x, ++k) {
+          for (auto j = threadIdx.x; j < hist.size(); j += blockDim.x) {
             auto p = hist.begin() + j;
             auto i = *p + firstPixel;
             auto m = clusterId[i];

--- a/src/cudadev/plugin-SiPixelClusterizer/gpuClustering.h
+++ b/src/cudadev/plugin-SiPixelClusterizer/gpuClustering.h
@@ -201,7 +201,7 @@ namespace gpuClustering {
       int nloops = 0;
       while (__syncthreads_or(more)) {
         if (1 == nloops % 2) {
-          for (auto j = threadIdx.x, k = 0U; j < hist.size(); j += blockDim.x, ++k) {
+          for (auto j = threadIdx.x; j < hist.size(); j += blockDim.x) {
             auto p = hist.begin() + j;
             auto i = *p + firstPixel;
             auto m = clusterId[i];

--- a/src/cudauvm/plugin-SiPixelClusterizer/gpuClustering.h
+++ b/src/cudauvm/plugin-SiPixelClusterizer/gpuClustering.h
@@ -204,7 +204,7 @@ namespace gpuClustering {
     int nloops = 0;
     while (__syncthreads_or(more)) {
       if (1 == nloops % 2) {
-        for (auto j = threadIdx.x, k = 0U; j < hist.size(); j += blockDim.x, ++k) {
+        for (auto j = threadIdx.x; j < hist.size(); j += blockDim.x) {
           auto p = hist.begin() + j;
           auto i = *p + firstPixel;
           auto m = clusterId[i];

--- a/src/hip/plugin-SiPixelClusterizer/gpuClustering.h
+++ b/src/hip/plugin-SiPixelClusterizer/gpuClustering.h
@@ -205,7 +205,7 @@ namespace gpuClustering {
     int nloops = 0;
     while (__syncthreads_or(more)) {
       if (1 == nloops % 2) {
-        for (uint32_t j = threadIdx.x, k = 0U; j < hist.size(); j += static_cast<uint32_t>(blockDim.x), ++k) {
+        for (uint32_t j = threadIdx.x; j < hist.size(); j += static_cast<uint32_t>(blockDim.x)) {
           auto p = hist.begin() + j;
           auto i = *p + firstPixel;
           auto m = clusterId[i];

--- a/src/serial/plugin-SiPixelClusterizer/gpuClustering.h
+++ b/src/serial/plugin-SiPixelClusterizer/gpuClustering.h
@@ -187,7 +187,7 @@ namespace gpuClustering {
       int nloops = 0;
       while (more) {
         if (1 == nloops % 2) {
-          for (uint32_t j = 0, k = 0U; j < hist.size(); j++, ++k) {
+          for (uint32_t j = 0; j < hist.size(); j++) {
             auto p = hist.begin() + j;
             auto i = *p + firstPixel;
             auto m = clusterId[i];

--- a/src/stdpar/plugin-SiPixelClusterizer/gpuClustering.h
+++ b/src/stdpar/plugin-SiPixelClusterizer/gpuClustering.h
@@ -188,7 +188,7 @@ namespace gpuClustering {
       int nloops = 0;
       while (more) {
         if (1 == nloops % 2) {
-          for (uint32_t j = 0, k = 0U; j < hist->size(); ++j, ++k) {
+          for (uint32_t j = 0; j < hist->size(); ++j) {
             auto p = hist->begin() + j;
             auto i = *p + firstPixel;
             auto m = clusterId[i];

--- a/src/sycl/plugin-SiPixelClusterizer/gpuClustering.h
+++ b/src/sycl/plugin-SiPixelClusterizer/gpuClustering.h
@@ -226,7 +226,7 @@ namespace gpuClustering {
 
     while ((sycl::group_barrier(item.get_group()), sycl::any_of_group(item.get_group(), more))) {
       if (1 == nloops % 2) {
-        for (unsigned int j = item.get_local_id(0), k = 0U; j < hist->size(); j += item.get_local_range(0), ++k) {
+        for (unsigned int j = item.get_local_id(0); j < hist->size(); j += item.get_local_range(0)) {
           auto p = hist->begin() + j;
           auto i = *p + firstPixel;
           auto m = clusterId[i];


### PR DESCRIPTION
CUDA uses the environment variable `NVCC_CCBIN` to specify the host compiler used by nvcc, e.g., in case of an incompatible system GCC version. Respect this variable in the Makefile and add support for Hopper and Blackwell in Kokkos.

Also remove an unused variable in SiPixelClusterizer/gpuClustering.